### PR TITLE
support sending back rows changed

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -1,3 +1,5 @@
+// Copyright 2015-present Facebook. All Rights Reserved.
+
 package com.facebook.stetho;
 
 import com.facebook.stetho.inspector.database.DefaultDatabaseFilesProvider;
@@ -26,6 +28,7 @@ import com.facebook.stetho.inspector.protocol.module.Console;
 import com.facebook.stetho.inspector.protocol.module.DOM;
 import com.facebook.stetho.inspector.protocol.module.DOMStorage;
 import com.facebook.stetho.inspector.protocol.module.Database;
+import com.facebook.stetho.inspector.protocol.module.DatabaseConstants;
 import com.facebook.stetho.inspector.protocol.module.Debugger;
 import com.facebook.stetho.inspector.protocol.module.HeapProfiler;
 import com.facebook.stetho.inspector.protocol.module.Inspector;
@@ -115,7 +118,7 @@ public class Stetho {
         modules.add(new Profiler());
         modules.add(new Runtime());
         modules.add(new Worker());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        if (Build.VERSION.SDK_INT >= DatabaseConstants.MIN_API_LEVEL) {
           modules.add(new Database(context, new DefaultDatabaseFilesProvider(context)));
         }
         return modules;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
@@ -1,0 +1,13 @@
+// Copyright 2015-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.protocol.module;
+
+import android.os.Build;
+
+public interface DatabaseConstants {
+
+  /**
+   * Minimum API version required to use the {@link Database}.
+   */
+  public static final int MIN_API_LEVEL = Build.VERSION_CODES.HONEYCOMB;
+}


### PR DESCRIPTION
This solves #82. We use the prefix of the first 3 characters to determine what type of request it is. Since we only have access to "columns" and "error" text use the column to display the type and the value to display the count.
![scalar-return](https://cloud.githubusercontent.com/assets/3724320/6608814/9dd53cfe-c807-11e4-8e5a-894da6463842.png)
