### PR TITLE
Avoid caching $HOME/.gradle in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ sudo: false
 cache:
   directories:
     - $HOME/.m2
-    - $HOME/.gradle


### PR DESCRIPTION
This directory changes on every invocation due to a lck file written
into it.  According to http://stackoverflow.com/a/27365925, it might be
better to just take the hit on downloading gradle's distribution each
time.  But we'll keep the Maven dependencies still since those are much
larger.