### PR TITLE
Avoid wildcard dependency in stetho-okhttp

### DIFF
--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -25,8 +25,7 @@ apply plugin: 'android-unit-test'
 dependencies {
     compile project(':stetho')
     compile 'com.google.code.findbugs:jsr305:2.0.1'
-    //noinspection GradleDynamicVersion
-    compile 'com.squareup.okhttp:okhttp:[2,3)'
+    compile 'com.squareup.okhttp:okhttp:2.2.0'
 
     testCompile 'junit:junit:4.12'
     testCompile('org.robolectric:robolectric:2.4') {


### PR DESCRIPTION
According to #59, it should be safe to just depend on 2.2.0 and ask the
dependency resolver to figure it out.