### PR TITLE
Avoid sending a null `type` or `mimeType` in network responses

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -130,9 +130,9 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       responseJSON.statusText = response.reasonPhrase();
       responseJSON.headers = formatHeadersAsJSON(response);
       String contentType = getContentType(response);
-      if (contentType != null) {
-        responseJSON.mimeType = getResourceTypeHelper().stripContentExtras(contentType);
-      }
+      responseJSON.mimeType = contentType != null ?
+          getResourceTypeHelper().stripContentExtras(contentType) :
+          "application/octet-stream";
       responseJSON.connectionReused = response.connectionReused();
       responseJSON.connectionId = response.connectionId();
       responseJSON.fromDiskCache = response.fromDiskCache();
@@ -141,9 +141,9 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       receivedParams.frameId = "1";
       receivedParams.loaderId = "1";
       receivedParams.timestamp = stethoNow() / 1000.0;
-      if (contentType != null) {
-        receivedParams.type = getResourceTypeHelper().determineResourceType(contentType);
-      }
+      receivedParams.type = contentType != null ?
+          getResourceTypeHelper().determineResourceType(contentType) :
+          Page.ResourceType.OTHER;
       receivedParams.response = responseJSON;
       peerManager.sendNotificationToPeers("Network.responseReceived", receivedParams);
     }


### PR DESCRIPTION
DevTools refuses to show any entry that lacks the `type` property in
recent versions.  This makes it possible to inspect network responses
that for whatever reason don't have the `Content-Type` header available.

Closes #57