### PR TITLE
Add Content-Encoding support to stetho-urlconnection and stetho-okhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ client.networkInterceptors().add(new StethoInterceptor());
 
 If you are using `HttpURLConnection`, you can use `StethoURLConnectionManager`
 to assist with integration though you should be aware that there are some
-caveats with this approach.  In particular, compressed payload sizes may not be
-visualized even though compression is indeed in effect.
+caveats with this approach.  In particular, you must explicitly add
+`Accept-Encoding: gzip` to the request headers and manually handle compressed
+responses in order for Stetho to report compressed payload sizes.
 
 See the `stetho-sample` project for more details.
 

--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -48,4 +48,6 @@ dependencies {
     // Needed for Robolectric and PowerMock to be combined in a single test.
     androidTestCompile 'org.powermock:powermock-module-junit4-rule:1.6.1'
     androidTestCompile 'org.powermock:powermock-classloading-xstream:1.6.1'
+
+    androidTestCompile 'com.squareup.okhttp:mockwebserver:2.2.0'
 }

--- a/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
+++ b/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
@@ -1,26 +1,18 @@
 package com.facebook.stetho.okhttp;
 
-import javax.annotation.Nullable;
+import com.facebook.stetho.inspector.network.DefaultResponseHandler;
+import com.facebook.stetho.inspector.network.NetworkEventReporter;
+import com.facebook.stetho.inspector.network.NetworkEventReporterImpl;
+import com.squareup.okhttp.*;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.facebook.stetho.inspector.network.DefaultResponseHandler;
-import com.facebook.stetho.inspector.network.NetworkEventReporter;
-import com.facebook.stetho.inspector.network.NetworkEventReporterImpl;
-
-import com.squareup.okhttp.Connection;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.ResponseBody;
-import okio.BufferedSink;
-import okio.BufferedSource;
-import okio.Okio;
 
 /**
  * Provides easy integration with <a href="http://square.github.io/okhttp/">OkHttp</a> 2.2.0+
@@ -86,6 +78,7 @@ public class StethoInterceptor implements Interceptor {
       responseStream = mEventReporter.interpretResponseStream(
           requestId,
           contentType != null ? contentType.toString() : null,
+          response.header("Content-Encoding"),
           responseStream,
           new DefaultResponseHandler(mEventReporter, requestId));
       if (responseStream != null) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
@@ -1,0 +1,34 @@
+package com.facebook.stetho.inspector.network;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+class CountingOutputStream extends FilterOutputStream {
+  private long mCount;
+
+  public CountingOutputStream(OutputStream out) {
+    super(out);
+  }
+
+  public long getCount() {
+    return mCount;
+  }
+
+  @Override
+  public void write(int oneByte) throws IOException {
+    out.write(oneByte);
+    mCount++;
+  }
+
+  @Override
+  public void write(byte[] buffer) throws IOException {
+    write(buffer, 0, buffer.length);
+  }
+
+  @Override
+  public void write(byte[] buffer, int offset, int length) throws IOException {
+    out.write(buffer, offset, length);
+    mCount += length;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
@@ -1,0 +1,56 @@
+package com.facebook.stetho.inspector.network;
+
+import com.facebook.stetho.inspector.console.CLog;
+import com.facebook.stetho.inspector.protocol.module.Console;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.InflaterOutputStream;
+
+// @VisibleForTest
+public class DecompressionHelper {
+  private static final String GZIP_ENCODING = "gzip";
+  private static final String DEFLATE_ENCODING = "deflate";
+
+  public static InputStream teeInputWithDecompression(
+      NetworkPeerManager peerManager,
+      String requestId,
+      InputStream availableInputStream,
+      OutputStream decompressedOutput,
+      @Nullable String contentEncoding,
+      ResponseHandler responseHandler) throws IOException {
+    OutputStream output = decompressedOutput;
+    CountingOutputStream decompressedCounter = null;
+
+    if (contentEncoding != null) {
+      boolean gzipEncoding = GZIP_ENCODING.equals(contentEncoding);
+      boolean deflateEncoding = DEFLATE_ENCODING.equals(contentEncoding);
+
+      if (gzipEncoding || deflateEncoding) {
+        decompressedCounter = new CountingOutputStream(decompressedOutput);
+        if (gzipEncoding) {
+          output = GunzippingOutputStream.create(decompressedCounter);
+        } else if (deflateEncoding) {
+          output = new InflaterOutputStream(decompressedCounter);
+        }
+      } else {
+        CLog.writeToConsole(
+            peerManager,
+            Console.MessageLevel.WARNING,
+            Console.MessageSource.NETWORK,
+            "Unsupported Content-Encoding in response for request #" + requestId +
+                ": " + contentEncoding);
+      }
+    }
+
+    return new ResponseHandlingInputStream(
+        availableInputStream,
+        requestId,
+        output,
+        decompressedCounter,
+        peerManager,
+        responseHandler);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
@@ -1,0 +1,97 @@
+package com.facebook.stetho.inspector.network;
+
+import com.facebook.stetho.common.ExceptionUtil;
+import com.facebook.stetho.common.Util;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * An {@link OutputStream} filter which decompresses gzip data before it is written to the
+ * specified destination output stream.  This is functionally equivalent to
+ * {@link java.util.zip.InflaterOutputStream} but provides gzip header awareness.  The
+ * implementation however is very different to avoid actually interpreting the gzip header.
+ */
+class GunzippingOutputStream extends FilterOutputStream {
+  private final Future<Void> mCopyFuture;
+
+  private static final ExecutorService sExecutor = Executors.newCachedThreadPool();
+
+  public static GunzippingOutputStream create(OutputStream finalOut) throws IOException {
+    PipedInputStream pipeIn = new PipedInputStream();
+    PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+
+    Future<Void> copyFuture = sExecutor.submit(
+        new GunzippingCallable(pipeIn, finalOut));
+
+    return new GunzippingOutputStream(pipeOut, copyFuture);
+  }
+
+  private GunzippingOutputStream(OutputStream out, Future<Void> copyFuture) throws IOException {
+    super(out);
+    mCopyFuture = copyFuture;
+  }
+
+  @Override
+  public void close() throws IOException {
+    boolean success = false;
+    try {
+      super.close();
+      success = true;
+    } finally {
+      try {
+        getAndRethrow(mCopyFuture);
+      } catch (IOException e) {
+        if (success) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  private static <T> T getAndRethrow(Future<T> future) throws IOException {
+    while (true) {
+      try {
+        return future.get();
+      } catch (InterruptedException e) {
+        // Continue...
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause();
+        ExceptionUtil.propagateIfInstanceOf(cause, IOException.class);
+        ExceptionUtil.propagate(cause);
+      }
+    }
+  }
+
+  private static class GunzippingCallable implements Callable<Void> {
+    private final InputStream mIn;
+    private final OutputStream mOut;
+
+    public GunzippingCallable(InputStream in, OutputStream out) {
+      mIn = in;
+      mOut = out;
+    }
+
+    @Override
+    public Void call() throws IOException {
+      GZIPInputStream in = new GZIPInputStream(mIn);
+      try {
+        Util.copy(in, mOut, new byte[1024]);
+      } finally {
+        in.close();
+        mOut.close();
+      }
+      return null;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
@@ -3,7 +3,6 @@
 package com.facebook.stetho.inspector.network;
 
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -78,6 +77,10 @@ public interface NetworkEventReporter {
    *     {@link InspectorResponse}.  This header is used to determine the appropriate
    *     storage format for the body.  For instance, {@code image/*} is necessary to cause
    *     images to appear in the Inspector UI.
+   * @param contentEncoding The {@code Content-Encoding} header value that was specified in
+   *     {@link InspectorResponse}.  This header is used to determine what type of decompression
+   *     is to be applied when delivering the raw response stream to the debugging interface.
+   *     If null, no decompression will be used.
    * @param inputStream Response stream if applicable ("HEAD" for instance does not have a body).
    *     {@code null} otherwise.
    * @param responseHandler Callback to forward stream events back to the relevant event reporter
@@ -90,6 +93,7 @@ public interface NetworkEventReporter {
   public InputStream interpretResponseStream(
       String requestId,
       @Nullable String contentType,
+      @Nullable String contentEncoding,
       @Nullable InputStream inputStream,
       ResponseHandler responseHandler);
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
@@ -8,14 +8,23 @@ import java.io.IOException;
  */
 public interface ResponseHandler {
   /**
-   * Signal that data has been read from the response stream.  Note that some HTTP implementations
-   * (like okhttp) will automatically decompress for you so you must hook in at a lower level
-   * than the default response handler to properly account for raw, compressed response bytes.
+   * Signal that data has been read from the response stream.
    *
    * @param numBytes Bytes read from the network stack's stream as established by
    *     {@link NetworkEventReporter#interpretResponseStream}.
    */
   public void onRead(int numBytes);
+
+  /**
+   * Signal that data has been decoded (reversing the response's {@code Content-Encoding}) while
+   * reading a raw stream.  This method is only called when the stream is known to have
+   * a supported encoding.  Note that for HTTP, content encoding almost always is used for
+   * some form of response compression.
+   *
+   * @param numBytes Bytes yielded after decoding bytes received from the network stack's
+   *     stream.
+   */
+  public void onReadDecoded(int numBytes);
 
   /**
    * Signals that EOF has been reached reading the response stream from the network

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
@@ -1,0 +1,27 @@
+package com.facebook.stetho.inspector.network;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class GunzippingOutputStreamTest {
+  @Test(timeout = 1000)
+  public void testGunzip() throws IOException {
+    byte[] data = "test123test123".getBytes();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    OutputStream unzippingStream = GunzippingOutputStream.create(out);
+    OutputStream zippingStream = new GZIPOutputStream(unzippingStream);
+    zippingStream.write(data);
+    zippingStream.close();
+    assertArrayEquals(data, out.toByteArray());
+  }
+}

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
@@ -56,6 +56,7 @@ public class ResponseHandlingInputStreamTest {
         new ByteArrayInputStream(TEST_RESPONSE_BODY),
         TEST_REQUEST_ID,
         mTestOutputStream,
+        null /* decompressedCounter */,
         mNetworkPeerManager,
         new DefaultResponseHandler(mNetworkEventReporter, TEST_REQUEST_ID));
   }
@@ -153,6 +154,7 @@ public class ResponseHandlingInputStreamTest {
         new ByteArrayInputStream(TEST_RESPONSE_BODY),
         TEST_REQUEST_ID,
         exceptionOutputStream,
+        null /* decompressedCounter */,
         mNetworkPeerManager,
         new DefaultResponseHandler(mNetworkEventReporter, TEST_REQUEST_ID));
 


### PR DESCRIPTION
Add first class support for transparently handling Content-Encoding
compression on response bodies for both supported HTTP stacks
(HttpURLConnection and okhttp).  There are caveats associated the
HttpURLConnection implementation due to the fact that under the hood the
Android implementation attempts to handle modern concepts like
compression automatically for you, which prevents inspection of the
compressed payloads in many common cases.  okhttp doesn't have these
issues and allows us to inspect both the compressed and uncompressed
sizes.

Also add a new test to okhttp to verify end-to-end integration with
okhttp interceptors by using the mockwebserver library provided by
okhttp to power its own internal tests.  This test also serves as proof
that compression handling works properly.
