### PR TITLE
Handle SIGPIPE gracefully in ./scripts/dumpapp

### DIFF
--- a/scripts/dumpapp
+++ b/scripts/dumpapp
@@ -50,6 +50,8 @@ def main():
   except HumanReadableError as e:
     print(e)
     sys.exit(1)
+  except BrokenPipeError as e:
+    sys.exit(0)
   except KeyboardInterrupt:
     sys.exit(1)
 


### PR DESCRIPTION
A broken pipe can be observed by scripting commands as in:

  ./scripts/dumpapp printforever | head -1

Though the intended behaviour is to have dumpapp die early and report
success as `head` in this case has caused the pipe to be broken on
purpose.
