### PR TITLE
Application element is now the root node in the UI

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.view.View;
 
 import com.facebook.stetho.common.ReflectionUtil;
-import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.Util;
 
 import java.lang.reflect.Field;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -9,9 +9,6 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.TextView;
 
-import com.facebook.stetho.common.LogUtil;
-import com.facebook.stetho.common.Util;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 import com.facebook.stetho.inspector.elements.DOMProvider;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
@@ -19,17 +16,18 @@ import com.facebook.stetho.inspector.elements.NodeDescriptor;
 import com.facebook.stetho.inspector.elements.ObjectDescriptor;
 
 final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
-  private final Application mApplication;
   private final DescriptorMap mDescriptorMap;
+  private final AndroidDOMRoot mDOMRoot;
   private final ViewHighlighter mHighlighter;
   private Listener mListener;
 
   public AndroidDOMProvider(Application application) {
-    mApplication = application;
+    mDOMRoot = new AndroidDOMRoot(application);
 
     mDescriptorMap = new DescriptorMap()
         .beginInit()
         .register(Activity.class, new ActivityDescriptor())
+        .register(AndroidDOMRoot.class, mDOMRoot)
         .register(Application.class, new ApplicationDescriptor());
     FragmentDescriptor.register(mDescriptorMap)
         .register(Object.class, new ObjectDescriptor())
@@ -56,7 +54,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
 
   @Override
   public Object getRootElement() {
-    return mApplication;
+    return mDOMRoot;
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
@@ -1,0 +1,42 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Application;
+
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.NodeType;
+
+// For the root, we use 1 object for both element and descriptor.
+
+final class AndroidDOMRoot extends ChainedDescriptor<AndroidDOMRoot> {
+  private final Application mApplication;
+
+  public AndroidDOMRoot(Application application) {
+    mApplication = Util.throwIfNull(application);
+  }
+
+  @Override
+  protected NodeType onGetNodeType(AndroidDOMRoot element) {
+    return NodeType.DOCUMENT_NODE;
+  }
+
+  @Override
+  protected String onGetNodeName(AndroidDOMRoot element) {
+    return "root";
+  }
+
+  @Override
+  protected int onGetChildCount(AndroidDOMRoot element) {
+    return 1;
+  }
+
+  @Override
+  protected Object onGetChildAt(AndroidDOMRoot element, int index) {
+    if (index != 0) {
+      throw new IndexOutOfBoundsException();
+    }
+    return mApplication;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -43,7 +43,7 @@ final class ApplicationDescriptor extends ChainedDescriptor<Application> {
 
   @Override
   protected NodeType onGetNodeType(Application element) {
-    return NodeType.DOCUMENT_NODE;
+    return NodeType.ELEMENT_NODE;
   }
 
   @Override


### PR DESCRIPTION
The node that we emit from DOM.getDocument() does not show up in the elements tab (it's just the way it works). Right now we are using the Application for that, which prevents us from seeing any information about it. By emitting a faux-node whose only purpose is to emit the Application as its sole child, we can now see details about Application itself. Even just having the class name helps answer the ever important question of "where is the code for this?"

![screen shot 2015-03-26 at 3 20 00 pm](https://cloud.githubusercontent.com/assets/10873410/6859416/e7dee3ac-d3d5-11e4-8604-6ea06b3189b4.png)

Closes #99 