### PR TITLE
Fix confusing LICENSE issue in fatjar release

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -35,7 +35,7 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar) {
+        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
             from variant.javaCompile.destinationDir
         }
     }
@@ -43,6 +43,7 @@ afterEvaluate { project ->
     artifacts {
         archives androidJavadocJar
         archives androidSourcesJar
+        archives jarRelease
     }
 
     version = VERSION_NAME

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -32,15 +32,30 @@ apply from: rootProject.file('release.gradle')
 
 android.libraryVariants.all { variant ->
     def name = variant.name.capitalize()
-    task "fatjar${name}"(type: Jar, dependsOn: "jar${name}") {
-       classifier = 'fatjar'
-       from variant.javaCompile.destinationDir
-       from {
-           configurations.compile.findAll {
-               it.getName() == 'commons-cli-1.2.jar'
-           }.collect {
-               it.isDirectory() ? it : zipTree(it)
-           }
-       }
+
+    // Ugly kludge to rename license files in the bundled commons-cli
+    // dependency so that they do not appear to describe Stetho's license.
+    configurations.compile.each {
+        if (it.getName() == 'commons-cli-1.2.jar') {
+            def depJarPath = it.getPath()
+            task "tidyCommonsCli${name}"(type: Copy) {
+                from zipTree(depJarPath)
+                into "build/commons-cli-tidy-${name}"
+                rename 'LICENSE', 'commons-cli-LICENSE'
+                rename 'NOTICE', 'commons-cli-NOTICE'
+            }
+        }
+    }
+
+    task "metainf${name}"(type: Copy) {
+        from rootProject.file('LICENSE')
+        into "build/metainf-${name}/META-INF"
+    }
+
+    task "fatjar${name}"(type: Jar, dependsOn: [ "jar${name}", "tidyCommonsCli${name}", "metainf${name}" ]) {
+        classifier = 'fatjar'
+        from variant.javaCompile.destinationDir
+        from "build/commons-cli-tidy-${name}"
+        from "build/metainf-${name}"
     }
 }


### PR DESCRIPTION
The fatjar release for 1.0.0 automatically merged commons-cli's
LICENSE.txt file into the base META-INF directory, appearing to replace
our own LICENSE with the Apache 2.0 license.  Very bad :)

This corrects the situation by somewhat manually organizing the
dependencies into the following structure:

  META-INF/
  META-INF/commons-cli-LICENSE.txt
  META-INF/commons-cli-NOTICE.txt
  META-INF/LICENSE
  META-INF/MANIFEST.MF
  META-INF/maven/
  META-INF/maven/commons-cli/
  META-INF/maven/commons-cli/commons-cli/
  META-INF/maven/commons-cli/commons-cli/pom.properties
  META-INF/maven/commons-cli/commons-cli/pom.xml