### PR TITLE
Improve Inspector button's hit-testing

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -20,51 +20,44 @@ public final class ViewUtil {
   private ViewUtil() {
   }
 
-  private static boolean isTouchable(View view) {
+  private static boolean isHittable(View view) {
     if (view.getVisibility() != View.VISIBLE) {
       return false;
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-      if (getAlphaHoneycomb(view) < 0.001f) {
-        return false;
-      }
+    if (ViewCompat.getInstance().getAlpha(view) < 0.001f) {
+      return false;
     }
 
     return true;
   }
 
-  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-  private static float getAlphaHoneycomb(View view) {
-    return view.getAlpha();
-  }
-
   @Nullable
-  public static View hitTestTouch(View view, float x, float y) {
-    return hitTestTouch(view, x, y, null /* viewSelector */);
+  public static View hitTest(View view, float x, float y) {
+    return hitTest(view, x, y, null /* viewSelector */);
   }
 
   // x,y are in view's local coordinate space (relative to its own top/left)
   @Nullable
-  public static View hitTestTouch(
+  public static View hitTest(
       View view,
       float x,
       float y,
       @Nullable Predicate<View> viewSelector) {
-    View result = hitTestTouchImpl(view, x, y, viewSelector, false);
+    View result = hitTestImpl(view, x, y, viewSelector, false);
     if (result == null) {
-      result = hitTestTouchImpl(view, x, y, viewSelector, true);
+      result = hitTestImpl(view, x, y, viewSelector, true);
     }
     return result;
   }
 
-  private static View hitTestTouchImpl(
+  private static View hitTestImpl(
       View view,
       float x,
       float y,
       @Nullable Predicate<View> viewSelector,
       boolean allowViewGroupResult) {
-    if (!isTouchable(view)) {
+    if (!isHittable(view)) {
       return null;
     }
 
@@ -90,7 +83,7 @@ public final class ViewUtil {
         final View child = viewGroup.getChildAt(i);
 
         if (ViewUtil.isTransformedPointInView(viewGroup, child, x, y, localPoint)) {
-          View childResult = hitTestTouch(child, localPoint.x, localPoint.y, viewSelector);
+          View childResult = hitTest(child, localPoint.x, localPoint.y, viewSelector);
           if (childResult != null) {
             return childResult;
           }
@@ -153,5 +146,35 @@ public final class ViewUtil {
     }
 
     return null;
+  }
+
+  private static class ViewCompat {
+    private static final ViewCompat sInstance;
+    static {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        sInstance = new ViewCompatHoneycomb();
+      } else {
+        sInstance = new ViewCompat();
+      }
+    }
+
+    public static ViewCompat getInstance() {
+      return sInstance;
+    }
+
+    protected ViewCompat() {
+    }
+
+    public float getAlpha(View view) {
+      return 1.0f;
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    private static class ViewCompatHoneycomb extends ViewCompat {
+      @Override
+      public float getAlpha(View view) {
+        return view.getAlpha();
+      }
+    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -281,7 +281,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
       public boolean onTouchEvent(MotionEvent event) {
         if (getParent() instanceof View) {
           final View parent = (View)getParent();
-          View view = ViewUtil.hitTestTouch(parent, event.getX(), event.getY(), mViewSelector);
+          View view = ViewUtil.hitTest(parent, event.getX(), event.getY(), mViewSelector);
 
           if (event.getAction() != MotionEvent.ACTION_CANCEL) {
             if (view != null) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -281,7 +281,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
       public boolean onTouchEvent(MotionEvent event) {
         if (getParent() instanceof View) {
           final View parent = (View)getParent();
-          View view = ViewUtil.hitTest(parent, event.getX(), event.getY(), mViewSelector);
+          View view = ViewUtil.hitTestTouch(parent, event.getX(), event.getY(), mViewSelector);
 
           if (event.getAction() != MotionEvent.ACTION_CANCEL) {
             if (view != null) {


### PR DESCRIPTION
ViewUtil.hitTest() is now renamed to hitTestTouch() to better articulate what it should be used for.

We were having trouble in some apps where the inspector button wouldn't work very well: it would often latch onto layout containers that were empty overlay stubs. Since we can't actually send a touch event down and see how finally responds to it, we're adjusting our algorithm: ViewGroups are effectively a lower priority than regular Views. To implement this, we just do two passes of hit-testing: in the first pass, we don't allow a ViewGroup to be the result and instead return null. The second pass allows ViewGroups as a result.

Closes #133