### PR TITLE
Add fatjarRelease task to fix stetho.jar export

### DIFF
--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -38,3 +38,18 @@ dependencies {
 }
 
 apply from: rootProject.file('release.gradle')
+
+android.libraryVariants.all { variant ->
+    def name = variant.name.capitalize()
+    task "fatjar${name}"(type: Jar, dependsOn: "jar${name}") {
+       classifier = 'fatjar'
+       from variant.javaCompile.destinationDir
+       from {
+           configurations.compile.findAll {
+               it.getName() == 'commons-cli-1.2.jar'
+           }.collect {
+               it.isDirectory() ? it : zipTree(it)
+           }
+       }
+    }
+}


### PR DESCRIPTION
Release fail.  The stetho-1.0.0.jar that was released excludes
commons-cli and will fail as a result.  This dependency is so esoteric
for an Android app that it feels appropriate to just bundle it.
