### PR TITLE
Fix Copyright consistency issues.

### DIFF
--- a/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
+++ b/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant 
+ * of patent rights can be found in the PATENTS file in the same directory.
+*/
+
 package com.facebook.stetho.okhttp;
 
 import com.facebook.stetho.inspector.network.DefaultResponseHandler;

--- a/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
+++ b/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.okhttp;
 
 import android.net.Uri;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.sample;
 
 import java.io.IOException;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.sample;
 
 import java.util.ArrayList;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.sample;
 
 import android.net.Uri;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.sample;
 
 import java.io.ByteArrayInputStream;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/Constants.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/Constants.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.sample;
 

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/HelloWorldDumperPlugin.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/HelloWorldDumperPlugin.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/SampleApplication.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/SampleApplication.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.sample;
 
 import java.util.ArrayList;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/ByteArrayRequestEntity.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/ByteArrayRequestEntity.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import java.io.IOException;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/SimpleRequestEntity.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/SimpleRequestEntity.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import java.io.IOException;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManager.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import com.facebook.stetho.inspector.network.DefaultResponseHandler;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import android.util.Pair;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorRequest.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorRequest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import com.facebook.stetho.inspector.network.NetworkEventReporter;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorResponse.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorResponse.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import com.facebook.stetho.inspector.network.NetworkEventReporter;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/Util.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/Util.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.urlconnection;
 
 import android.util.Pair;

--- a/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2015-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.common;
 
 public class ExceptionUtil {

--- a/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/LogUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/LogUtil.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.common;
 
 import java.util.Locale;

--- a/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.common;
 
 import javax.annotation.Nullable;

--- a/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
@@ -1,4 +1,13 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/RawDumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/RawDumpappHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamFramer.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamFramer.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamingDumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamingDumpappHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp.plugins;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector;
 
 import javax.annotation.Nullable;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/CLog.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/CLog.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.console;
 
 import com.facebook.stetho.common.LogRedirector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.database;
 
 import java.io.File;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.database;
 
 import android.content.Context;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/DOMStoragePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/DOMStoragePeerManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.domstorage;
 
 import android.content.Context;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.domstorage;
 
 import android.content.Context;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import java.io.FilterOutputStream;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import com.facebook.stetho.inspector.console.CLog;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultResponseHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultResponseHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import java.io.IOException;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import com.facebook.stetho.common.ExceptionUtil;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import java.io.IOException;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2015-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.json;
 
 import javax.annotation.Nullable;

--- a/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonProperty.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonProperty.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.json.annotation;
 
 import java.lang.annotation.Retention;

--- a/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonValue.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonValue.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.json.annotation;
 
 import java.lang.annotation.Retention;

--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServer.java
@@ -1,32 +1,10 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
-// This is based on ElementalHttpServer.java in the Apache httpcore
-// examples.
-
 /*
- * ====================================================================
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- * ====================================================================
- *
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation.  For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
- *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/PeerAuthorizationException.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/PeerAuthorizationException.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.server;
 

--- a/stetho/src/main/java/com/facebook/stetho/server/RegistryInitializer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/RegistryInitializer.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SecureHttpRequestHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SecureHttpRequestHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/CompositeInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/CompositeInputStream.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+//
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import org.junit.Test;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
@@ -1,4 +1,13 @@
-package  com.facebook.stetho.json;
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.json;
 
 import android.os.Build;
 import com.facebook.stetho.json.annotation.JsonProperty;


### PR DESCRIPTION
An accidental lack of enforcement of the copyright template left the
source inconsistently marked.  The first step is to correct the
formatting of existing files, then we will contribute the
IntelliJ/Android Studio project files which enforce it in the future.