### PR TITLE
Catch out of memory exceptions while inspecting download of large files

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
@@ -132,7 +132,16 @@ public class ChromeDevtoolsServer implements SimpleEndpoint {
       response.result = result;
       response.error = error;
       JSONObject jsonObject = mObjectMapper.convertValue(response, JSONObject.class);
-      String responseString = jsonObject.toString();
+      String responseString;
+      try {
+        responseString = jsonObject.toString();
+      } catch (OutOfMemoryError e) {
+        // JSONStringer can cause an OOM when the Json to handle is too big.
+        response.result = null;
+        response.error = mObjectMapper.convertValue(e.getMessage(), JSONObject.class);
+        jsonObject = mObjectMapper.convertValue(response, JSONObject.class);
+        responseString = jsonObject.toString();
+      }
       peer.getWebSocket().sendText(responseString);
     }
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -110,7 +110,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       if (body != null) {
         return new String(body, Utf8Charset.INSTANCE);
       }
-    } catch (IOException e) {
+    } catch (IOException | OutOfMemoryError e) {
       CLog.writeToConsole(
           peerManager,
           Console.MessageLevel.WARNING,

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -64,9 +64,16 @@ public class Network implements ChromeDevtoolsDomain {
   }
 
   private GetResponseBodyResponse readResponseBody(String requestId)
-      throws IOException {
+      throws IOException, JsonRpcException {
     GetResponseBodyResponse response = new GetResponseBodyResponse();
-    ResponseBodyData bodyData = mResponseBodyFileManager.readFile(requestId);
+    ResponseBodyData bodyData;
+    try {
+      bodyData = mResponseBodyFileManager.readFile(requestId);
+    } catch (OutOfMemoryError e) {
+      throw new JsonRpcException(new JsonRpcError(JsonRpcError.ErrorCode.INTERNAL_ERROR,
+          e.toString(),
+          null /* data */));
+    }
     response.body = bodyData.data;
     response.base64Encoded = bodyData.base64Encoded;
     return response;


### PR DESCRIPTION
This solves #88.

@jasta that should do (solution 1), right?