### PR TITLE
Add `-p <process>` option to scripts/hprof_dump.sh

### DIFF
--- a/scripts/dumpapp
+++ b/scripts/dumpapp
@@ -15,8 +15,7 @@ def main():
   args = sys.argv[1:]
   if len(args) > 0 and (args[0] == '-p' or args[0] == '--process'):
     if len(args) < 2:
-      print(sys.stderr, 'Missing <process>')
-      sys.exit(1)
+      sys.exit('Missing <process>')
     else:
       process = args[1]
       args = args[2:]
@@ -48,8 +47,7 @@ def main():
 
     read_frames(reply)
   except HumanReadableError as e:
-    print(e)
-    sys.exit(1)
+    sys.exit(e)
   except BrokenPipeError as e:
     sys.exit(0)
   except KeyboardInterrupt:

--- a/scripts/hprof_dump.sh
+++ b/scripts/hprof_dump.sh
@@ -18,7 +18,7 @@ fi
 TEMPFILE="${OUTFILE}-dalvik.tmp"
 
 echo "Generating hprof on device (this can take a while)..."
-$DUMPAPP hprof - > ${TEMPFILE}
+$DUMPAPP "$@" hprof - > ${TEMPFILE}
 
 echo "Converting $TEMPFILE to standard format..."
 hprof-conv $TEMPFILE $OUTFILE


### PR DESCRIPTION
This allows a caller to respect the advice given by the error message
("Use -p to select a process...").  Also fix an issue where those error
messages would not be displayed correctly to the user by way of my
terrible misunderanding of Python3.