### PR TITLE
Upgrade latest gradle and sdk versions. Fix build error because of:   classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.iml
 .DS_Store
 /build
+/.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
   components:
-    - build-tools 21.1.2
-    - android-21
+    - build-tools 22.0.0
+    - android-22
 
 branches:
   except:

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
+        classpath 'com.android.tools.build:gradle:1.1.3'
+//        classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
     }
 }
 

--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.0"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -20,7 +20,7 @@ android {
     }
 }
 
-apply plugin: 'android-unit-test'
+//apply plugin: 'android-unit-test'
 
 dependencies {
     compile project(':stetho')

--- a/stetho-sample/build.gradle
+++ b/stetho-sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.00"
 
     defaultConfig {
         applicationId "com.facebook.stetho.sample"
         minSdkVersion 11
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }

--- a/stetho-urlconnection/build.gradle
+++ b/stetho-urlconnection/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.0"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.0"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 }
 
-apply plugin: 'android-unit-test'
+//apply plugin: 'android-unit-test'
 
 dependencies {
     compile 'commons-cli:commons-cli:1.2'


### PR DESCRIPTION
Upgrade latest gradle and sdk versions.
Fix build error because of:
  classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'