### PR TITLE
Break the bindToSocket retry loop on success

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
@@ -276,6 +276,8 @@ public class LocalSocketHttpServer {
             LogUtil.d("Binding server to " + address);
           }
           mServerSocket = new LocalServerSocket(address);
+          LogUtil.i("Listening on @" + address);
+          return;
         } catch (BindException be) {
           LogUtil.w(be, "Binding error, sleep 1 second ...");
           if (retries == 0)


### PR DESCRIPTION
This caused all invocations to print a stack trace indicating a serious
sounding error when in fact everything was working fine.  Added a log
statement to clarify that everything is fine :)

Closes #49