### PR TITLE
Added a way to provide the database files to the DatabasePeerManager module.

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -1,5 +1,6 @@
 package com.facebook.stetho;
 
+import com.facebook.stetho.inspector.database.DefaultDatabaseFilesProvider;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -115,7 +116,7 @@ public class Stetho {
         modules.add(new Runtime());
         modules.add(new Worker());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-          modules.add(new Database(context));
+          modules.add(new Database(context, new DefaultDatabaseFilesProvider(context)));
         }
         return modules;
       }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
@@ -1,0 +1,16 @@
+package com.facebook.stetho.inspector.database;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Provides a {@link List} of database files.
+ */
+public interface DatabaseFilesProvider {
+
+  /**
+   * Returns a {@link List} of database files.
+   */
+  List<File> getDatabaseFiles();
+
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
@@ -1,0 +1,27 @@
+package com.facebook.stetho.inspector.database;
+
+import android.content.Context;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides the results of {@link Context#databaseList()}.
+ */
+public final class DefaultDatabaseFilesProvider implements DatabaseFilesProvider {
+
+  private final Context mContext;
+
+  public DefaultDatabaseFilesProvider(Context context) {
+    mContext = context;
+  }
+
+  @Override
+  public List<File> getDatabaseFiles() {
+    List<File> databaseFiles = new ArrayList<File>();
+    for (String filename : mContext.databaseList()) {
+      databaseFiles.add(new File(filename));
+    }
+    return databaseFiles;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -2,6 +2,7 @@
 
 package com.facebook.stetho.inspector.protocol.module;
 
+import com.facebook.stetho.inspector.database.DatabaseFilesProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,8 +39,22 @@ public class Database implements ChromeDevtoolsDomain {
   private final DatabasePeerManager mDatabasePeerManager;
   private final ObjectMapper mObjectMapper;
 
+  /**
+   * Constructs the object with the default {@link DatabasePeerManager}.
+   * @param context the context
+   */
+  @Deprecated
   public Database(Context context) {
     mDatabasePeerManager = new DatabasePeerManager(context);
+    mObjectMapper = new ObjectMapper();
+  }
+
+  /**
+   * @param context the context
+   * @param databaseFilesProvider a database files provider
+   */
+  public Database(Context context, DatabaseFilesProvider databaseFilesProvider) {
+    mDatabasePeerManager = new DatabasePeerManager(context, databaseFilesProvider);
     mObjectMapper = new ObjectMapper();
   }
 

--- a/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
@@ -2,6 +2,8 @@
 
 package com.facebook.stetho.inspector.database;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -11,19 +13,19 @@ import static org.junit.Assert.assertArrayEquals;
 public class DatabasePeerManagerTest {
   @Test
   public void testTidyDatabaseList() {
-     String[] databases = {
-         "foo.db", "foo.db-journal",
-         "bar.db", "bar.db-journal", "bar.db-uid",
-         "baz.db", "baz.db-somethingelse",
-         "dangling.db-journal",
-     };
-     String[] expected = {
-         "foo.db",
-         "bar.db",
-         "baz.db", "baz.db-somethingelse",
-         "dangling.db-journal",
-     };
-     List<String> tidied = DatabasePeerManager.tidyDatabaseList(databases);
-     assertArrayEquals(expected, tidied.toArray());
+    File[] databases = {
+        new File("foo.db"), new File("foo.db-journal"),
+        new File("bar.db"), new File("bar.db-journal"), new File( "bar.db-uid"),
+        new File("baz.db"), new File("baz.db-somethingelse"),
+        new File("dangling.db-journal"),
+    };
+    File[] expected = {
+        new File( "foo.db"),
+        new File("bar.db"),
+        new File("baz.db"), new File("baz.db-somethingelse"),
+        new File("dangling.db-journal")
+    };
+    List<File> tidied = DatabasePeerManager.tidyDatabaseList(Arrays.asList(databases));
+    assertArrayEquals(expected, tidied.toArray());
   }
 }


### PR DESCRIPTION
Created an interface to provide database files at the time of a peer connection. This allows applications that create databases in directories other than the default one to have their data viewable in the Database section.