### PR TITLE
Avoid installing the DOM module when Activity detection is unavailable

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -34,6 +34,7 @@ import com.facebook.stetho.dumpapp.StreamingDumpappHandler;
 import com.facebook.stetho.dumpapp.plugins.SharedPreferencesDumperPlugin;
 import com.facebook.stetho.inspector.ChromeDevtoolsServer;
 import com.facebook.stetho.inspector.ChromeDiscoveryHandler;
+import com.facebook.stetho.inspector.elements.android.AndroidDOMConstants;
 import com.facebook.stetho.inspector.elements.android.AndroidDOMProviderFactory;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.module.CSS;
@@ -124,7 +125,9 @@ public class Stetho {
         modules.add(new Console());
         modules.add(new CSS());
         modules.add(new Debugger());
-        modules.add(new DOM(new AndroidDOMProviderFactory((Application)context.getApplicationContext())));
+        if (Build.VERSION.SDK_INT >= AndroidDOMConstants.MIN_API_LEVEL) {
+          modules.add(new DOM(new AndroidDOMProviderFactory((Application)context.getApplicationContext())));
+        }
         modules.add(new DOMStorage(context));
         modules.add(new HeapProfiler());
         modules.add(new Inspector());

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMConstants.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.os.Build;
+
+public interface AndroidDOMConstants {
+  /**
+   * Minimum API version required to make effective use of the DOM module.  This can be moved
+   * back significantly through manual APIs to discover {@link android.app.Activity} instances.
+   */
+  public static final int MIN_API_LEVEL = Build.VERSION_CODES.ICE_CREAM_SANDWICH;
+}


### PR DESCRIPTION
The DOM module effectively doesn't work due to our hack that lists all
activities not functioning properly on previous versions of Android.
Without this, we currently cannot provide the DOM feature.

We can fix these issues by providing a manual API that informs us of
activity lifecycle events similar to Romain Guy's ViewServer:
https://github.com/romainguy/ViewServer