### PR TITLE
Stop using Travis-CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,3 @@ branches:
     - gh-pages
 
 sudo: false
-
-cache:
-  directories:
-    - $HOME/.m2
-    - $HOME/.gradle


### PR DESCRIPTION
This just doesn't optimize things with Gradle due to the lock file being
changed in ~/.gradle/caches on each build.  Disable for now; hopefully
Travis-CI will fix this.