### PR TITLE
Workaround serious throughput issue in Stetho's HTTP server

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
@@ -147,5 +147,15 @@ public class LocalSocketHttpServerConnection extends AbstractHttpServerConnectio
         HttpParams params) throws IOException {
       init(socket.getOutputStream(), bufferSize, params);
     }
+
+    @Override
+    public void flush() throws IOException {
+      // Do not call through to super.flush() to fix a serious throughput issue due to a
+      // polling/sleep based implementation of LocalSocketImpl#flush.  This is apparently done to
+      // guarantee that after flush is called the write buffer has been fully drained but we don't
+      // need or expect this guarantee since our buffering strategy is entirely at the HTTP
+      // level.
+      flushBuffer();
+    }
   }
 }


### PR DESCRIPTION
All communication between host and Stetho is done by a LocalSocket (a
UNIX abstract domain socket) which has a very heavy-handed
implementation of LocalSocketImpl#flush which polls/sleeps waiting for
the kernel buffer to become empty.  This behaviour in practice reduces
observed throughput of dumpapp (using either the buffered stdout or
stderr) to between 300 and 600KB/s despite adb being capable of ~5MB/s
on the same device.

This workaround involves blocking the final flush call to the socket
output stream.  This still drains the local Java buffer as originally
intended, but does not ask the kernel to drain its buffer (and block
doing so).  This kernel draining behaviour is entirely unnecessary for
our purposes and presumably for everyone else as it appears to be added
for some special purpose hack in the Bluetooth implementation.

Offending AOSP commit appears to be: https://android.googlesource.com/platform/frameworks/base/+/71bfafc84af4b820748b12e1a1010b0dfa7bdea6%5E%21/