### PR TITLE
Fix issue that can hide slow network requests

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -97,6 +97,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       params.timestamp = stethoNow() / 1000.0;
       params.initiator = initiatorJSON;
       params.redirectResponse = null;
+      params.type = Page.ResourceType.OTHER;
       peerManager.sendNotificationToPeers("Network.requestWillBeSent", params);
     }
   }
@@ -146,7 +147,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       }
       receivedParams.response = responseJSON;
       peerManager.sendNotificationToPeers("Network.responseReceived", receivedParams);
-      }
+    }
   }
 
   @Override


### PR DESCRIPTION
WebKit Inspector contains an apparent implementation bug whereby if the
request does not provide a Page.ResourceType guess then it will hide it
from the UI until Network.responseReceived is delivered with the actual
Page.ResourceType is given.  This works fine when there is a small delay
between requestWillBeSent and responseReceived, but if the delay widens
significantly, the Inspector UI will discard the record and fail to show
it no matter how progress is made after that point.

This can be demonstrated by adding significant timing delays in network
events (such as by using iptables to slow down or stop traffic entirely)
or just adding delays in NetworkEventReporterImpl.
