### PR TITLE
Inspector button on Elements tab

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/Predicate.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Predicate.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common;
+
+public interface Predicate<T> {
+  public boolean apply(T t);
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -4,13 +4,95 @@ package com.facebook.stetho.common.android;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.PointF;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
+
+import com.facebook.stetho.common.Predicate;
+import com.facebook.stetho.common.Util;
 
 import javax.annotation.Nullable;
 
 public final class ViewUtil {
   private ViewUtil() {
+  }
+
+  @Nullable
+  public static View hitTest(View view, float x, float y) {
+    return hitTest(view, x, y, null /* viewSelector */);
+  }
+
+  // x,y are in view's local coordinate space (relative to its own top/left)
+  @Nullable
+  public static View hitTest(View view, float x, float y, @Nullable Predicate<View> viewSelector) {
+    if (!ViewUtil.pointInView(view, x, y)) {
+      return null;
+    }
+
+    if (!(view instanceof ViewGroup)) {
+      return null;
+    }
+
+    final ViewGroup viewGroup = (ViewGroup)view;
+
+    // TODO: get list of Views that are sorted in Z- and draw-order, e.g. buildOrderedChildList()
+    for (int i = viewGroup.getChildCount() - 1; i >= 0; --i) {
+      final View child = viewGroup.getChildAt(i);
+
+      if (child.getVisibility() != View.VISIBLE) {
+        continue;
+      }
+
+      if (viewSelector != null && !viewSelector.apply(child)) {
+        continue;
+      }
+
+      PointF localPoint = new PointF();
+      if (ViewUtil.isTransformedPointInView(viewGroup, child, x, y, localPoint)) {
+        if (child instanceof ViewGroup) {
+          return hitTest(child, localPoint.x, localPoint.y, viewSelector);
+        } else {
+          return child;
+        }
+      }
+    }
+
+    return viewGroup;
+  }
+
+  public static boolean pointInView(View view, float localX, float localY) {
+    return localX >= 0 && localX < (view.getRight() - view.getLeft())
+        && localY >= 0 && localY < (view.getBottom() - view.getTop());
+  }
+
+  public static boolean isTransformedPointInView(
+      ViewGroup parent,
+      View child,
+      float x,
+      float y,
+      @Nullable PointF outLocalPoint) {
+    Util.throwIfNull(parent);
+    Util.throwIfNull(child);
+
+    float localX = x + parent.getScrollX() - child.getLeft();
+    float localY = y + parent.getScrollY() - child.getTop();
+
+    // TODO: handle transforms
+    /*Matrix childMatrix = child.getMatrix();
+    if (!childMatrix.isIdentity()) {
+      final float[] localXY = new float[2];
+      localXY[0] = localX;
+      localXY[1] = localY;
+      child.getInverseMatrix
+    }*/
+
+    final boolean isInView = ViewUtil.pointInView(child, localX, localY);
+    if (isInView && outLocalPoint != null) {
+      outLocalPoint.set(localX, localY);
+    }
+
+    return isInView;
   }
 
   @Nullable

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -19,6 +19,8 @@ public interface DOMProvider {
 
   public void hideHighlight();
 
+  public void setInspectModeEnabled(boolean enabled);
+
   public static interface Factory {
     DOMProvider create();
   }
@@ -41,5 +43,8 @@ public interface DOMProvider {
     public void onChildRemoved(
         Object parentElement,
         Object childElement);
+
+    public void onInspectRequested(
+        Object element);
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -4,24 +4,44 @@ package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.TextView;
 
+import com.facebook.stetho.common.Predicate;
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.common.android.ViewUtil;
 import com.facebook.stetho.inspector.elements.DOMProvider;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.NodeDescriptor;
 import com.facebook.stetho.inspector.elements.ObjectDescriptor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
+  private static final int INSPECT_OVERLAY_COLOR = 0x40FFFFFF;
+  private static final int INSPECT_HOVER_COLOR = 0x404040ff;
+
+  private final Application mApplication;
+  private final Handler mHandler;
   private final DescriptorMap mDescriptorMap;
   private final AndroidDOMRoot mDOMRoot;
   private final ViewHighlighter mHighlighter;
+  private final InspectModeHandler mInspectModeOverlay;
   private Listener mListener;
 
   public AndroidDOMProvider(Application application) {
+    mApplication = Util.throwIfNull(application);
+    mHandler = new Handler(Looper.getMainLooper());
     mDOMRoot = new AndroidDOMRoot(application);
 
     mDescriptorMap = new DescriptorMap()
@@ -39,12 +59,14 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
         .endInit();
 
     mHighlighter = ViewHighlighter.newInstance();
+    mInspectModeOverlay = new InspectModeHandler();
   }
 
   // DOMProvider implementation
   @Override
   public void dispose() {
     mHighlighter.clearHighlight();
+    mInspectModeOverlay.disable();
   }
 
   @Override
@@ -75,6 +97,15 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
   @Override
   public void hideHighlight() {
     mHighlighter.clearHighlight();
+  }
+
+  @Override
+  public void setInspectModeEnabled(boolean enabled) {
+    if (enabled) {
+      mInspectModeOverlay.enable();
+    } else {
+      mInspectModeOverlay.disable();
+    }
   }
 
   // Descriptor.Host implementation
@@ -128,5 +159,137 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
     }
 
     return highlightingView;
+  }
+
+  private List<Window> collectWindows() {
+    ArrayList<Window> windows = new ArrayList<Window>();
+
+    Descriptor appDescriptor = getDescriptor(mApplication);
+    if (appDescriptor == null) {
+      return windows;
+    }
+
+    int activityCount = appDescriptor.getChildCount(mApplication);
+    for (int ai = 0; ai < activityCount; ++ai) {
+      final Activity activity = (Activity)appDescriptor.getChildAt(mApplication, ai);
+      Descriptor activityDescriptor = getDescriptor(activity);
+      if (activityDescriptor == null) {
+        continue;
+      }
+
+      int windowCount = activityDescriptor.getChildCount(activity);
+      for (int wi = 0; wi < windowCount; ++wi) {
+        final Window window = (Window)activityDescriptor.getChildAt(activity, wi);
+        windows.add(window);
+      }
+    }
+
+    return windows;
+  }
+
+  private final class InspectModeHandler {
+    private final Runnable mEnableOnUiThreadRunnable = new Runnable() {
+      @Override
+      public void run() {
+        enableOnUiThread();
+      }
+    };
+
+    private final Runnable mDisableOnUiThreadRunnable = new Runnable() {
+      @Override
+      public void run() {
+        disableOnUiThread();
+      }
+    };
+
+    private final Predicate<View> mViewSelector = new Predicate<View>() {
+      @Override
+      public boolean apply(View view) {
+        return !(view instanceof DOMHiddenView);
+      }
+    };
+
+    private List<View> mOverlays;
+
+    public void enable() {
+      mHandler.post(mEnableOnUiThreadRunnable);
+    }
+
+    private void enableOnUiThread() {
+      if (mOverlays != null) {
+        disableOnUiThread();
+      }
+
+      mOverlays = new ArrayList<View>();
+
+      List<Window> windows = collectWindows();
+      for (int i = 0; i < windows.size(); ++i) {
+        final Window window = windows.get(i);
+        if (window.peekDecorView() instanceof ViewGroup) {
+          final ViewGroup decorView = (ViewGroup)window.peekDecorView();
+
+          OverlayView overlayView = new OverlayView(mApplication);
+
+          WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams();
+          layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT;
+          layoutParams.height = WindowManager.LayoutParams.MATCH_PARENT;
+
+          decorView.addView(overlayView, layoutParams);
+          decorView.bringChildToFront(overlayView);
+
+          mOverlays.add(overlayView);
+        }
+      }
+    }
+
+    public void disable() {
+      mHandler.post(mDisableOnUiThreadRunnable);
+    }
+
+    private void disableOnUiThread() {
+      if (mOverlays == null) {
+        return;
+      }
+
+      for (int i = 0; i < mOverlays.size(); ++i) {
+        final View overlayView = mOverlays.get(i);
+        ViewGroup decorViewGroup = (ViewGroup)overlayView.getParent();
+        decorViewGroup.removeView(overlayView);
+      }
+
+      mOverlays = null;
+    }
+
+    private final class OverlayView extends DOMHiddenView {
+      public OverlayView(Context context) {
+        super(context);
+      }
+
+      @Override
+      protected void onDraw(Canvas canvas) {
+        canvas.drawColor(INSPECT_OVERLAY_COLOR);
+        super.onDraw(canvas);
+      }
+
+      @Override
+      public boolean onTouchEvent(MotionEvent event) {
+        if (getParent() instanceof View) {
+          final View parent = (View)getParent();
+          View view = ViewUtil.hitTest(parent, event.getX(), event.getY(), mViewSelector);
+
+          if (event.getAction() != MotionEvent.ACTION_CANCEL) {
+            if (view != null) {
+              mHighlighter.setHighlightedView(view, INSPECT_HOVER_COLOR);
+
+              if (event.getAction() == MotionEvent.ACTION_UP) {
+                mListener.onInspectRequested(view);
+              }
+            }
+          }
+        }
+
+        return true;
+      }
+    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DOMHiddenView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DOMHiddenView.java
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.content.Context;
+import android.view.View;
+
+class DOMHiddenView extends View {
+  public DOMHiddenView(Context context) {
+    super(context);
+  }
+}


### PR DESCRIPTION
This allows the "inspector" magnifying glass to work on the elements tab. When you click on the button, it enters a modal state where you can pick which UI element should be highlighted. When you push your finger down on the Android app, it will hit-test and highlight the appropriate view on the device (and also as you move your finger around, if you'd like). When you move your finger up, a command will be sent back to Chrome and it will now highlight the view in the inspector UI.

Closes #124 