### PR TITLE
Adding id attribute to Views

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
@@ -2,7 +2,6 @@
 
 package com.facebook.stetho.inspector.elements;
 
-public final class NodeAttribute {
-  public String name;
-  public String value;
+public interface AttributeAccumulator {
+  public void add(String name, String value);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -120,39 +120,11 @@ public abstract class ChainedDescriptor<E> extends Descriptor {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final int getAttributeCount(Object element) {
-    int superCount = mSuper.getAttributeCount(element);
-    int thisCount = onGetAttributeCount((E)element);
-    return superCount + thisCount;
+  public final void copyAttributes(Object element, AttributeAccumulator attributes) {
+    mSuper.copyAttributes(element, attributes);
+    onCopyAttributes((E)element, attributes);
   }
 
-  protected int onGetAttributeCount(E element) {
-    return 0;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public final void copyAttributeAt(Object element, int index, NodeAttribute outAttribute) {
-    if (index < 0) {
-      throw new IndexOutOfBoundsException();
-    }
-
-    int superCount = mSuper.getChildCount(element);
-    if (index < superCount) {
-      mSuper.copyAttributeAt(element, index, outAttribute);
-      return;
-    }
-
-    int thisCount = onGetAttributeCount((E)element);
-    int thisIndex = index - superCount;
-    if (thisIndex < 0 || thisIndex >= thisCount) {
-      throw new IndexOutOfBoundsException();
-    }
-
-    onCopyAttributeAt((E)element, thisIndex, outAttribute);
-  }
-
-  protected void onCopyAttributeAt(E element, int index, NodeAttribute outAttribute) {
-    throw new IndexOutOfBoundsException();
+  protected void onCopyAttributes(E element, AttributeAccumulator attributes) {
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -1,3 +1,5 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
 package com.facebook.stetho.inspector.elements;
 
 import javax.annotation.Nullable;
@@ -20,7 +22,5 @@ public interface NodeDescriptor {
 
   public Object getChildAt(Object element, int index);
 
-  public int getAttributeCount(Object element);
-
-  public void copyAttributeAt(Object element, int index, NodeAttribute outAttribute);
+  public void copyAttributes(Object element, AttributeAccumulator attributes);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -42,12 +42,6 @@ public final class ObjectDescriptor extends Descriptor {
   }
 
   @Override
-  public int getAttributeCount(Object element) {
-    return 0;
-  }
-
-  @Override
-  public void copyAttributeAt(Object element, int index, NodeAttribute outAttribute) {
-    throw new IndexOutOfBoundsException();
+  public void copyAttributes(Object element, AttributeAccumulator attributes) {
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -7,8 +7,8 @@ import android.text.TextWatcher;
 import android.widget.TextView;
 
 import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
-import com.facebook.stetho.inspector.elements.NodeAttribute;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -33,22 +33,10 @@ final class TextViewDescriptor extends ChainedDescriptor<TextView> {
   }
 
   @Override
-  protected int onGetAttributeCount(TextView element) {
-    return (element.getText().length() == 0) ? 0 : 1;
-  }
-
-  @Override
-  protected void onCopyAttributeAt(TextView element, int index, NodeAttribute outAttribute) {
-    if (index != 0) {
-      throw new IndexOutOfBoundsException();
-    }
-
+  protected void onCopyAttributes(TextView element, AttributeAccumulator attributes) {
     CharSequence text = element.getText();
-    if (text.length() == 0) {
-      throw new IndexOutOfBoundsException();
-    } else {
-      outAttribute.name = TEXT_ATTRIBUTE_NAME;
-      outAttribute.value = text.toString();
+    if (text.length() != 0) {
+      attributes.add(TEXT_ATTRIBUTE_NAME, text.toString());
     }
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -2,12 +2,19 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.content.res.Resources;
 import android.view.View;
 
+import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.StringUtil;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
+import javax.annotation.Nullable;
+
 final class ViewDescriptor extends ChainedDescriptor<View> {
+  private static final String ID_ATTRIBUTE_NAME = "id";
+
   @Override
   protected String onGetNodeName(View element) {
     String className = element.getClass().getName();
@@ -16,5 +23,69 @@ final class ViewDescriptor extends ChainedDescriptor<View> {
         StringUtil.removePrefix(className, "android.view.",
         StringUtil.removePrefix(className, "android.widget."));
   }
-}
 
+  @Override
+  protected void onCopyAttributes(View element, AttributeAccumulator attributes) {
+    String id = getIdAttribute(element);
+    if (id != null) {
+      attributes.add(ID_ATTRIBUTE_NAME, id);
+    }
+  }
+
+  private static int getResourcePackageId(int id) {
+    return (id >>> 24) & 0xff;
+  }
+
+  @Nullable
+  private static String getIdAttribute(View element) {
+    // Adapted from View.toString()
+
+    int id = element.getId();
+    if (id == View.NO_ID) {
+      return null;
+    }
+
+    String idString = null;
+    Resources r = element.getResources();
+    if (r != null) {
+      try {
+        String prefix;
+        String prefixSeparator;
+        switch (getResourcePackageId(id)) {
+          case 0x7f:
+            prefix = "";
+            prefixSeparator = "";
+            break;
+          default:
+            prefix = r.getResourcePackageName(id);
+            prefixSeparator = ":";
+            break;
+        }
+
+        String typeName = r.getResourceTypeName(id);
+        String entryName = r.getResourceEntryName(id);
+
+        StringBuilder sb = new StringBuilder(
+            1 + prefix.length() + prefixSeparator.length() +
+            typeName.length() + 1 + entryName.length());
+        sb.append("@");
+        sb.append(prefix);
+        sb.append(prefixSeparator);
+        sb.append(typeName);
+        sb.append("/");
+        sb.append(entryName);
+
+        idString = sb.toString();
+
+      } catch (Resources.NotFoundException e) {
+        LogUtil.w(e, "Could not retrieve resource info for element: %s", element);
+      }
+    }
+
+    if (idString == null) {
+      idString = "#" + Integer.toHexString(id);
+    }
+
+    return idString;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -6,8 +6,8 @@ import android.graphics.Color;
 
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.DOMProvider;
-import com.facebook.stetho.inspector.elements.NodeAttribute;
 import com.facebook.stetho.inspector.elements.NodeDescriptor;
 import com.facebook.stetho.inspector.elements.NodeType;
 import com.facebook.stetho.inspector.helper.ChromePeerManager;
@@ -105,21 +105,8 @@ public class DOM implements ChromeDevtoolsDomain {
     node.children = getChildNodesForElement(element);
     node.childNodeCount = node.children.size();
 
-    int attributeCount = descriptor.getAttributeCount(element);
-    if (attributeCount > 0) {
-      node.attributes = new ArrayList<String>(attributeCount * 2);
-
-      NodeAttribute attribute = new NodeAttribute();
-      for (int i = 0; i < attributeCount; ++i) {
-        descriptor.copyAttributeAt(element, i, attribute);
-
-        node.attributes.add(attribute.name);
-        node.attributes.add(attribute.value);
-
-        attribute.name = null;
-        attribute.value = null;
-      }
-    }
+    node.attributes = new ArrayList<String>();
+    descriptor.copyAttributes(element, new AttributeListAccumulator(node.attributes));
 
     return node;
   }
@@ -169,6 +156,20 @@ public class DOM implements ChromeDevtoolsDomain {
 
       mDOMProvider.dispose();
       mDOMProvider = null;
+    }
+  }
+
+  private static final class AttributeListAccumulator implements AttributeAccumulator {
+    private final List<String> mList;
+
+    public AttributeListAccumulator(List<String> list) {
+      mList = Util.throwIfNull(list);
+    }
+
+    @Override
+    public void add(String name, String value) {
+      mList.add(name);
+      mList.add(value);
     }
   }
 


### PR DESCRIPTION
The 'id' attribute will now show up in a way that's recognizable from XML layouts, e.g. `id="@id/ima_button"`

I also refactored the protocol for retrieving attributes via NodeDescriptor to reduce allocations and CPU usage. I found that I was having to determine the contents of the attributes twice, once for getAttributeCount() to determine its existence, and then a second time in copyAttributeAt(). Since we currently only need to retrieve all the attributes at once, it makes sense to switch to an accumulator which can pack the name/value pairs directly into the interleaved String array that the JSON protocol uses. And the code is a lot simpler.

![screen shot 2015-03-11 at 4 34 58 pm](https://cloud.githubusercontent.com/assets/10873410/6609277/b4324410-c80c-11e4-868f-95404c461117.png)

Closes #86 