### PR TITLE
Support for Fragments as parents of their associated View

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
@@ -1,0 +1,75 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.annotation.Nullable;
+
+public final class ReflectionUtil {
+  private static final Object[] sEmptyArray = new Object[0];
+
+  private ReflectionUtil() {
+  }
+
+  @Nullable
+  public static Class<?> tryGetClassForName(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  public static Field tryGetDeclaredField(Class<?> theClass, String fieldName) {
+    try {
+      return theClass.getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      LogUtil.d(
+          e,
+          "Could not retrieve %s field from %s",
+          fieldName,
+          theClass);
+
+      return null;
+    }
+  }
+
+  public static Method getMethod(Class<?> theClass, String methodName) {
+    try {
+      return theClass.getMethod(methodName);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nullable
+  public static Method tryGetMethod(Class<?> theClass, String methodName) {
+    try {
+      return theClass.getMethod(methodName);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  public static Object invokeMethod(Method method, @Nullable Object target) {
+    try {
+      return method.invoke(target, sEmptyArray);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nullable
+  public static Object getFieldValue(Field field, Object target) {
+    try {
+      return field.get(target);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ApplicationUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ApplicationUtil.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class ApplicationUtil {
+public final class ApplicationUtil {
   private ApplicationUtil() {
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
@@ -1,0 +1,25 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.view.View;
+
+import javax.annotation.Nullable;
+
+public interface FragmentAccessor {
+  public static final int NO_ID = -1;
+
+  @Nullable
+  public Object getFragmentManager(Object fragment);
+
+  public int getId(Object fragment);
+
+  @Nullable
+  public String getTag(Object fragment);
+
+  @Nullable
+  public View getView(Object fragment);
+
+  @Nullable
+  public Object peekChildFragmentManager(Object fragment);
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
@@ -1,0 +1,15 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.app.Activity;
+
+import javax.annotation.Nullable;
+
+public interface FragmentActivityAccessor {
+  @Nullable
+  public Object getFragmentManager(Activity fragmentActivity);
+
+  @Nullable
+  public Object getSupportFragmentManager(Activity fragmentActivity);
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
@@ -1,0 +1,239 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.app.Activity;
+import android.view.View;
+
+import com.facebook.stetho.common.ReflectionUtil;
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+// TODO: Don't use reflection to implement the accessors. We cannot express an optional dependency
+//       on the v4 support library with our current maven plugin for Gradle (need to upgrade to
+//       maven-publish?).
+//       Having 2 accessor implementations, one for the support API and another for the native API,
+//       will yield better performance and much cleaner code.
+//       (We will still need to use reflection to access fields, e.g. FragmentManagerImpl.mAdded)
+
+public final class FragmentApi {
+  private static final Class<?> sSupportFragmentClass;
+  private static final Class<?> sSupportFragmentActivityClass;
+  private static final Class<?> sSupportFragmentManagerClass;
+
+  private static final FragmentAccessor sSupportFragmentAccessor;
+  private static final FragmentActivityAccessor sSupportFragmentActivityAccessor;
+  private static final FragmentManagerAccessor sSupportFragmentManagerAccessor;
+
+  private static final Class<?> sFragmentClass;
+  private static final Class<?> sActivityClass;
+  private static final Class<?> sFragmentManagerClass;
+
+  private static final FragmentAccessor sFragmentAccessor;
+  private static final FragmentActivityAccessor sActivityAccessor;
+  private static final FragmentManagerAccessor sFragmentManagerAccessor;
+
+  static {
+    sSupportFragmentClass = ReflectionUtil.tryGetClassForName("android.support.v4.app.Fragment");
+    sSupportFragmentAccessor = (sSupportFragmentClass != null)
+        ? new ReflectionFragmentAccessor(sSupportFragmentClass)
+        : null;
+
+    sSupportFragmentActivityClass = ReflectionUtil.tryGetClassForName(
+        "android.support.v4.app.FragmentActivity");
+    sSupportFragmentActivityAccessor = (sSupportFragmentActivityClass != null)
+        ? new ReflectionFragmentActivityAccessor(sSupportFragmentActivityClass)
+        : null;
+
+    sSupportFragmentManagerClass = ReflectionUtil.tryGetClassForName(
+        "android.support.v4.app.FragmentManagerImpl");
+    sSupportFragmentManagerAccessor = (sSupportFragmentManagerClass != null)
+        ? new ReflectionFragmentManagerAccessor(sSupportFragmentManagerClass)
+        : null;
+
+    sFragmentClass = ReflectionUtil.tryGetClassForName("android.app.Fragment");
+    sFragmentAccessor = (sFragmentClass != null)
+        ? new ReflectionFragmentAccessor(sFragmentClass)
+        : null;
+
+    sActivityClass = ReflectionUtil.tryGetClassForName("android.app.Activity");
+    sActivityAccessor = (sActivityClass != null)
+        ? new ReflectionFragmentActivityAccessor(sActivityClass)
+        : null;
+
+    sFragmentManagerClass = ReflectionUtil.tryGetClassForName("android.app.FragmentManagerImpl");
+    sFragmentManagerAccessor = (sFragmentManagerClass != null)
+        ? new ReflectionFragmentManagerAccessor(sFragmentManagerClass)
+        : null;
+  }
+
+  @Nullable
+  public static Class<?> tryGetFragmentClass() {
+    return sFragmentClass;
+  }
+
+  @Nullable
+  public static Class<?> tryGetSupportFragmentClass() {
+    return sSupportFragmentClass;
+  }
+
+  public static FragmentAccessor getFragmentAccessorFor(Object fragment) {
+    Util.throwIfNull(fragment);
+
+    if (sSupportFragmentClass != null &&
+        sSupportFragmentClass.isAssignableFrom(fragment.getClass())) {
+      return sSupportFragmentAccessor;
+    }
+
+    if (sFragmentClass != null &&
+        sFragmentClass.isAssignableFrom(fragment.getClass())) {
+      return sFragmentAccessor;
+    }
+
+    throw new IllegalArgumentException();
+  }
+
+  @Nullable
+  public static FragmentActivityAccessor tryGetFragmentActivityAccessorFor(Object fragmentActivity) {
+    Util.throwIfNull(fragmentActivity);
+
+    if (sSupportFragmentActivityClass != null &&
+        sSupportFragmentActivityClass.isAssignableFrom(fragmentActivity.getClass())) {
+      return sSupportFragmentActivityAccessor;
+    }
+
+    if (sActivityClass != null &&
+        sActivityClass.isAssignableFrom(fragmentActivity.getClass())) {
+      return sActivityAccessor;
+    }
+
+    return null;
+  }
+
+  public static FragmentManagerAccessor getFragmentManagerAccessorFor(Object fragmentManager) {
+    if (sSupportFragmentManagerClass != null &&
+        sSupportFragmentManagerClass.isAssignableFrom(fragmentManager.getClass())) {
+      return sSupportFragmentManagerAccessor;
+    }
+
+    if (sFragmentManagerClass != null &&
+        sFragmentManagerClass.isAssignableFrom(fragmentManager.getClass())) {
+      return sFragmentManagerAccessor;
+    }
+
+    throw new IllegalArgumentException();
+  }
+
+  private static final class ReflectionFragmentAccessor implements FragmentAccessor {
+    // We access the field instead of calling the getChildFragmentManager() method
+    // because the method will instantiate a child FragmentManager if it doesn't exist
+    @Nullable
+    private final Field mFieldMChildFragmentManager;
+
+    private final Method mMethodGetFragmentManager;
+    private final Method mMethodGetId;
+    private final Method mMethodGetTag;
+    private final Method mMethodGetView;
+
+    public ReflectionFragmentAccessor(Class<?> fragmentClass) {
+      Util.throwIfNull(fragmentClass);
+
+      mFieldMChildFragmentManager = ReflectionUtil.tryGetDeclaredField(
+          fragmentClass,
+          "mChildFragmentManager");
+      if (mFieldMChildFragmentManager != null) {
+        mFieldMChildFragmentManager.setAccessible(true);
+      }
+
+      mMethodGetFragmentManager = ReflectionUtil.getMethod(fragmentClass, "getFragmentManager");
+      mMethodGetId = ReflectionUtil.getMethod(fragmentClass, "getId");
+      mMethodGetTag = ReflectionUtil.getMethod(fragmentClass, "getTag");
+      mMethodGetView = ReflectionUtil.getMethod(fragmentClass, "getView");
+    }
+
+    @Override
+    public Object getFragmentManager(Object fragment) {
+      return ReflectionUtil.invokeMethod(mMethodGetFragmentManager, fragment);
+    }
+
+    @Override
+    public int getId(Object fragment) {
+      return (Integer)ReflectionUtil.invokeMethod(mMethodGetId, fragment);
+    }
+
+    @Override
+    public String getTag(Object fragment) {
+      return (String)ReflectionUtil.invokeMethod(mMethodGetTag, fragment);
+    }
+
+    @Override
+    public View getView(Object fragment) {
+      return (View)ReflectionUtil.invokeMethod(mMethodGetView, fragment);
+    }
+
+    @Override
+    public Object peekChildFragmentManager(Object fragment) {
+      return (mFieldMChildFragmentManager != null)
+          ? ReflectionUtil.getFieldValue(mFieldMChildFragmentManager, fragment)
+          : null;
+    }
+  }
+
+  private static final class ReflectionFragmentActivityAccessor
+      implements FragmentActivityAccessor {
+    @Nullable
+    private final Method mMethodGetFragmentManager;
+
+    @Nullable
+    private final Method mMethodGetSupportFragmentManager;
+
+    public ReflectionFragmentActivityAccessor(Class<?> fragmentActivityClass) {
+      mMethodGetFragmentManager = ReflectionUtil.tryGetMethod(
+          fragmentActivityClass,
+          "getFragmentManager");
+
+      mMethodGetSupportFragmentManager = ReflectionUtil.tryGetMethod(
+          fragmentActivityClass,
+          "getSupportFragmentManager");
+    }
+
+    @Override
+    public Object getFragmentManager(Activity fragmentActivity) {
+      return (mMethodGetFragmentManager != null)
+          ? ReflectionUtil.invokeMethod(mMethodGetFragmentManager, fragmentActivity)
+          : null;
+    }
+
+    @Override
+    public Object getSupportFragmentManager(Activity fragmentActivity) {
+      return (mMethodGetSupportFragmentManager != null)
+          ? ReflectionUtil.invokeMethod(mMethodGetSupportFragmentManager, fragmentActivity)
+          : null;
+    }
+  }
+
+  private static class ReflectionFragmentManagerAccessor implements FragmentManagerAccessor {
+    private final Field mFieldMAdded;
+
+    public ReflectionFragmentManagerAccessor(Class<?> fragmentManagerClass) {
+      Util.throwIfNull(fragmentManagerClass);
+      mFieldMAdded = ReflectionUtil.tryGetDeclaredField(fragmentManagerClass, "mAdded");
+      if (mFieldMAdded != null) {
+        mFieldMAdded.setAccessible(true);
+      }
+    }
+
+    @Override
+    public List<?> getAddedFragments(Object fragmentManager) {
+      return (mFieldMAdded != null)
+          ? (List<?>)ReflectionUtil.getFieldValue(mFieldMAdded, fragmentManager)
+          : null;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApiUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApiUtil.java
@@ -1,0 +1,85 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.app.Activity;
+import android.view.View;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+public final class FragmentApiUtil {
+  private FragmentApiUtil() {
+  }
+
+  @Nullable
+  public static Object findFragmentForView(View view) {
+    Activity activity = ViewUtil.tryGetActivity(view);
+    if (activity == null) {
+      return null;
+    }
+
+    return findFragmentForViewInActivity(activity, view);
+  }
+
+  @Nullable
+  private static Object findFragmentForViewInActivity(Activity activity, View view) {
+    FragmentActivityAccessor accessor = FragmentApi.tryGetFragmentActivityAccessorFor(activity);
+    if (accessor == null) {
+      return null;
+    }
+
+    Object supportFragmentManager = accessor.getSupportFragmentManager(activity);
+    if (supportFragmentManager != null) {
+      Object fragment = findFragmentForViewInFragmentManager(supportFragmentManager, view);
+      if (fragment != null) {
+        return fragment;
+      }
+    }
+
+    Object fragmentManager = accessor.getFragmentManager(activity);
+    if (fragmentManager != null) {
+      Object fragment = findFragmentForViewInFragmentManager(fragmentManager, view);
+      if (fragment != null) {
+        return fragment;
+      }
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private static Object findFragmentForViewInFragmentManager(Object fragmentManager, View view) {
+    FragmentManagerAccessor accessor = FragmentApi.getFragmentManagerAccessorFor(fragmentManager);
+    List<?> fragments = accessor.getAddedFragments(fragmentManager);
+
+    if (fragments != null) {
+      for (int i = 0; i < fragments.size(); ++i) {
+        Object fragment = fragments.get(i);
+        Object result = findFragmentForViewInFragment(fragment, view);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private static Object findFragmentForViewInFragment(Object fragment, View view) {
+    FragmentAccessor accessor = FragmentApi.getFragmentAccessorFor(fragment);
+
+    if (accessor.getView(fragment) == view) {
+      return fragment;
+    }
+
+    Object childFragmentManager = accessor.peekChildFragmentManager(fragment);
+    if (childFragmentManager != null) {
+      return findFragmentForViewInFragmentManager(childFragmentManager, view);
+    }
+
+    return null;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+public interface FragmentManagerAccessor {
+  @Nullable
+  public List<?> getAddedFragments(Object fragmentManager);
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
@@ -1,0 +1,55 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.stetho.common.ReflectionUtil;
+
+import java.lang.reflect.Field;
+
+import javax.annotation.Nullable;
+
+public final class ViewGroupUtil {
+  private static final Field sOnHierarchyChangeListenerField =
+      tryGetOnHierarchyChangeListenerField();
+
+  @Nullable
+  private static Field tryGetOnHierarchyChangeListenerField() {
+    Field field = ReflectionUtil.tryGetDeclaredField(
+        ViewGroup.class,
+        "mOnHierarchyChangeListener");
+
+    if (field != null) {
+      field.setAccessible(true);
+    }
+
+    return field;
+  }
+
+  private ViewGroupUtil() {
+  }
+
+  public static int findChildIndex(ViewGroup parent, View child) {
+    int count = parent.getChildCount();
+    for (int i = 0; i < count; ++i) {
+      if (parent.getChildAt(i) == child) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Nullable
+  public static ViewGroup.OnHierarchyChangeListener tryGetOnHierarchyChangeListenerHack(
+      ViewGroup viewGroup) {
+    if (sOnHierarchyChangeListenerField == null) {
+      return null;
+    }
+
+    return (ViewGroup.OnHierarchyChangeListener)ReflectionUtil.getFieldValue(
+        sOnHierarchyChangeListenerField,
+        viewGroup);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -1,0 +1,35 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.common.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import android.view.ViewParent;
+
+import javax.annotation.Nullable;
+
+public final class ViewUtil {
+  private ViewUtil() {
+  }
+
+  @Nullable
+  public static Activity tryGetActivity(View view) {
+    if (view == null) {
+      return null;
+    }
+
+    Context context = view.getContext();
+    if (context instanceof Activity) {
+      return (Activity)context;
+    }
+
+    ViewParent parent = view.getParent();
+    if (parent instanceof View) {
+      View parentView = (View)parent;
+      return tryGetActivity(parentView);
+    }
+
+    return null;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -9,14 +9,22 @@ import javax.annotation.Nullable;
 public abstract class ChainedDescriptor<E> extends Descriptor {
   private Descriptor mSuper;
 
-  // This is used by DescriptorMap to hook us up to whatever handles E's super class
+  // This is used by DescriptorMap to hook us up to whatever handles E's super class.
+  // This method is idempotent in the sense that once you call it with a specific
+  // reference you must either 1) never call it again, or 2) call it again with that
+  // same reference.
   final void setSuper(Descriptor superDescriptor) {
     Util.throwIfNull(superDescriptor);
-    Util.throwIfNotNull(mSuper);
-    mSuper = superDescriptor;
+
+    if (superDescriptor != mSuper) {
+      if (mSuper != null) {
+        throw new IllegalStateException();
+      }
+      mSuper = superDescriptor;
+    }
   }
 
-  protected final Descriptor getSuper() {
+  public final Descriptor getSuper() {
     return mSuper;
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -12,14 +12,10 @@ public interface DOMProvider {
   @Nullable
   public Object getRootElement();
 
-  public NodeDescriptor getNodeDescriptor(Object element);
+  @Nullable
+  public NodeDescriptor getNodeDescriptor(@Nullable Object element);
 
-  public void highlightElement(
-      Object element,
-      int contentColor,
-      int paddingColor,
-      int borderColor,
-      int marginColor);
+  public void highlightElement(Object element, int color);
 
   public void hideHighlight();
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -2,24 +2,34 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import com.facebook.stetho.common.Util;
+
 import javax.annotation.Nullable;
 
 public abstract class Descriptor implements NodeDescriptor {
-
-  private Listener mListener;
+  private Host mHost;
 
   protected Descriptor() {
   }
 
-  void setListener(Listener listener) {
-    mListener = listener;
+  void initialize(Host host) {
+    Util.throwIfNull(host);
+    Util.throwIfNotNull(mHost);
+    mHost = host;
   }
 
-  protected final Listener getListener() {
-    return mListener;
+  boolean isInitialized() {
+    return mHost != null;
   }
 
-  public interface Listener {
+  protected final Host getHost() {
+    return mHost;
+  }
+
+  public interface Host {
+    @Nullable
+    public Descriptor getDescriptor(@Nullable Object element);
+
     public void onAttributeModified(
         Object element,
         String name,

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -9,14 +9,13 @@ import android.view.Window;
 import com.facebook.stetho.common.StringUtil;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
-final class ActivityDescriptor extends ChainedDescriptor<Activity> {
+final class ActivityDescriptor
+    extends ChainedDescriptor<Activity> implements HighlightableDescriptor {
   @Override
   protected String onGetNodeName(Activity element) {
     String className = element.getClass().getName();
     return StringUtil.removePrefix(className, "android.app.");
   }
-
-  // TODO: support for Fragment
 
   @Override
   protected int onGetChildCount(Activity element) {
@@ -32,5 +31,16 @@ final class ActivityDescriptor extends ChainedDescriptor<Activity> {
     } else {
       return window;
     }
+  }
+
+  @Override
+  public View getViewForHighlighting(Object element) {
+    if (getHost() instanceof AndroidDescriptorHost) {
+      final AndroidDescriptorHost host = (AndroidDescriptorHost)getHost();
+      Activity activity = (Activity)element;
+      Window window = activity.getWindow();
+      return host.getHighlightingView(window);
+    }
+    return null;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
@@ -1,0 +1,14 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.view.View;
+
+import com.facebook.stetho.inspector.elements.Descriptor;
+
+import javax.annotation.Nullable;
+
+interface AndroidDescriptorHost extends Descriptor.Host {
+  @Nullable
+  public View getHighlightingView(@Nullable Object element);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -109,7 +109,7 @@ final class ApplicationDescriptor extends ChainedDescriptor<Application> {
         @Override
         public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
           mActivities.add(0, activity);
-          getListener().onChildInserted(mElement, null, activity);
+          getHost().onChildInserted(mElement, null, activity);
         }
 
         @Override
@@ -135,7 +135,7 @@ final class ApplicationDescriptor extends ChainedDescriptor<Application> {
         @Override
         public void onActivityDestroyed(Activity activity) {
           mActivities.remove(activity);
-          getListener().onChildRemoved(mElement, activity);
+          getHost().onChildRemoved(mElement, activity);
         }
       };
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -1,0 +1,81 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.view.View;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.android.FragmentAccessor;
+import com.facebook.stetho.common.android.FragmentApi;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.DescriptorMap;
+
+final class FragmentDescriptor
+    extends ChainedDescriptor<Object> implements HighlightableDescriptor {
+  private static final String ID_ATTRIBUTE_NAME = "id";
+  private static final String TAG_ATTRIBUTE_NAME = "tag";
+
+  public static DescriptorMap register(DescriptorMap map) {
+    Class<?> supportFragmentClass = FragmentApi.tryGetSupportFragmentClass();
+    if (supportFragmentClass != null) {
+      LogUtil.d("Registering support Fragment descriptor");
+      map.register(supportFragmentClass, new FragmentDescriptor());
+    }
+
+    Class<?> fragmentClass = FragmentApi.tryGetFragmentClass();
+    if (fragmentClass != null) {
+      LogUtil.d("Registering Fragment descriptor");
+      map.register(fragmentClass, new FragmentDescriptor());
+    }
+
+    return map;
+  }
+
+  private FragmentDescriptor() {
+  }
+
+  @Override
+  protected void onCopyAttributes(Object element, AttributeAccumulator attributes) {
+    FragmentAccessor accessor = FragmentApi.getFragmentAccessorFor(element);
+
+    int id = accessor.getId(element);
+    if (id != FragmentAccessor.NO_ID) {
+      String value = "0x" + Integer.toHexString(id);
+      attributes.add(ID_ATTRIBUTE_NAME, value);
+    }
+
+    String tag = accessor.getTag(element);
+    if (tag != null && tag.length() > 0) {
+      attributes.add(TAG_ATTRIBUTE_NAME, tag);
+    }
+  }
+
+  @Override
+  protected int onGetChildCount(Object element) {
+    FragmentAccessor accessor = FragmentApi.getFragmentAccessorFor(element);
+    View view = accessor.getView(element);
+    return (view == null) ? 0 : 1;
+  }
+
+  @Override
+  protected Object onGetChildAt(Object element, int index) {
+    if (index != 0) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    FragmentAccessor accessor = FragmentApi.getFragmentAccessorFor(element);
+    View view = accessor.getView(element);
+    if (view == null) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    return view;
+  }
+
+  @Override
+  public View getViewForHighlighting(Object element) {
+    FragmentAccessor accessor = FragmentApi.getFragmentAccessorFor(element);
+    return accessor.getView(element);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.view.View;
+
+import javax.annotation.Nullable;
+
+interface HighlightableDescriptor {
+  @Nullable
+  public View getViewForHighlighting(Object element);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -66,9 +66,9 @@ final class TextViewDescriptor extends ChainedDescriptor<TextView> {
     @Override
     public void afterTextChanged(Editable s) {
       if (s.length() == 0) {
-        getListener().onAttributeRemoved(mElement, TEXT_ATTRIBUTE_NAME);
+        getHost().onAttributeRemoved(mElement, TEXT_ATTRIBUTE_NAME);
       } else {
-        getListener().onAttributeModified(mElement, TEXT_ATTRIBUTE_NAME, s.toString());
+        getHost().onAttributeModified(mElement, TEXT_ATTRIBUTE_NAME, s.toString());
       }
     }
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -12,7 +12,7 @@ import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
 import javax.annotation.Nullable;
 
-final class ViewDescriptor extends ChainedDescriptor<View> {
+final class ViewDescriptor extends ChainedDescriptor<View> implements HighlightableDescriptor {
   private static final String ID_ATTRIBUTE_NAME = "id";
 
   @Override
@@ -87,5 +87,10 @@ final class ViewDescriptor extends ChainedDescriptor<View> {
     }
 
     return idString;
+  }
+
+  @Override
+  public View getViewForHighlighting(Object element) {
+    return (View)element;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -6,34 +6,16 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.stetho.common.Util;
+import com.facebook.stetho.common.android.FragmentApiUtil;
+import com.facebook.stetho.common.android.ViewGroupUtil;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
-  // TODO: We're probably going to switch to another way of determining structural
-  //       changes in the View tree. So this gizmo with chaining OnHierarchyChangeListener
-  //       via reflection should go away soon.
-
-  private static final Field sOnHierarchyChangeListenerField;
-  static {
-    Field field;
-    try {
-      field = ViewGroup.class.getDeclaredField("mOnHierarchyChangeListener");
-    } catch (NoSuchFieldException ex) {
-      field = null;
-    }
-
-    sOnHierarchyChangeListenerField = field;
-
-    if (sOnHierarchyChangeListenerField != null) {
-      sOnHierarchyChangeListenerField.setAccessible(true);
-    }
-  }
-
   private final Map<ViewGroup, ElementContext> mElementToContextMap =
       Collections.synchronizedMap(new HashMap<ViewGroup, ElementContext>());
 
@@ -60,64 +42,32 @@ final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
 
   @Override
   protected Object onGetChildAt(ViewGroup element, int index) {
-    if (index < 0 || index >= element.getChildCount()) {
-      throw new IndexOutOfBoundsException();
-    }
-
-    return element.getChildAt(index);
-  }
-
-  private static ViewGroup.OnHierarchyChangeListener getOnHierarchyChangeListenerHack(
-      ViewGroup viewGroup) throws NoSuchFieldException {
-    if (sOnHierarchyChangeListenerField == null) {
-      throw new NoSuchFieldException();
-    }
-
-    try {
-      return (ViewGroup.OnHierarchyChangeListener) sOnHierarchyChangeListenerField.get(viewGroup);
-    } catch (IllegalAccessException ex) {
-      // should not happen since we called setAccessible(true)
-      throw new IllegalAccessError(ex.getMessage());
-    }
-  }
-
-  private static int findChildIndex(ViewGroup parent, View child) {
-    int count = parent.getChildCount();
-    for (int i = 0; i < count; ++i) {
-      if (parent.getChildAt(i) == child) {
-        return i;
-      }
-    }
-    return -1;
+    ElementContext context = mElementToContextMap.get(element);
+    return context.getChildAt(element, index);
   }
 
   private final class ElementContext implements ViewGroup.OnHierarchyChangeListener {
+    // This is a cache that maps from a View to the Fragment that contains it. If the
+    // View isn't contained by a Fragment, then this maps the View to itself.
+    // For Views contained by Fragments, we emit the Fragment instead, and then let
+    // the Fragment's descriptor emit the View as its sole child. This allows us to
+    // see Fragments in the inspector as part of the UI tree.
+    private final Map<View, Object> mViewToElementMap =
+        Collections.synchronizedMap(new IdentityHashMap<View, Object>());
 
     private ViewGroup mElement;
     private ViewGroup.OnHierarchyChangeListener mInnerListener;
 
     public void hook(ViewGroup element) {
       mElement = Util.throwIfNull(element);
-
-      ViewGroup.OnHierarchyChangeListener innerListener;
-      try {
-        innerListener = getOnHierarchyChangeListenerHack(mElement);
-      } catch (NoSuchFieldException ex) {
-        innerListener = null;
-      }
-      mInnerListener = innerListener;
-
+      mInnerListener = ViewGroupUtil.tryGetOnHierarchyChangeListenerHack(mElement);
       mElement.setOnHierarchyChangeListener(this);
     }
 
     public void unhook() {
       if (mElement != null) {
-        ViewGroup.OnHierarchyChangeListener currentListener;
-        try {
-          currentListener = getOnHierarchyChangeListenerHack(mElement);
-        } catch (NoSuchFieldException ex) {
-          currentListener = null;
-        }
+        ViewGroup.OnHierarchyChangeListener currentListener =
+            ViewGroupUtil.tryGetOnHierarchyChangeListenerHack(mElement);
 
         if (currentListener == this) {
           mElement.setOnHierarchyChangeListener(mInnerListener);
@@ -127,6 +77,37 @@ final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
 
         mInnerListener = null;
         mElement = null;
+
+        mViewToElementMap.clear();
+      }
+    }
+
+    public Object getChildAt(ViewGroup element, int index) {
+      if (index < 0 || index >= element.getChildCount()) {
+        throw new IndexOutOfBoundsException();
+      }
+
+      View view = element.getChildAt(index);
+      return getElementForView(view);
+    }
+
+    private Object getElementForView(View view) {
+      if (view == null) {
+        return null;
+      }
+
+      Object element = mViewToElementMap.get(view);
+      if (element != null) {
+        return element;
+      }
+
+      Object fragment = FragmentApiUtil.findFragmentForView(view);
+      if (fragment != null) {
+        mViewToElementMap.put(view, fragment);
+        return fragment;
+      } else {
+        mViewToElementMap.put(view, view);
+        return view;
       }
     }
 
@@ -142,9 +123,14 @@ final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
 
       if (parent instanceof ViewGroup) {
         final ViewGroup parentGroup = (ViewGroup)parent;
-        int index = findChildIndex(parentGroup, child);
-        View previousChild = (index == 0) ? null : parentGroup.getChildAt(index - 1);
-        getListener().onChildInserted(parent, previousChild, child);
+
+        int childIndex = ViewGroupUtil.findChildIndex(parentGroup, child);
+        View previousChild = (childIndex == 0) ? null : parentGroup.getChildAt(childIndex - 1);
+
+        Object childElement = getElementForView(child);
+        Object previousElement = getElementForView(previousChild);
+
+        getHost().onChildInserted(parent, previousElement, childElement);
       }
     }
 
@@ -158,7 +144,10 @@ final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
         mInnerListener.onChildViewRemoved(parent, child);
       }
 
-      getListener().onChildRemoved(parent, child);
+      Object childElement = getElementForView(child);
+      getHost().onChildRemoved(parent, childElement);
+
+      mViewToElementMap.remove(child);
     }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -34,12 +34,7 @@ abstract class ViewHighlighter {
 
   public abstract void clearHighlight();
 
-  public abstract void setHighlightedView(
-      View view,
-      int contentColor,
-      int paddingColor,
-      int borderColor,
-      int marginColor);
+  public abstract void setHighlightedView(View view, int color);
 
   private static final class NoopHighlighter extends ViewHighlighter {
     @Override
@@ -47,12 +42,7 @@ abstract class ViewHighlighter {
     }
 
     @Override
-    public void setHighlightedView(
-        View view,
-        int contentColor,
-        int paddingColor,
-        int borderColor,
-        int marginColor) {
+    public void setHighlightedView(View view, int color) {
     }
   }
 
@@ -84,33 +74,18 @@ abstract class ViewHighlighter {
 
     @Override
     public void clearHighlight() {
-      setHighlightedViewImpl(null, 0, 0, 0, 0);
+      setHighlightedViewImpl(null, 0);
     }
 
     @Override
-    public void setHighlightedView(
-        View view,
-        int contentColor,
-        int paddingColor,
-        int borderColor,
-        int marginColor) {
-      setHighlightedViewImpl(
-          Util.throwIfNull(view),
-          contentColor,
-          paddingColor,
-          borderColor,
-          marginColor);
+    public void setHighlightedView(View view, int color) {
+      setHighlightedViewImpl(Util.throwIfNull(view), color);
     }
 
-    private void setHighlightedViewImpl(
-        @Nullable View view,
-        int contentColor,
-        int paddingColor,
-        int borderColor,
-        int marginColor) {
+    private void setHighlightedViewImpl(@Nullable View view, int color) {
       mHandler.removeCallbacks(mHighlightViewOnUiThreadRunnable);
       mViewToHighlight.set(view);
-      mContentColor.set(contentColor);
+      mContentColor.set(color);
       mHandler.postDelayed(mHighlightViewOnUiThreadRunnable, 100);
     }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
-final class WindowDescriptor extends ChainedDescriptor<Window> {
+final class WindowDescriptor extends ChainedDescriptor<Window> implements HighlightableDescriptor {
   private final Map<Window, ElementContext> mElementToContextMap =
       Collections.synchronizedMap(new IdentityHashMap<Window, ElementContext>());
 
@@ -52,6 +52,12 @@ final class WindowDescriptor extends ChainedDescriptor<Window> {
     } else {
       return decorView;
     }
+  }
+
+  @Override
+  public View getViewForHighlighting(Object element) {
+    Window window = (Window)element;
+    return window.peekDecorView();
   }
 
   // TODO: We're probably going to switch to another way of determining structural
@@ -183,7 +189,7 @@ final class WindowDescriptor extends ChainedDescriptor<Window> {
       if (mDecorView == null) {
         mDecorView = mWindow.peekDecorView();
         if (mDecorView != null) {
-          getListener().onChildInserted(mWindow, null, mDecorView);
+          getHost().onChildInserted(mWindow, null, mDecorView);
           // TODO: once we have the decorView, we don't need to worry about further changes (AFAIK).
           //       but since we're going to do something else for this (tree diffing), I don't
           //       think we need to worry about removing our callback for now

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -84,15 +84,15 @@ public class DOM implements ChromeDevtoolsDomain {
   public void highlightNode(JsonRpcPeer peer, JSONObject params) {
     HighlightNodeRequest request = mObjectMapper.convertValue(params, HighlightNodeRequest.class);
     if (request.nodeId == null) {
-      LogUtil.w("highlightNode was not given a nodeId; JS objectId is not supported");
+      LogUtil.w("DOM.highlightNode was not given a nodeId; JS objectId is not supported");
     } else {
-      Object element = mObjectIdMapper.getObjectForId(request.nodeId);
-      mDOMProvider.highlightElement(
-          element,
-          request.highlightConfig.contentColor.getColor(),
-          request.highlightConfig.paddingColor.getColor(),
-          request.highlightConfig.borderColor.getColor(),
-          request.highlightConfig.marginColor.getColor());
+      RGBAColor contentColor = request.highlightConfig.contentColor;
+      if (contentColor == null) {
+        LogUtil.w("DOM.highlightNode was not given a color to highlight with");
+      } else {
+        Object element = mObjectIdMapper.getObjectForId(request.nodeId);
+        mDOMProvider.highlightElement(element, contentColor.getColor());
+      }
     }
   }
 
@@ -336,15 +336,6 @@ public class DOM implements ChromeDevtoolsDomain {
   private static class HighlightConfig {
     @JsonProperty
     public RGBAColor contentColor;
-
-    @JsonProperty
-    public RGBAColor paddingColor;
-
-    @JsonProperty
-    public RGBAColor borderColor;
-
-    @JsonProperty
-    public RGBAColor marginColor;
   }
 
   private static class RGBAColor {


### PR DESCRIPTION
This adds support for Fragments in the element tree. Fragments will show up as the parent of the View that they contain, and therefore as the child of the ViewGroup which contains the Fragment's View. 

`ViewGroup -> Fragment -> View`

ViewGroupDescriptor does the high-level work of substituting Fragments for Views, and maintains a cache for mapping from Views to Fragments. Looking up the Fragment for a View is a bit expensive since it requires searching through all of the Fragments (see `FragmentApiUtil.findViewForFragment()`).

Closes #97