### PR TITLE
Optimize Travis-CI builds by caching Gradle/Maven artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ android:
 branches:
   except:
     - gh-pages
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle


### PR DESCRIPTION
These artifacts are those downloaded as part of the dynamic build
process and which don't change regularly.