### PR TITLE
Initial check-in for Elements tab

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -19,6 +20,7 @@ import com.facebook.stetho.dumpapp.StreamingDumpappHandler;
 import com.facebook.stetho.dumpapp.plugins.SharedPreferencesDumperPlugin;
 import com.facebook.stetho.inspector.ChromeDevtoolsServer;
 import com.facebook.stetho.inspector.ChromeDiscoveryHandler;
+import com.facebook.stetho.inspector.elements.android.AndroidDOMProviderFactory;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.module.CSS;
 import com.facebook.stetho.inspector.protocol.module.Console;
@@ -105,7 +107,7 @@ public class Stetho {
         modules.add(new Console());
         modules.add(new CSS());
         modules.add(new Debugger());
-        modules.add(new DOM());
+        modules.add(new DOM(new AndroidDOMProviderFactory((Application)context.getApplicationContext())));
         modules.add(new DOMStorage());
         modules.add(new HeapProfiler());
         modules.add(new Inspector());

--- a/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
@@ -14,6 +14,4 @@ public class ExceptionUtil {
     propagateIfInstanceOf(t, RuntimeException.class);
     throw new RuntimeException(t);
   }
-
-
 }

--- a/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
@@ -1,0 +1,25 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common;
+
+public final class StringUtil {
+  private StringUtil() {
+  }
+
+  @SuppressWarnings("StringEquality")
+  public static String removePrefix(String string, String prefix, String previousAttempt) {
+    if (string != previousAttempt) {
+      return previousAttempt;
+    } else {
+      return removePrefix(string, prefix);
+    }
+  }
+
+  public static String removePrefix(String string, String prefix) {
+    if (string.startsWith(prefix)) {
+      return string.substring(prefix.length());
+    } else {
+      return string;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -21,6 +21,12 @@ public class Util {
     }
   }
 
+  public static void throwIf(boolean condition) {
+    if (condition) {
+      throw new IllegalStateException();
+    }
+  }
+
   public static void throwIfNot(boolean condition) {
     if (!condition) {
       throw new IllegalStateException();

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ApplicationUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ApplicationUtil.java
@@ -1,0 +1,52 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.app.Activity;
+
+import com.facebook.stetho.common.LogUtil;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ApplicationUtil {
+  private static final String TAG = "ApplicationUtil";
+
+  private ApplicationUtil() {
+  }
+
+  public static List<Activity> getAllActivities() {
+    try {
+      return getAllActivitiesHack();
+    } catch (Exception e) {
+      LogUtil.w(TAG, e, "Cannot retrieve list of Activity instances. UI inspection may not work!");
+      return Collections.emptyList();
+    }
+  }
+
+  // HACK: https://androidreclib.wordpress.com/2014/11/22/getting-the-current-activity/
+  // TODO: I'm unsure which version(s) of Android this works on
+  private static List<Activity> getAllActivitiesHack()
+      throws ClassNotFoundException, NoSuchMethodException, NoSuchFieldException, IllegalAccessException, InvocationTargetException {
+    Class activityThreadClass = Class.forName("android.app.ActivityThread");
+    Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+    Field activitiesField = activityThreadClass.getDeclaredField("mActivities");
+    activitiesField.setAccessible(true);
+    Map activities = (Map)activitiesField.get(activityThread);
+    List<Activity> activitiesList = new ArrayList<Activity>(activities.size());
+
+    for (Object activityRecord : activities.values()) {
+      Class activityRecordClass = activityRecord.getClass();
+      Field activityField = activityRecordClass.getDeclaredField("activity");
+      activityField.setAccessible(true);
+      Activity activity = (Activity)activityField.get(activityRecord);
+      activitiesList.add(activity);
+    }
+
+    return activitiesList;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -1,0 +1,158 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.common.Util;
+
+import javax.annotation.Nullable;
+
+public abstract class ChainedDescriptor<E> extends Descriptor {
+  private Descriptor mSuper;
+
+  // This is used by DescriptorMap to hook us up to whatever handles E's super class
+  final void setSuper(Descriptor superDescriptor) {
+    Util.throwIfNull(superDescriptor);
+    Util.throwIfNotNull(mSuper);
+    mSuper = superDescriptor;
+  }
+
+  protected final Descriptor getSuper() {
+    return mSuper;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void hook(Object element) {
+    mSuper.hook(element);
+    onHook((E)element);
+  }
+
+  protected void onHook(E element) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void unhook(Object element) {
+    onUnhook((E)element);
+    mSuper.unhook(element);
+  }
+
+  protected void onUnhook(E element) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final NodeType getNodeType(Object element) {
+    return onGetNodeType((E)element);
+  }
+
+  protected NodeType onGetNodeType(E element) {
+    return mSuper.getNodeType(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getNodeName(Object element) {
+    return onGetNodeName((E)element);
+  }
+
+  protected String onGetNodeName(E element) {
+    return mSuper.getNodeName(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getLocalName(Object element) {
+    return onGetLocalName((E)element);
+  }
+
+  protected String onGetLocalName(E element) {
+    return mSuper.getLocalName(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getNodeValue(Object element) {
+    return onGetNodeValue((E)element);
+  }
+
+  @Nullable
+  public String onGetNodeValue(E element) {
+    return mSuper.getNodeValue(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final int getChildCount(Object element) {
+    int superCount = mSuper.getChildCount(element);
+    int derivedCount = onGetChildCount((E) element);
+    return superCount + derivedCount;
+  }
+
+  protected int onGetChildCount(E element) {
+    return 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final Object getChildAt(Object element, int index) {
+    if (index < 0) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    int superCount = mSuper.getChildCount(element);
+    if (index < superCount) {
+      return mSuper.getChildAt(element, index);
+    }
+
+    int thisCount = onGetChildCount((E)element);
+    int thisIndex = index - superCount;
+    if (thisIndex < 0 || thisIndex >= thisCount) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    return onGetChildAt((E)element, thisIndex);
+  }
+
+  protected Object onGetChildAt(E element, int index) {
+    throw new IndexOutOfBoundsException();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final int getAttributeCount(Object element) {
+    int superCount = mSuper.getAttributeCount(element);
+    int thisCount = onGetAttributeCount((E)element);
+    return superCount + thisCount;
+  }
+
+  protected int onGetAttributeCount(E element) {
+    return 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void copyAttributeAt(Object element, int index, NodeAttribute outAttribute) {
+    if (index < 0) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    int superCount = mSuper.getChildCount(element);
+    if (index < superCount) {
+      mSuper.copyAttributeAt(element, index, outAttribute);
+      return;
+    }
+
+    int thisCount = onGetAttributeCount((E)element);
+    int thisIndex = index - superCount;
+    if (thisIndex < 0 || thisIndex >= thisCount) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    onCopyAttributeAt((E)element, thisIndex, outAttribute);
+  }
+
+  protected void onCopyAttributeAt(E element, int index, NodeAttribute outAttribute) {
+    throw new IndexOutOfBoundsException();
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -1,0 +1,49 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+import javax.annotation.Nullable;
+
+public interface DOMProvider {
+  public void setListener(Listener listener);
+
+  public void dispose();
+
+  @Nullable
+  public Object getRootElement();
+
+  public NodeDescriptor getNodeDescriptor(Object element);
+
+  public void highlightElement(
+      Object element,
+      int contentColor,
+      int paddingColor,
+      int borderColor,
+      int marginColor);
+
+  public void hideHighlight();
+
+  public static interface Factory {
+    DOMProvider create();
+  }
+
+  public static interface Listener {
+    public void onAttributeModified(
+        Object element,
+        String name,
+        String value);
+
+    public void onAttributeRemoved(
+        Object element,
+        String name);
+
+    public void onChildInserted(
+        Object parentElement,
+        @Nullable Object previousElement,
+        Object childElement);
+
+    public void onChildRemoved(
+        Object parentElement,
+        Object childElement);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -1,0 +1,41 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+import javax.annotation.Nullable;
+
+public abstract class Descriptor implements NodeDescriptor {
+
+  private Listener mListener;
+
+  protected Descriptor() {
+  }
+
+  void setListener(Listener listener) {
+    mListener = listener;
+  }
+
+  protected final Listener getListener() {
+    return mListener;
+  }
+
+  public interface Listener {
+    public void onAttributeModified(
+        Object element,
+        String name,
+        String value);
+
+    public void onAttributeRemoved(
+        Object element,
+        String name);
+
+    public void onChildInserted(
+        Object parentElement,
+        @Nullable Object previousElement,
+        Object childElement);
+
+    public void onChildRemoved(
+        Object parentElement,
+        Object childElement);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
@@ -1,0 +1,84 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.common.Util;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+public final class DescriptorMap {
+  private final Map<Class<?>, Descriptor> mMap = new IdentityHashMap<Class<?>, Descriptor>();
+  private boolean mIsInitializing;
+  private Descriptor.Listener mListener;
+
+  public DescriptorMap beginInit() {
+    Util.throwIf(mIsInitializing);
+    mIsInitializing = true;
+    return this;
+  }
+
+  public DescriptorMap register(Class<?> elementClass, Descriptor nodeDescriptor) {
+    Util.throwIfNull(elementClass);
+    Util.throwIfNull(nodeDescriptor);
+    Util.throwIfNot(mIsInitializing);
+
+    if (mMap.containsKey(elementClass)) {
+      throw new UnsupportedOperationException();
+    }
+
+    mMap.put(elementClass, nodeDescriptor);
+    return this;
+  }
+
+  public DescriptorMap setListener(Descriptor.Listener listener) {
+    Util.throwIfNull(listener);
+    Util.throwIfNot(mIsInitializing);
+    Util.throwIfNotNull(mListener);
+
+    mListener = listener;
+
+    return this;
+  }
+
+  public DescriptorMap endInit() {
+    Util.throwIfNot(mIsInitializing);
+    Util.throwIfNull(mListener);
+
+    for (final Class<?> elementClass : mMap.keySet()) {
+      final Descriptor nodeDescriptor = mMap.get(elementClass);
+
+      if (nodeDescriptor instanceof ChainedDescriptor) {
+        final ChainedDescriptor<?> chainedNodeDescriptor = (ChainedDescriptor<?>)nodeDescriptor;
+        Class<?> superClass = elementClass.getSuperclass();
+        Descriptor superNodeDescriptor = getImpl(superClass);
+        chainedNodeDescriptor.setSuper(superNodeDescriptor);
+      }
+
+      nodeDescriptor.setListener(mListener);
+    }
+
+    mIsInitializing = false;
+    return this;
+  }
+
+  public Descriptor get(Class<?> elementClass) {
+    Util.throwIfNull(elementClass);
+    Util.throwIf(mIsInitializing);
+    return getImpl(elementClass);
+  }
+
+  private Descriptor getImpl(final Class<?> elementClass) {
+    Class<?> theClass = elementClass;
+    while (theClass != null) {
+      Descriptor nodeDescriptor = mMap.get(theClass);
+      if (nodeDescriptor != null) {
+        return nodeDescriptor;
+      }
+
+      theClass = theClass.getSuperclass();
+    }
+
+    return null;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeAttribute.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeAttribute.java
@@ -1,0 +1,8 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+public final class NodeAttribute {
+  public String name;
+  public String value;
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -1,0 +1,26 @@
+package com.facebook.stetho.inspector.elements;
+
+import javax.annotation.Nullable;
+
+public interface NodeDescriptor {
+  public void hook(Object element);
+
+  public void unhook(Object element);
+
+  public NodeType getNodeType(Object element);
+
+  public String getNodeName(Object element);
+
+  public String getLocalName(Object element);
+
+  @Nullable
+  public String getNodeValue(Object element);
+
+  public int getChildCount(Object element);
+
+  public Object getChildAt(Object element, int index);
+
+  public int getAttributeCount(Object element);
+
+  public void copyAttributeAt(Object element, int index, NodeAttribute outAttribute);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
@@ -1,0 +1,26 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.json.annotation.JsonValue;
+
+public enum NodeType {
+  ELEMENT_NODE(1),
+  TEXT_NODE(3),
+  PROCESSING_INSTRUCTION_NODE(7),
+  COMMENT_NODE(8),
+  DOCUMENT_NODE(9),
+  DOCUMENT_TYPE_NODE(10),
+  DOCUMENT_FRAGMENT_NODE(11);
+
+  private final int mValue;
+
+  private NodeType(int value) {
+    mValue = value;
+  }
+
+  @JsonValue
+  public int getProtocolValue() {
+    return mValue;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -1,0 +1,53 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements;
+
+public final class ObjectDescriptor extends Descriptor {
+  @Override
+  public void hook(Object element) {
+  }
+
+  @Override
+  public void unhook(Object element) {
+  }
+
+  @Override
+  public NodeType getNodeType(Object element) {
+    return NodeType.ELEMENT_NODE;
+  }
+
+  @Override
+  public String getNodeName(Object element) {
+    return element.getClass().getName();
+  }
+
+  @Override
+  public String getLocalName(Object element) {
+    return getNodeName(element);
+  }
+
+  @Override
+  public String getNodeValue(Object element) {
+    return null;
+  }
+
+  @Override
+  public int getChildCount(Object element) {
+    return 0;
+  }
+
+  @Override
+  public Object getChildAt(Object element, int index) {
+    throw new IndexOutOfBoundsException();
+  }
+
+  @Override
+  public int getAttributeCount(Object element) {
+    return 0;
+  }
+
+  @Override
+  public void copyAttributeAt(Object element, int index, NodeAttribute outAttribute) {
+    throw new IndexOutOfBoundsException();
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -1,0 +1,36 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Activity;
+import android.view.View;
+import android.view.Window;
+
+import com.facebook.stetho.common.StringUtil;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+
+final class ActivityDescriptor extends ChainedDescriptor<Activity> {
+  @Override
+  protected String onGetNodeName(Activity element) {
+    String className = element.getClass().getName();
+    return StringUtil.removePrefix(className, "android.app.");
+  }
+
+  // TODO: support for Fragment
+
+  @Override
+  protected int onGetChildCount(Activity element) {
+    Window window = element.getWindow();
+    return (window != null) ? 1 : 0;
+  }
+
+  @Override
+  protected Object onGetChildAt(Activity element, int index) {
+    Window window = element.getWindow();
+    if (window == null) {
+      throw new IndexOutOfBoundsException();
+    } else {
+      return window;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -1,0 +1,105 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Activity;
+import android.app.Application;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.TextView;
+
+import com.facebook.stetho.inspector.elements.DOMProvider;
+import com.facebook.stetho.inspector.elements.Descriptor;
+import com.facebook.stetho.inspector.elements.DescriptorMap;
+import com.facebook.stetho.inspector.elements.NodeDescriptor;
+import com.facebook.stetho.inspector.elements.ObjectDescriptor;
+
+final class AndroidDOMProvider implements DOMProvider {
+  private final Application mApplication;
+  private final DescriptorMap mDescriptorMap;
+  private final ViewHighlighter mHighlighter;
+  private Listener mListener;
+
+  public AndroidDOMProvider(Application application) {
+    mApplication = application;
+
+    mDescriptorMap = new DescriptorMap()
+        .beginInit()
+        .register(Activity.class, new ActivityDescriptor())
+        .register(Application.class, new ApplicationDescriptor())
+        .register(Object.class, new ObjectDescriptor())
+        .register(TextView.class, new TextViewDescriptor())
+        .register(View.class, new ViewDescriptor())
+        .register(ViewGroup.class, new ViewGroupDescriptor())
+        .register(Window.class, new WindowDescriptor())
+        .setListener(new DescriptorListener())
+        .endInit();
+
+    mHighlighter = ViewHighlighter.newInstance();
+  }
+
+  @Override
+  public void dispose() {
+    mHighlighter.clearHighlight();
+  }
+
+  @Override
+  public void setListener(Listener listener) {
+    mListener = listener;
+  }
+
+  @Override
+  public Object getRootElement() {
+    return mApplication;
+  }
+
+  @Override
+  public NodeDescriptor getNodeDescriptor(Object element) {
+    return (element == null) ? null : mDescriptorMap.get(element.getClass());
+  }
+
+  @Override
+  public void highlightElement(
+      Object element,
+      int contentColor,
+      int paddingColor,
+      int borderColor,
+      int marginColor) {
+    if (!(element instanceof View)) {
+      mHighlighter.clearHighlight();
+    }
+    else {
+      final View view = (View)element;
+      mHighlighter.setHighlightedView(view, contentColor, paddingColor, borderColor, marginColor);
+    }
+  }
+
+  @Override
+  public void hideHighlight() {
+    mHighlighter.clearHighlight();
+  }
+
+  // Forwards notifications from Descriptor to DOM
+  private class DescriptorListener implements Descriptor.Listener {
+    @Override
+    public void onAttributeModified(Object element, String name, String value) {
+      mListener.onAttributeModified(element, name, value);
+    }
+
+    @Override
+    public void onAttributeRemoved(Object element, String name) {
+      mListener.onAttributeRemoved(element, name);
+    }
+
+    @Override
+    public void onChildInserted(Object parentElement, Object previousElement, Object childElement) {
+      mListener.onChildInserted(parentElement, previousElement, childElement);
+    }
+
+    @Override
+    public void onChildRemoved(Object parentElement, Object childElement) {
+      mListener.onChildRemoved(parentElement, childElement);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProviderFactory.java
@@ -1,0 +1,21 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Application;
+
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.DOMProvider;
+
+public class AndroidDOMProviderFactory implements DOMProvider.Factory {
+  private final Application mApplication;
+
+  public AndroidDOMProviderFactory(Application application) {
+    mApplication = Util.throwIfNull(application);
+  }
+
+  @Override
+  public DOMProvider create() {
+    return new AndroidDOMProvider(mApplication);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -1,0 +1,166 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Application;
+import android.os.Build;
+import android.os.Bundle;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.common.android.ApplicationUtil;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.NodeType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class ApplicationDescriptor extends ChainedDescriptor<Application> {
+  private static final String TAG = "ApplicationDescriptor";
+
+  private final Map<Application, ElementContext> mElementToContextMap =
+      Collections.synchronizedMap(new IdentityHashMap<Application, ElementContext>());
+
+  private ElementContext getContext(Application element) {
+    return mElementToContextMap.get(element);
+  }
+
+  @Override
+  protected void onHook(Application element) {
+    ElementContext context = newElementContext();
+    context.hook(element);
+    mElementToContextMap.put(element, context);
+  }
+
+  @Override
+  protected void onUnhook(Application element) {
+    ElementContext context = mElementToContextMap.remove(element);
+    context.unhook();
+  }
+
+  @Override
+  protected NodeType onGetNodeType(Application element) {
+    return NodeType.DOCUMENT_NODE;
+  }
+
+  @Override
+  protected int onGetChildCount(Application element) {
+    ElementContext context = getContext(element);
+    return context.getActivitiesList().size();
+  }
+
+  @Override
+  protected Object onGetChildAt(Application element, int index) {
+    ElementContext context = getContext(element);
+    return context.getActivitiesList().get(index);
+  }
+
+  private ElementContext newElementContext() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+      return new ElementContextICS();
+    } else {
+      LogUtil.w(TAG, "Running on pre-ICS: must manually reload inspector when Activity changes");
+      return new ElementContextPreICS();
+    }
+  }
+
+  private abstract class ElementContext {
+    public abstract void hook(Application element);
+
+    public abstract void unhook();
+
+    public abstract List<Activity> getActivitiesList();
+  }
+
+  private final class ElementContextPreICS extends ElementContext {
+    @Override
+    public void hook(Application element) {
+    }
+
+    @Override
+    public void unhook() {
+    }
+
+    @Override
+    public List<Activity> getActivitiesList() {
+      return ApplicationUtil.getAllActivities();
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+  private final class ElementContextICS extends ElementContext {
+    private Application mElement;
+    private Application.ActivityLifecycleCallbacks mCallbacks;
+    private List<Activity> mActivities;
+
+    @Override
+    public void hook(Application element) {
+      mElement = Util.throwIfNull(element);
+      mActivities = new ArrayList<Activity>();
+
+      // TODO: tree diffing will remove the need to even worry about installing this callback,
+      //       which will then allow ~realtime updates for pre-ICS. for now, pre-ICS will just
+      //       have to close and re-open the inspector whenever the activity changes.
+      //       (this does assume that the hack below for getAllActivitiesHack() works on pre-ICS)
+      mCallbacks = new Application.ActivityLifecycleCallbacks() {
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+          mActivities.add(0, activity);
+          getListener().onChildInserted(mElement, null, activity);
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+          mActivities.remove(activity);
+          getListener().onChildRemoved(mElement, activity);
+        }
+      };
+
+      mElement.registerActivityLifecycleCallbacks(mCallbacks);
+
+      mActivities = ApplicationUtil.getAllActivities();
+    }
+
+    @Override
+    public void unhook() {
+      if (mElement != null) {
+        if (mCallbacks != null) {
+          mElement.unregisterActivityLifecycleCallbacks(mCallbacks);
+          mCallbacks = null;
+        }
+
+        mElement = null;
+      }
+    }
+
+    @Override
+    public List<Activity> getActivitiesList() {
+      return mActivities;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -1,0 +1,87 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.TextView;
+
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.NodeAttribute;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+final class TextViewDescriptor extends ChainedDescriptor<TextView> {
+  private static final String TEXT_ATTRIBUTE_NAME = "text";
+
+  private final Map<TextView, ElementContext> mElementToContextMap =
+      Collections.synchronizedMap(new IdentityHashMap<TextView, ElementContext>());
+
+  @Override
+  protected void onHook(final TextView element) {
+    ElementContext context = new ElementContext();
+    context.hook(element);
+    mElementToContextMap.put(element, context);
+  }
+
+  protected void onUnhook(TextView element) {
+    ElementContext context = mElementToContextMap.remove(element);
+    context.unhook();
+  }
+
+  @Override
+  protected int onGetAttributeCount(TextView element) {
+    return (element.getText().length() == 0) ? 0 : 1;
+  }
+
+  @Override
+  protected void onCopyAttributeAt(TextView element, int index, NodeAttribute outAttribute) {
+    if (index != 0) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    CharSequence text = element.getText();
+    if (text.length() == 0) {
+      throw new IndexOutOfBoundsException();
+    } else {
+      outAttribute.name = TEXT_ATTRIBUTE_NAME;
+      outAttribute.value = text.toString();
+    }
+  }
+
+  private final class ElementContext implements TextWatcher {
+    private TextView mElement;
+
+    public void hook(TextView element) {
+      mElement = Util.throwIfNull(element);
+      mElement.addTextChangedListener(this);
+    }
+
+    public void unhook() {
+      if (mElement != null) {
+        mElement.removeTextChangedListener(this);
+        mElement = null;
+      }
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+      if (s.length() == 0) {
+        getListener().onAttributeRemoved(mElement, TEXT_ATTRIBUTE_NAME);
+      } else {
+        getListener().onAttributeModified(mElement, TEXT_ATTRIBUTE_NAME, s.toString());
+      }
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -1,0 +1,20 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.view.View;
+
+import com.facebook.stetho.common.StringUtil;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+
+final class ViewDescriptor extends ChainedDescriptor<View> {
+  @Override
+  protected String onGetNodeName(View element) {
+    String className = element.getClass().getName();
+
+    return
+        StringUtil.removePrefix(className, "android.view.",
+        StringUtil.removePrefix(className, "android.widget."));
+  }
+}
+

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -1,0 +1,164 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
+  // TODO: We're probably going to switch to another way of determining structural
+  //       changes in the View tree. So this gizmo with chaining OnHierarchyChangeListener
+  //       via reflection should go away soon.
+
+  private static final Field sOnHierarchyChangeListenerField;
+  static {
+    Field field;
+    try {
+      field = ViewGroup.class.getDeclaredField("mOnHierarchyChangeListener");
+    } catch (NoSuchFieldException ex) {
+      field = null;
+    }
+
+    sOnHierarchyChangeListenerField = field;
+
+    if (sOnHierarchyChangeListenerField != null) {
+      sOnHierarchyChangeListenerField.setAccessible(true);
+    }
+  }
+
+  private final Map<ViewGroup, ElementContext> mElementToContextMap =
+      Collections.synchronizedMap(new HashMap<ViewGroup, ElementContext>());
+
+  public ViewGroupDescriptor() {
+  }
+
+  @Override
+  protected void onHook(ViewGroup element) {
+    ElementContext context = new ElementContext();
+    context.hook(element);
+    mElementToContextMap.put(element, context);
+  }
+
+  @Override
+  protected void onUnhook(ViewGroup element) {
+    ElementContext context = mElementToContextMap.remove(element);
+    context.unhook();
+  }
+
+  @Override
+  protected int onGetChildCount(ViewGroup element) {
+    return element.getChildCount();
+  }
+
+  @Override
+  protected Object onGetChildAt(ViewGroup element, int index) {
+    if (index < 0 || index >= element.getChildCount()) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    return element.getChildAt(index);
+  }
+
+  private static ViewGroup.OnHierarchyChangeListener getOnHierarchyChangeListenerHack(
+      ViewGroup viewGroup) throws NoSuchFieldException {
+    if (sOnHierarchyChangeListenerField == null) {
+      throw new NoSuchFieldException();
+    }
+
+    try {
+      return (ViewGroup.OnHierarchyChangeListener) sOnHierarchyChangeListenerField.get(viewGroup);
+    } catch (IllegalAccessException ex) {
+      // should not happen since we called setAccessible(true)
+      throw new IllegalAccessError(ex.getMessage());
+    }
+  }
+
+  private static int findChildIndex(ViewGroup parent, View child) {
+    int count = parent.getChildCount();
+    for (int i = 0; i < count; ++i) {
+      if (parent.getChildAt(i) == child) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private final class ElementContext implements ViewGroup.OnHierarchyChangeListener {
+
+    private ViewGroup mElement;
+    private ViewGroup.OnHierarchyChangeListener mInnerListener;
+
+    public void hook(ViewGroup element) {
+      mElement = Util.throwIfNull(element);
+
+      ViewGroup.OnHierarchyChangeListener innerListener;
+      try {
+        innerListener = getOnHierarchyChangeListenerHack(mElement);
+      } catch (NoSuchFieldException ex) {
+        innerListener = null;
+      }
+      mInnerListener = innerListener;
+
+      mElement.setOnHierarchyChangeListener(this);
+    }
+
+    public void unhook() {
+      if (mElement != null) {
+        ViewGroup.OnHierarchyChangeListener currentListener;
+        try {
+          currentListener = getOnHierarchyChangeListenerHack(mElement);
+        } catch (NoSuchFieldException ex) {
+          currentListener = null;
+        }
+
+        if (currentListener == this) {
+          mElement.setOnHierarchyChangeListener(mInnerListener);
+        } else {
+          mElement.setOnHierarchyChangeListener(null);
+        }
+
+        mInnerListener = null;
+        mElement = null;
+      }
+    }
+
+    @Override
+    public void onChildViewAdded(View parent, View child) {
+      if (mElement == null) {
+        return;
+      }
+
+      if (mInnerListener != null) {
+        mInnerListener.onChildViewAdded(parent, child);
+      }
+
+      if (parent instanceof ViewGroup) {
+        final ViewGroup parentGroup = (ViewGroup)parent;
+        int index = findChildIndex(parentGroup, child);
+        View previousChild = (index == 0) ? null : parentGroup.getChildAt(index - 1);
+        getListener().onChildInserted(parent, previousChild, child);
+      }
+    }
+
+    @Override
+    public void onChildViewRemoved(View parent, View child) {
+      if (mElement == null) {
+        return;
+      }
+
+      if (mInnerListener != null) {
+        mInnerListener.onChildViewRemoved(parent, child);
+      }
+
+      getListener().onChildRemoved(parent, child);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -1,0 +1,137 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.annotation.TargetApi;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+
+abstract class ViewHighlighter {
+  private static final String TAG = "ViewHighlighter";
+
+  public static ViewHighlighter newInstance() {
+    // TODO: find ways to do highlighting on older versions too
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      return new OverlayHighlighter();
+    } else {
+      LogUtil.w(TAG, "Running on pre-JBMR2: View highlighting is not supported");
+      return new NoopHighlighter();
+    }
+  }
+
+  protected ViewHighlighter() {
+  }
+
+  public abstract void clearHighlight();
+
+  public abstract void setHighlightedView(
+      View view,
+      int contentColor,
+      int paddingColor,
+      int borderColor,
+      int marginColor);
+
+  private static final class NoopHighlighter extends ViewHighlighter {
+    @Override
+    public void clearHighlight() {
+    }
+
+    @Override
+    public void setHighlightedView(
+        View view,
+        int contentColor,
+        int paddingColor,
+        int borderColor,
+        int marginColor) {
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+  private static final class OverlayHighlighter extends ViewHighlighter {
+    // TODO: use the top-level ViewGroupOverlay instead of ViewOverlay so that we don't end up
+    //       causing every single view to allocate a ViewOverlay
+
+    private final Handler mHandler;
+    private final ColorDrawable mHighlightDrawable;
+
+    // Only assigned on the UI thread
+    private View mHighlightedView;
+
+    private AtomicReference<View> mViewToHighlight = new AtomicReference<View>();
+    private AtomicInteger mContentColor = new AtomicInteger();
+
+    private final Runnable mHighlightViewOnUiThreadRunnable = new Runnable() {
+      @Override
+      public void run() {
+        highlightViewOnUiThread();
+      }
+    };
+
+    public OverlayHighlighter() {
+      mHandler = new Handler(Looper.getMainLooper());
+      mHighlightDrawable = new ColorDrawable();
+    }
+
+    @Override
+    public void clearHighlight() {
+      setHighlightedViewImpl(null, 0, 0, 0, 0);
+    }
+
+    @Override
+    public void setHighlightedView(
+        View view,
+        int contentColor,
+        int paddingColor,
+        int borderColor,
+        int marginColor) {
+      setHighlightedViewImpl(
+          Util.throwIfNull(view),
+          contentColor,
+          paddingColor,
+          borderColor,
+          marginColor);
+    }
+
+    private void setHighlightedViewImpl(
+        @Nullable View view,
+        int contentColor,
+        int paddingColor,
+        int borderColor,
+        int marginColor) {
+      mHandler.removeCallbacks(mHighlightViewOnUiThreadRunnable);
+      mViewToHighlight.set(view);
+      mContentColor.set(contentColor);
+      mHandler.postDelayed(mHighlightViewOnUiThreadRunnable, 100);
+    }
+
+    private void highlightViewOnUiThread() {
+      final View viewToHighlight = mViewToHighlight.getAndSet(null);
+      if (viewToHighlight == mHighlightedView) {
+        return;
+      }
+
+      if (mHighlightedView != null) {
+        mHighlightedView.getOverlay().remove(mHighlightDrawable);
+      }
+
+      if (viewToHighlight != null) {
+        mHighlightDrawable.setColor(mContentColor.get());
+        mHighlightDrawable.setBounds(0, 0, viewToHighlight.getWidth(), viewToHighlight.getHeight());
+        viewToHighlight.getOverlay().add(mHighlightDrawable);
+        mHighlightedView = viewToHighlight;
+      }
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -1,0 +1,249 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.view.ActionMode;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+final class WindowDescriptor extends ChainedDescriptor<Window> {
+  private static final String TAG = "WindowDescriptor";
+
+  private final Map<Window, ElementContext> mElementToContextMap =
+      Collections.synchronizedMap(new IdentityHashMap<Window, ElementContext>());
+
+  @Override
+  protected void onHook(Window element) {
+    ElementContext context = newElementContext();
+    context.hook(element);
+    mElementToContextMap.put(element, context);
+  }
+
+  @Override
+  protected void onUnhook(Window element) {
+    ElementContext context = mElementToContextMap.remove(element);
+    context.unhook();
+  }
+
+  @Override
+  protected int onGetChildCount(Window element) {
+    View decorView = element.peekDecorView();
+    return (decorView != null) ? 1 : 0;
+  }
+
+  @Override
+  protected Object onGetChildAt(Window element, int index) {
+    View decorView = element.peekDecorView();
+    if (decorView == null) {
+      throw new IndexOutOfBoundsException();
+    } else {
+      return decorView;
+    }
+  }
+
+  // TODO: We're probably going to switch to another way of determining structural
+  //       changes in the View tree. So this good-faith effort gizmo with chaining
+  //       Window.Callback should go away soon enough. Pre-HCMR1 should be supported
+  //       just fine then too.
+
+  private ElementContext newElementContext() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+      return new ElementContextHCMR1();
+    } else {
+      LogUtil.w(
+          TAG,
+          "Running on pre-HCMR1: must manually reload inspector after Window installs DecorView");
+
+      return new ElementContext();
+    }
+  }
+
+  private class ElementContext {
+    public void hook(Window window) {
+    }
+
+    public void unhook() {
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
+  private final class ElementContextHCMR1 extends ElementContext implements Window.Callback {
+    private Window mWindow;
+    private Window.Callback mInnerCallback;
+    private View mDecorView;
+
+    @Override
+    public void hook(Window window) {
+      mWindow = window;
+      mInnerCallback = mWindow.getCallback();
+      mWindow.setCallback(this);
+      mDecorView = mWindow.peekDecorView();
+    }
+
+    @Override
+    public void unhook() {
+      if (mWindow != null) {
+        if (mInnerCallback != null) {
+          if (mWindow.getCallback() == this) {
+            mWindow.setCallback(mInnerCallback);
+          }
+          mInnerCallback = null;
+        }
+
+        mDecorView = null;
+        mWindow = null;
+      }
+    }
+
+    // Window.Callback
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchKeyEvent(event) : false;
+    }
+
+    @Override
+    public boolean dispatchKeyShortcutEvent(KeyEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchKeyShortcutEvent(event) : false;
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchTouchEvent(event) : false;
+    }
+
+    @Override
+    public boolean dispatchTrackballEvent(MotionEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchTrackballEvent(event) : false;
+    }
+
+    @Override
+    public boolean dispatchGenericMotionEvent(MotionEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchGenericMotionEvent(event) : false;
+    }
+
+    @Override
+    public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.dispatchPopulateAccessibilityEvent(event) : false;
+    }
+
+    @Override
+    public View onCreatePanelView(int featureId) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onCreatePanelView(featureId) : null;
+    }
+
+    @Override
+    public boolean onCreatePanelMenu(int featureId, Menu menu) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onCreatePanelMenu(featureId, menu) : false;
+    }
+
+    @Override
+    public boolean onPreparePanel(int featureId, View view, Menu menu) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onPreparePanel(featureId, view, menu) : false;
+    }
+
+    @Override
+    public boolean onMenuOpened(int featureId, Menu menu) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onMenuOpened(featureId, menu) : false;
+    }
+
+    @Override
+    public boolean onMenuItemSelected(int featureId, MenuItem item) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onMenuItemSelected(featureId, item) : false;
+    }
+
+    @Override
+    public void onWindowAttributesChanged(WindowManager.LayoutParams attrs) {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onWindowAttributesChanged(attrs);
+      }
+    }
+
+    @Override
+    public void onContentChanged() {
+      if (mWindow == null) {
+        return;
+      }
+
+      if (mInnerCallback != null) {
+        mInnerCallback.onContentChanged();
+      }
+
+      if (mDecorView == null) {
+        mDecorView = mWindow.peekDecorView();
+        if (mDecorView != null) {
+          getListener().onChildInserted(mWindow, null, mDecorView);
+          // TODO: once we have the decorView, we don't need to worry about further changes (AFAIK).
+          //       but since we're going to do something else for this (tree diffing), I don't
+          //       think we need to worry about removing our callback for now
+        }
+      }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onWindowFocusChanged(hasFocus);
+      }
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onAttachedToWindow();
+      }
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onDetachedFromWindow();
+      }
+    }
+
+    @Override
+    public void onPanelClosed(int featureId, Menu menu) {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onPanelClosed(featureId, menu);
+      }
+    }
+
+    @Override
+    public boolean onSearchRequested() {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onSearchRequested() : false;
+    }
+
+    @Override
+    public ActionMode onWindowStartingActionMode(ActionMode.Callback callback) {
+      return (mWindow != null && mInnerCallback != null) ? mInnerCallback.onWindowStartingActionMode(callback) : null;
+    }
+
+    @Override
+    public void onActionModeStarted(ActionMode mode) {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onActionModeStarted(mode);
+      }
+    }
+
+    @Override
+    public void onActionModeFinished(ActionMode mode) {
+      if (mWindow != null && mInnerCallback != null) {
+        mInnerCallback.onActionModeFinished(mode);
+      }
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
@@ -23,7 +23,7 @@ import com.facebook.stetho.inspector.jsonrpc.PendingRequestCallback;
  * to the peer to have them appear in the inspector UI.  This class simplifies managing those
  * enabled peers for each functionality domain.
  */
-public abstract class ChromePeerManager {
+public class ChromePeerManager {
   private static final String TAG = "ChromePeerManager";
 
   /**

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
@@ -1,0 +1,96 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.helper;
+
+import android.util.SparseArray;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import javax.annotation.concurrent.GuardedBy;
+
+public class ObjectIdMapper {
+  protected final Object mSync = new Object();
+
+  @GuardedBy("mSync")
+  private int mNextId = 1;
+
+  @GuardedBy("mSync")
+  private final Map<Object, Integer> mObjectToIdMap = new IdentityHashMap<Object, Integer>();
+
+  @GuardedBy("mSync")
+  private SparseArray<Object> mIdToObjectMap = new SparseArray<Object>();
+
+  public void clear() {
+    SparseArray<Object> idToObjectMap;
+    synchronized (mSync) {
+      idToObjectMap = mIdToObjectMap;
+      mObjectToIdMap.clear();
+      mIdToObjectMap = new SparseArray<Object>();
+    }
+
+    int size = idToObjectMap.size();
+    for (int i = 0; i < size; ++i) {
+      int id = idToObjectMap.keyAt(i);
+      Object object = idToObjectMap.valueAt(i);
+      onUnmapped(object, id);
+    }
+  }
+
+  public Object getObjectForId(int id) {
+    synchronized (mSync) {
+      return mIdToObjectMap.get(id);
+    }
+  }
+
+  public Integer getIdForObject(Object object) {
+    synchronized (mSync) {
+      return mObjectToIdMap.get(object);
+    }
+  }
+
+  public int putObject(Object object) {
+    Integer id;
+
+    synchronized (mSync) {
+      id = mObjectToIdMap.get(object);
+      if (id != null) {
+        return id;
+      }
+
+      id = mNextId++;
+      mObjectToIdMap.put(object, id);
+      mIdToObjectMap.put(id, object);
+    }
+
+    onMapped(object, id);
+    return id;
+  }
+
+  public Integer removeObject(Object object) {
+    Integer id;
+
+    synchronized (mSync) {
+      id = mObjectToIdMap.remove(object);
+      if (id == null) {
+        return null;
+      }
+
+      mIdToObjectMap.remove(id);
+    }
+
+    onUnmapped(object, id);
+    return id;
+  }
+
+  public int size() {
+    return mObjectToIdMap.size();
+  }
+
+  protected void onMapped(Object object, int id) {
+  }
+
+  protected void onUnmapped(Object object, int id) {
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -2,30 +2,237 @@
 
 package com.facebook.stetho.inspector.protocol.module;
 
+import android.graphics.Color;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.DOMProvider;
+import com.facebook.stetho.inspector.elements.NodeAttribute;
+import com.facebook.stetho.inspector.elements.NodeDescriptor;
+import com.facebook.stetho.inspector.elements.NodeType;
+import com.facebook.stetho.inspector.helper.ChromePeerManager;
+import com.facebook.stetho.inspector.helper.ObjectIdMapper;
+import com.facebook.stetho.inspector.helper.PeersRegisteredListener;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcPeer;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcResult;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsMethod;
+import com.facebook.stetho.json.ObjectMapper;
 import com.facebook.stetho.json.annotation.JsonProperty;
 
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 public class DOM implements ChromeDevtoolsDomain {
-  public DOM() {
+  private final ChromePeerManager mPeerManager;
+  private final DOMProvider.Factory mDOMProviderFactory;
+  private final ObjectMapper mObjectMapper;
+  private final DOMObjectIdMapper mObjectIdMapper;
+
+  @Nullable
+  private DOMProvider mDOMProvider;
+
+  public DOM(DOMProvider.Factory providerFactory) {
+    mDOMProviderFactory = Util.throwIfNull(providerFactory);
+
+    mPeerManager = new ChromePeerManager();
+    mPeerManager.setListener(new PeerManagerListener());
+
+    mObjectMapper = new ObjectMapper();
+    mObjectIdMapper = new DOMObjectIdMapper();
+  }
+
+  @ChromeDevtoolsMethod
+  public void enable(JsonRpcPeer peer, JSONObject params) {
+    mPeerManager.addPeer(peer);
+  }
+
+  @ChromeDevtoolsMethod
+  public void disable(JsonRpcPeer peer, JSONObject params) {
+    mPeerManager.removePeer(peer);
   }
 
   @ChromeDevtoolsMethod
   public JsonRpcResult getDocument(JsonRpcPeer peer, JSONObject params) {
-    Node node = new Node();
-    node.nodeId = 1;
-    node.nodeType = 1;
-    node.nodeName = "";
-    node.nodeValue = "";
-    return node;
+    Object rootElement = mDOMProvider.getRootElement();
+    if (rootElement == null) {
+      return null;
+    }
+
+    Node rootNode = createNodeForElement(rootElement);
+
+    GetDocumentResponse result = new GetDocumentResponse();
+    result.root = rootNode;
+    return result;
+  }
+
+  @ChromeDevtoolsMethod
+  public void highlightNode(JsonRpcPeer peer, JSONObject params) {
+    HighlightNodeRequest request = mObjectMapper.convertValue(params, HighlightNodeRequest.class);
+    if (request.nodeId == null) {
+      LogUtil.w("highlightNode was not given a nodeId; JS objectId is not supported");
+    } else {
+      Object element = mObjectIdMapper.getObjectForId(request.nodeId);
+      mDOMProvider.highlightElement(
+          element,
+          request.highlightConfig.contentColor.getColor(),
+          request.highlightConfig.paddingColor.getColor(),
+          request.highlightConfig.borderColor.getColor(),
+          request.highlightConfig.marginColor.getColor());
+    }
   }
 
   @ChromeDevtoolsMethod
   public void hideHighlight(JsonRpcPeer peer, JSONObject params) {
+    mDOMProvider.hideHighlight();
+  }
+
+  private Node createNodeForElement(Object element) {
+    NodeDescriptor descriptor = mDOMProvider.getNodeDescriptor(element);
+
+    Node node = new Node();
+    node.nodeId = mObjectIdMapper.putObject(element);
+    node.nodeType = descriptor.getNodeType(element);
+    node.nodeName = descriptor.getNodeName(element);
+    node.localName = descriptor.getLocalName(element);
+    node.nodeValue = descriptor.getNodeValue(element);
+
+    node.children = getChildNodesForElement(element);
+    node.childNodeCount = node.children.size();
+
+    int attributeCount = descriptor.getAttributeCount(element);
+    if (attributeCount > 0) {
+      node.attributes = new ArrayList<String>(attributeCount * 2);
+
+      NodeAttribute attribute = new NodeAttribute();
+      for (int i = 0; i < attributeCount; ++i) {
+        descriptor.copyAttributeAt(element, i, attribute);
+
+        node.attributes.add(attribute.name);
+        node.attributes.add(attribute.value);
+
+        attribute.name = null;
+        attribute.value = null;
+      }
+    }
+
+    return node;
+  }
+
+  private List<Node> getChildNodesForElement(Object element) {
+    NodeDescriptor descriptor = mDOMProvider.getNodeDescriptor(element);
+    int childNodeCount = descriptor.getChildCount(element);
+
+    List<Node> childNodes;
+    if (childNodeCount == 0) {
+      childNodes = Collections.emptyList();
+    } else {
+      childNodes = new ArrayList<Node>(childNodeCount);
+      for (int i = 0; i < childNodeCount; ++i) {
+        Object childElement = descriptor.getChildAt(element, i);
+        Node childNode = createNodeForElement(childElement);
+        childNodes.add(childNode);
+      }
+    }
+
+    return childNodes;
+  }
+
+  private void removeElementTree(Object element) {
+    NodeDescriptor descriptor = mDOMProvider.getNodeDescriptor(element);
+    int childCount = descriptor.getChildCount(element);
+    for (int i = 0; i < childCount; ++i) {
+      Object childElement = descriptor.getChildAt(element, i);
+      removeElementTree(childElement);
+    }
+    mObjectIdMapper.removeObject(element);
+  }
+
+  private final class PeerManagerListener extends PeersRegisteredListener {
+    @Override
+    protected synchronized void onFirstPeerRegistered() {
+      mDOMProvider = mDOMProviderFactory.create();
+      mDOMProvider.setListener(new ProviderListener());
+    }
+
+    @Override
+    protected synchronized void onLastPeerUnregistered() {
+      Object rootElement = mDOMProvider.getRootElement();
+      removeElementTree(rootElement);
+
+      mObjectIdMapper.clear();
+
+      mDOMProvider.dispose();
+      mDOMProvider = null;
+    }
+  }
+
+  private final class DOMObjectIdMapper extends ObjectIdMapper {
+    @Override
+    protected void onMapped(Object object, int id) {
+      NodeDescriptor descriptor = mDOMProvider.getNodeDescriptor(object);
+      descriptor.hook(object);
+    }
+
+    @Override
+    protected void onUnmapped(Object object, int id) {
+      NodeDescriptor descriptor = mDOMProvider.getNodeDescriptor(object);
+      descriptor.unhook(object);
+    }
+  }
+
+  private final class ProviderListener implements DOMProvider.Listener {
+    @Override
+    public void onAttributeModified(Object element, String name, String value) {
+      AttributeModifiedEvent message = new AttributeModifiedEvent();
+      message.nodeId = mObjectIdMapper.getIdForObject(element);
+      message.name = name;
+      message.value = value;
+      mPeerManager.sendNotificationToPeers("DOM.attributeModified", message);
+    }
+
+    @Override
+    public void onAttributeRemoved(Object element, String name) {
+      AttributeRemovedEvent message = new AttributeRemovedEvent();
+      message.nodeId = mObjectIdMapper.getIdForObject(element);
+      message.name = name;
+      mPeerManager.sendNotificationToPeers("DOM.attributeRemoved", message);
+    }
+
+    @Override
+    public void onChildInserted(Object parentElement, Object previousElement, Object childElement) {
+      ChildNodeInsertedEvent message = new ChildNodeInsertedEvent();
+      message.parentNodeId = mObjectIdMapper.getIdForObject(parentElement);
+
+      // using -1 was just a guess, and it seemed to work. this is for the case where we
+      // go from 0 to 1 children, or if we just happen to be inserting at index 0
+      message.previousNodeId = (previousElement == null)
+          ? -1
+          : mObjectIdMapper.getIdForObject(previousElement);
+
+      message.node = createNodeForElement(childElement);
+      mPeerManager.sendNotificationToPeers("DOM.childNodeInserted", message);
+    }
+
+    @Override
+    public void onChildRemoved(Object parentElement, Object childElement) {
+      ChildNodeRemovedEvent message = new ChildNodeRemovedEvent();
+      message.parentNodeId = mObjectIdMapper.getIdForObject(parentElement);
+      message.nodeId = mObjectIdMapper.getIdForObject(childElement);
+      mPeerManager.sendNotificationToPeers("DOM.childNodeRemoved", message);
+
+      removeElementTree(childElement);
+    }
+  }
+
+  private static class GetDocumentResponse implements JsonRpcResult {
+    @JsonProperty(required = true)
+    public Node root;
   }
 
   private static class Node implements JsonRpcResult {
@@ -33,7 +240,7 @@ public class DOM implements ChromeDevtoolsDomain {
     public int nodeId;
 
     @JsonProperty(required = true)
-    public int nodeType;
+    public NodeType nodeType;
 
     @JsonProperty(required = true)
     public String nodeName;
@@ -43,5 +250,103 @@ public class DOM implements ChromeDevtoolsDomain {
 
     @JsonProperty(required = true)
     public String nodeValue;
+
+    @JsonProperty
+    public Integer childNodeCount;
+
+    @JsonProperty
+    public List<Node> children;
+
+    @JsonProperty
+    public List<String> attributes;
+  }
+
+  private static class AttributeModifiedEvent {
+    @JsonProperty(required = true)
+    public int nodeId;
+
+    @JsonProperty(required = true)
+    public String name;
+
+    @JsonProperty(required = true)
+    public String value;
+  }
+
+  private static class AttributeRemovedEvent {
+    @JsonProperty(required = true)
+    public int nodeId;
+
+    @JsonProperty(required = true)
+    public String name;
+  }
+
+  private static class ChildNodeInsertedEvent {
+    @JsonProperty(required = true)
+    public int parentNodeId;
+
+    @JsonProperty(required = true)
+    public int previousNodeId;
+
+    @JsonProperty(required = true)
+    public Node node;
+  }
+
+  private static class ChildNodeRemovedEvent {
+    @JsonProperty(required = true)
+    public int parentNodeId;
+
+    @JsonProperty(required = true)
+    public int nodeId;
+  }
+
+  private static class HighlightNodeRequest {
+    @JsonProperty(required = true)
+    public HighlightConfig highlightConfig;
+
+    @JsonProperty
+    public Integer nodeId;
+
+    @JsonProperty
+    public String objectId;
+  }
+
+  private static class HighlightConfig {
+    @JsonProperty
+    public RGBAColor contentColor;
+
+    @JsonProperty
+    public RGBAColor paddingColor;
+
+    @JsonProperty
+    public RGBAColor borderColor;
+
+    @JsonProperty
+    public RGBAColor marginColor;
+  }
+
+  private static class RGBAColor {
+    @JsonProperty(required = true)
+    public int r;
+
+    @JsonProperty(required = true)
+    public int g;
+
+    @JsonProperty(required = true)
+    public int b;
+
+    @JsonProperty
+    public Double a;
+
+    public int getColor() {
+      byte alpha;
+      if (this.a == null) {
+        alpha = (byte)255;
+      } else {
+        long aLong = Math.round(this.a * 255.0);
+        alpha = (aLong < 0) ? (byte)0 : (aLong >= 255) ? (byte)255 : (byte)aLong;
+      }
+
+      return Color.argb(alpha, this.r, this.g, this.b);
+    }
   }
 }


### PR DESCRIPTION
This is a first stab at providing an Elements tab for Stetho.

The DOM class handles the JSON protocol and element <--> node ID mapping. An element is meant to be a real object in whatever DOM-type tree is being plugged in via a DOM.Provider implementation. We implement this in UIDOMProvider and our "DOM-type tree" is an Android application. We use the android.app.Application as the root of the DOM, its children are the android.app.Activity instances (initial list retrieved via a hack, then updated via Application.ActivityLifecycleCallbacks), then the android.view.Window and finally its android.view.View tree.

We use DOM.NodeDescriptor to describe an element in terms of a node (DOM.Node). In UIDOMProvider we use the element's class to figure out which descriptor(s) to use, but another DOM.Provider implementation could potentially choose another strategy.

For instance, an android.view.ViewGroup is an "element." ViewGroupNodeDescriptor knows how to describe it in DOM.Node terms (name, children), and how to hook into it (with ViewGroup.OnHierarchyChangedListener) in order to report updates (via DOM.childNodeInserted / DOM.childNodeRemoved). Also participating in this are ViewNodeDescriptor (technically anyway, since it's currently empty) and ObjectNodeDescriptor (mostly just knows how to shorten class names to remove all the "android.*.*" package name noise).

In the Elements tab you can mouse-over a node and it will cause the Android device to draw a red highlight over the corresponding View. This is ultimately handled in the WindowNodeDescriptor class because that's where the highlighting View is installed (and uninstalled).

FIrst step on #14 

![screen shot 2015-02-24 at 1 27 13 pm](https://cloud.githubusercontent.com/assets/10873410/6359566/06d20ef2-bc29-11e4-8f81-1857c90f0680.png)