### PR TITLE
DOM now calls into AndroidDOMProvider via the UI thread

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common.android;
+
+import android.os.Handler;
+import android.os.Looper;
+
+public final class HandlerUtil {
+  private HandlerUtil() {
+  }
+
+  public static boolean postAndWait(Handler handler, final Runnable r) {
+    if (Looper.myLooper() == handler.getLooper()) {
+      r.run();
+      return true;
+    }
+
+    WaitableRunnable wrapper = new WaitableRunnable(r);
+    if (!handler.post(wrapper)) {
+      return false;
+    }
+
+    wrapper.join();
+    return true;
+  }
+
+  private static final class WaitableRunnable implements Runnable {
+    private final Runnable mRunnable;
+    private boolean mIsDone;
+
+    public WaitableRunnable(Runnable runnable) {
+      mRunnable = runnable;
+    }
+
+    @Override
+    public void run() {
+      try {
+        mRunnable.run();
+      } finally {
+        synchronized (this) {
+          mIsDone = true;
+          notifyAll();
+        }
+      }
+    }
+
+    public void join() {
+      synchronized (this) {
+        while (!mIsDone) {
+          try {
+            wait();
+          } catch (InterruptedException e) {
+          }
+        }
+      }
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -9,6 +9,8 @@ public interface DOMProvider {
 
   public void dispose();
 
+  public boolean postAndWait(Runnable r);
+
   @Nullable
   public Object getRootElement();
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import com.facebook.stetho.common.Predicate;
 import com.facebook.stetho.common.Util;
+import com.facebook.stetho.common.android.HandlerUtil;
 import com.facebook.stetho.common.android.ViewUtil;
 import com.facebook.stetho.inspector.elements.DOMProvider;
 import com.facebook.stetho.inspector.elements.Descriptor;
@@ -36,7 +37,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
   private final DescriptorMap mDescriptorMap;
   private final AndroidDOMRoot mDOMRoot;
   private final ViewHighlighter mHighlighter;
-  private final InspectModeHandler mInspectModeOverlay;
+  private final InspectModeHandler mInspectModeHandler;
   private Listener mListener;
 
   public AndroidDOMProvider(Application application) {
@@ -59,19 +60,24 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
         .endInit();
 
     mHighlighter = ViewHighlighter.newInstance();
-    mInspectModeOverlay = new InspectModeHandler();
+    mInspectModeHandler = new InspectModeHandler();
   }
 
   // DOMProvider implementation
   @Override
   public void dispose() {
     mHighlighter.clearHighlight();
-    mInspectModeOverlay.disable();
+    mInspectModeHandler.disable();
   }
 
   @Override
   public void setListener(Listener listener) {
     mListener = listener;
+  }
+
+  @Override
+  public boolean postAndWait(Runnable r) {
+    return HandlerUtil.postAndWait(mHandler, r);
   }
 
   @Override
@@ -102,9 +108,9 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
   @Override
   public void setInspectModeEnabled(boolean enabled) {
     if (enabled) {
-      mInspectModeOverlay.enable();
+      mInspectModeHandler.enable();
     } else {
-      mInspectModeOverlay.disable();
+      mInspectModeHandler.disable();
     }
   }
 


### PR DESCRIPTION
This patches DOM so that it calls into AndroidDOMProvider on the UI thread in the necessary locations. Otherwise we have a strong chance of stepping on UI objects from background threads. Proper enforcement and discovery of the threading model for AndroidDOMProvider needs a bit more chin-scratching, which we plan to do soon.

Closes #114 