### PR TITLE
Use raw process name for UNIX abstract socket name

### DIFF
--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -85,13 +85,12 @@ def _parse_process_from_stetho_socket(socket_name):
   if len(parts) < 2 or parts[0] != '@stetho':
     raise Exception('Unexpected Stetho socket formatting: %s' % (socket_name))
   if parts[-2:] == [ 'devtools', 'remote' ]:
-    return '.'.join(parts[1:-2])
+    return '_'.join(parts[1:-2])
   else:
-    return '.'.join(parts[1:])
+    return '_'.join(parts[1:])
 
 def _format_process_as_stetho_socket(process):
-  filtered = process.replace('.', '_').replace(':', '_')
-  return 'stetho_%s_devtools_remote' % (filtered)
+  return 'stetho_%s_devtools_remote' % (process)
 
 class AdbSmartSocketClient(object):
   """Implements the smartsockets system defined by:

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -15,6 +15,7 @@
 
 import socket
 import struct
+import re
 
 def stetho_open(device=None, process=None):
   adb = _connect_to_device(device)
@@ -81,13 +82,10 @@ def _connect_to_device(device=None):
         'Failure to target device %s: %s' % (device, e.reason))
 
 def _parse_process_from_stetho_socket(socket_name):
-  parts = socket_name.split('_')
-  if len(parts) < 2 or parts[0] != '@stetho':
+  m = re.match("^\@stetho_(.+)_devtools_remote$", socket_name)
+  if m is None:
     raise Exception('Unexpected Stetho socket formatting: %s' % (socket_name))
-  if parts[-2:] == [ 'devtools', 'remote' ]:
-    return '_'.join(parts[1:-2])
-  else:
-    return '_'.join(parts[1:])
+  return m.group(1)
 
 def _format_process_as_stetho_socket(process):
   return 'stetho_%s_devtools_remote' % (process)

--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
@@ -31,22 +31,13 @@
 
 package com.facebook.stetho.server;
 
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.BindException;
-import java.net.SocketException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import android.annotation.SuppressLint;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.util.Log;
-
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.ProcessUtil;
 import com.facebook.stetho.common.Util;
-
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpServerConnection;
@@ -56,17 +47,14 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.BasicHttpProcessor;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpRequestHandlerRegistry;
-import org.apache.http.protocol.HttpService;
-import org.apache.http.protocol.ResponseConnControl;
-import org.apache.http.protocol.ResponseContent;
-import org.apache.http.protocol.ResponseDate;
-import org.apache.http.protocol.ResponseServer;
+import org.apache.http.protocol.*;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.BindException;
+import java.net.SocketException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class LocalSocketHttpServer {
 
@@ -171,12 +159,8 @@ public class LocalSocketHttpServer {
   private static String getDefaultAddress() throws IOException {
     return
         SOCKET_NAME_PREFIX +
-        tidyProcessName(ProcessUtil.getProcessName()) +
+        ProcessUtil.getProcessName() +
         SOCKET_NAME_SUFFIX;
-  }
-
-  private static String tidyProcessName(String processName) {
-    return processName.replaceAll("[\\\\\\.:]", "_");
   }
 
   private HttpParams createParams() {


### PR DESCRIPTION
Previously we formatted the process name using underscores due to
primitive tooling that has since been replaced.  We can now use the real
process name which fixes an issue with ./scripts/dumpapp output when
there are multiple targets that include derivative processes
(com.mypackage:myprocess).  Previously this would show up as
com.mypackage.myprocess.