### PR TITLE
Work around an issue causing network requests to disappear from the UI

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -94,7 +94,12 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       params.timestamp = stethoNow() / 1000.0;
       params.initiator = initiatorJSON;
       params.redirectResponse = null;
+
+      // Type is now required as of at least WebKit Inspector rev @188492.  If you don't send
+      // it, Chrome will refuse to draw the row in the Network tab until the response is
+      // received (providing the type).  This delay is very noticable on slow networks.
       params.type = Page.ResourceType.OTHER;
+
       peerManager.sendNotificationToPeers("Network.requestWillBeSent", params);
     }
   }
@@ -227,6 +232,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       failedParams.requestId = requestId;
       failedParams.timestamp = stethoNow() / 1000.0;
       failedParams.errorText = errorText;
+      failedParams.type = Page.ResourceType.OTHER;
       peerManager.sendNotificationToPeers("Network.loadingFailed", failedParams);
     }
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -146,6 +146,13 @@ public class Network implements ChromeDevtoolsDomain {
 
     @JsonProperty(required = true)
     public String errorText;
+
+    // Chrome introduced this undocumented new addition that, if not sent, will cause the row
+    // to be removed from the UI and raise a JavaScript exception in the console.  This is
+    // clearly an upstream bug that needs to be fixed, though we can work around it by
+    // providing this new undocumented field.
+    @JsonProperty
+    public Page.ResourceType type;
   }
 
   public static class DataReceivedParams {


### PR DESCRIPTION
This works around an apparent upstream bug in which a new undocumented
field which, if not added, will cause a JavaScript error to occur in the
UI and the row will be removed during Network.loadingFailed.  This
appears to be a related regression to that fixes in PR #10.
