### PR TITLE
Avoid caching $HOME/.gradle lock files in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ branches:
 
 sudo: false
 
+# Delete gradle lock files to improve Travis-CI caching
+after_script:
+  - find $HOME/.gradle -name '*.lck' -or -name '*.lock' -exec rm -f {} \;
+
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Without proper support for Gradle caching currently, it would seem the
best strategy for improving build times would be to remove the lock
files after build so that they are not detected as having changed.

Current build times are >2m and that seems really silly for Stetho.
Local builds on my machine are <50s.