### PR TITLE
Properly encode multiple headers with the same name

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -280,8 +280,15 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
   private static JSONObject formatHeadersAsJSON(InspectorHeaders headers) {
     JSONObject json = new JSONObject();
     for (int i = 0; i < headers.headerCount(); i++) {
+      String name = headers.headerName(i);
+      String value = headers.headerValue(i);
       try {
-        json.put(headers.headerName(i), headers.headerValue(i));
+        if (json.has(name)) {
+          // Multiple headers are separated with a new line.
+          json.put(name, json.getString(name) + "\n" + value);
+        } else {
+          json.put(name, value);
+        }
       } catch (JSONException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
Unspecified in the protocol docs, we're expected to separate multiple
header values with the same name using a new line character.  This is
necessary because a normal JSON object cannot have the same name
repeated twice (and headers are encoded using a JSON object not an
array).

Closes #115