### PR TITLE
Fetch deep links to find large format image URLs for APOD sample

### DIFF
--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
@@ -109,7 +109,7 @@ public class APODActivity extends ListActivity {
       int bindPosition = cursor.getPosition();
       holder.position = bindPosition;
 
-      final String imageUrl = cursor.getString(APODPostsQuery.DESCRIPTION_IMAGE_URL_INDEX);
+      final String imageUrl = cursor.getString(APODPostsQuery.LARGE_IMAGE_URL_INDEX);
       holder.image.setImageDrawable(null);
       fetchImage(imageUrl, bindPosition, holder);
 
@@ -181,13 +181,13 @@ public class APODActivity extends ListActivity {
         APODContract.Columns._ID,
         APODContract.Columns.TITLE,
         APODContract.Columns.DESCRIPTION_TEXT,
-        APODContract.Columns.DESCRIPTION_IMAGE_URL,
+        APODContract.Columns.LARGE_IMAGE_URL,
     };
 
     public static final int ID_INDEX = 0;
     public static final int TITLE_INDEX = 1;
     public static final int DESCRIPTION_TEXT_INDEX = 2;
-    public static final int DESCRIPTION_IMAGE_URL_INDEX = 3;
+    public static final int LARGE_IMAGE_URL_INDEX = 3;
 
     public static CursorLoader createCursorLoader(Context context) {
       return new CursorLoader(

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
@@ -99,7 +99,7 @@ public class APODContentProvider extends ContentProvider {
 
   private static class APODSQLiteOpenHelper extends SQLiteOpenHelper {
     private static final String DB_NAME = "apod.db";
-    private static final int DB_VERSION = 1;
+    private static final int DB_VERSION = 2;
 
     public APODSQLiteOpenHelper(Context context) {
       super(context, DB_NAME, null /* factory */, DB_VERSION);
@@ -112,7 +112,8 @@ public class APODContentProvider extends ContentProvider {
               APODContract.Columns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
               APODContract.Columns.TITLE + " TEXT, " +
               APODContract.Columns.DESCRIPTION_IMAGE_URL + " TEXT, " +
-              APODContract.Columns.DESCRIPTION_TEXT + " TEXT " +
+              APODContract.Columns.DESCRIPTION_TEXT + " TEXT, " +
+              APODContract.Columns.LARGE_IMAGE_URL + " TEXT " +
               ")");
     }
 

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
@@ -22,5 +22,6 @@ public interface APODContract {
     public static final String TITLE = "title";
     public static final String DESCRIPTION_TEXT = "description_text";
     public static final String DESCRIPTION_IMAGE_URL = "description_image_url";
+    public static final String LARGE_IMAGE_URL = "large_image_url";
   }
 }

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/HtmlScraper.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/HtmlScraper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.sample;
+
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.text.Html;
+import android.text.TextUtils;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class HtmlScraper {
+  /**
+   * Scrapes an HTML page for &lt;img&gt; tags.
+   *
+   * @return Scraped plain text
+   */
+  public static String parseWithImageTags(
+      String htmlText,
+      @Nullable String originUrl,
+      List<String> outImageUrls) {
+    ExtractImageGetter imageGetter = new ExtractImageGetter(originUrl, outImageUrls);
+    String strippedText = Html.fromHtml(
+        htmlText,
+        imageGetter,
+        null /* tagHandler */)
+        .toString();
+
+    return strippedText.trim();
+  }
+
+  private static class ExtractImageGetter implements Html.ImageGetter {
+    @Nullable private final String mOriginUrl;
+    private final List<String> mSources;
+
+    public ExtractImageGetter(@Nullable String originUrl, List<String> outSources) {
+      mOriginUrl = originUrl;
+      mSources = outSources;
+    }
+
+    @Override
+    public Drawable getDrawable(String source) {
+      if (mOriginUrl != null && TextUtils.isEmpty(Uri.parse(source).getScheme())) {
+        StringBuilder newSource = new StringBuilder();
+        newSource.append(mOriginUrl);
+        if (!mOriginUrl.endsWith("/") && !source.startsWith("/")) {
+          newSource.append("/");
+        }
+        newSource.append(source);
+        source = newSource.toString();
+      }
+      mSources.add(source);
+
+      // Dummy drawable.
+      return new ColorDrawable(Color.TRANSPARENT);
+    }
+
+    public List<String> getSources() {
+      return mSources;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
@@ -26,4 +26,8 @@ public class Utf8Charset {
       throw new RuntimeException(e);
     }
   }
+
+  public static String decodeUTF8(byte[] bytes) {
+    return new String(bytes, INSTANCE);
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -96,4 +96,15 @@ public class Util {
       }
     }
   }
+
+  public static void awaitUninterruptibly(CountDownLatch latch) {
+    while (true) {
+      try {
+        latch.await();
+        return;
+      } catch (InterruptedException e) {
+        // Keep going...
+      }
+    }
+  }
 }


### PR DESCRIPTION
This adds somewhat arbitrary network overhead to highlight the kinds of
bugs/inefficiencies that Stetho is good at rooting out.  Specifically in
this case, we improved the quality of the APOD thumbnail image but by
greatly overfetching data and slowing down the UI.  Stetho's Network tab
makes it very easy to see why (adding an extra round-trip through an
HTML page and downloading images that are 4x+ larger than the space they
occupy)