### PR TITLE
Bring id pretty printing to <fragment> support as well.

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
@@ -2,6 +2,7 @@
 
 package com.facebook.stetho.common.android;
 
+import android.content.res.Resources;
 import android.view.View;
 
 import javax.annotation.Nullable;
@@ -11,6 +12,8 @@ public interface FragmentAccessor {
 
   @Nullable
   public Object getFragmentManager(Object fragment);
+
+  public Resources getResources(Object fragment);
 
   public int getId(Object fragment);
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentApi.java
@@ -3,6 +3,7 @@
 package com.facebook.stetho.common.android;
 
 import android.app.Activity;
+import android.content.res.Resources;
 import android.view.View;
 
 import com.facebook.stetho.common.ReflectionUtil;
@@ -136,6 +137,7 @@ public final class FragmentApi {
     private final Field mFieldMChildFragmentManager;
 
     private final Method mMethodGetFragmentManager;
+    private final Method mMethodGetResources;
     private final Method mMethodGetId;
     private final Method mMethodGetTag;
     private final Method mMethodGetView;
@@ -151,6 +153,7 @@ public final class FragmentApi {
       }
 
       mMethodGetFragmentManager = ReflectionUtil.getMethod(fragmentClass, "getFragmentManager");
+      mMethodGetResources = ReflectionUtil.getMethod(fragmentClass, "getResources");
       mMethodGetId = ReflectionUtil.getMethod(fragmentClass, "getId");
       mMethodGetTag = ReflectionUtil.getMethod(fragmentClass, "getTag");
       mMethodGetView = ReflectionUtil.getMethod(fragmentClass, "getView");
@@ -159,6 +162,11 @@ public final class FragmentApi {
     @Override
     public Object getFragmentManager(Object fragment) {
       return ReflectionUtil.invokeMethod(mMethodGetFragmentManager, fragment);
+    }
+
+    @Override
+    public Resources getResources(Object fragment) {
+      return (Resources)ReflectionUtil.invokeMethod(mMethodGetResources, fragment);
     }
 
     @Override

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ResourcesUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ResourcesUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common.android;
+
+import android.content.res.Resources;
+import com.facebook.stetho.common.LogUtil;
+
+import javax.annotation.Nonnull;
+
+public class ResourcesUtil {
+  private ResourcesUtil() {
+  }
+
+  @Nonnull
+  public static String getIdStringQuietly(Object idContext, Resources r, int resourceId) {
+    try {
+      return getIdString(r, resourceId);
+    } catch (Resources.NotFoundException e) {
+      String idString = "#" + Integer.toHexString(resourceId);
+      LogUtil.w("Unknown identifier encountered on " + idContext + ": " + idString);
+      return idString;
+    }
+  }
+
+  public static String getIdString(Resources r, int resourceId) throws Resources.NotFoundException {
+    String prefix;
+    String prefixSeparator;
+    switch (getResourcePackageId(resourceId)) {
+      case 0x7f:
+        prefix = "";
+        prefixSeparator = "";
+        break;
+      default:
+        prefix = r.getResourcePackageName(resourceId);
+        prefixSeparator = ":";
+        break;
+    }
+
+    String typeName = r.getResourceTypeName(resourceId);
+    String entryName = r.getResourceEntryName(resourceId);
+
+    StringBuilder sb = new StringBuilder(
+        1 + prefix.length() + prefixSeparator.length() +
+            typeName.length() + 1 + entryName.length());
+    sb.append("@");
+    sb.append(prefix);
+    sb.append(prefixSeparator);
+    sb.append(typeName);
+    sb.append("/");
+    sb.append(entryName);
+
+    return sb.toString();
+  }
+
+  private static int getResourcePackageId(int id) {
+    return (id >>> 24) & 0xff;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -7,6 +7,7 @@ import android.view.View;
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.android.FragmentAccessor;
 import com.facebook.stetho.common.android.FragmentApi;
+import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
@@ -41,7 +42,10 @@ final class FragmentDescriptor
 
     int id = accessor.getId(element);
     if (id != FragmentAccessor.NO_ID) {
-      String value = "0x" + Integer.toHexString(id);
+      String value = ResourcesUtil.getIdStringQuietly(
+          element,
+          accessor.getResources(element),
+          id);
       attributes.add(ID_ATTRIBUTE_NAME, value);
     }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -2,11 +2,10 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
-import android.content.res.Resources;
 import android.view.View;
 
-import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.StringUtil;
+import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
@@ -32,61 +31,13 @@ final class ViewDescriptor extends ChainedDescriptor<View> implements Highlighta
     }
   }
 
-  private static int getResourcePackageId(int id) {
-    return (id >>> 24) & 0xff;
-  }
-
   @Nullable
   private static String getIdAttribute(View element) {
-    // Adapted from View.toString()
-
     int id = element.getId();
     if (id == View.NO_ID) {
       return null;
     }
-
-    String idString = null;
-    Resources r = element.getResources();
-    if (r != null) {
-      try {
-        String prefix;
-        String prefixSeparator;
-        switch (getResourcePackageId(id)) {
-          case 0x7f:
-            prefix = "";
-            prefixSeparator = "";
-            break;
-          default:
-            prefix = r.getResourcePackageName(id);
-            prefixSeparator = ":";
-            break;
-        }
-
-        String typeName = r.getResourceTypeName(id);
-        String entryName = r.getResourceEntryName(id);
-
-        StringBuilder sb = new StringBuilder(
-            1 + prefix.length() + prefixSeparator.length() +
-            typeName.length() + 1 + entryName.length());
-        sb.append("@");
-        sb.append(prefix);
-        sb.append(prefixSeparator);
-        sb.append(typeName);
-        sb.append("/");
-        sb.append(entryName);
-
-        idString = sb.toString();
-
-      } catch (Resources.NotFoundException e) {
-        LogUtil.w(e, "Could not retrieve resource info for element: %s", element);
-      }
-    }
-
-    if (idString == null) {
-      idString = "#" + Integer.toHexString(id);
-    }
-
-    return idString;
+    return ResourcesUtil.getIdStringQuietly(element, element.getResources(), id);
   }
 
   @Override


### PR DESCRIPTION
Previously only View instances in the DOM would format ids using human
readable names.  This refactors the logic into a common class and
modifies FragmentDescriptor to support this.