### PR TITLE
Fixed the implementation of ViewUtil.hitTestImpl()

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -83,7 +83,13 @@ public final class ViewUtil {
         final View child = viewGroup.getChildAt(i);
 
         if (ViewUtil.isTransformedPointInView(viewGroup, child, x, y, localPoint)) {
-          View childResult = hitTest(child, localPoint.x, localPoint.y, viewSelector);
+          View childResult = hitTestImpl(
+              child,
+              localPoint.x,
+              localPoint.y,
+              viewSelector,
+              allowViewGroupResult);
+
           if (childResult != null) {
             return childResult;
           }


### PR DESCRIPTION
VewUtil.hitTestImpl needs to recursively call itself, not hitTest(). Otherwise it defeats our heuristic, preventing allowViewGroupResult from being passed down the call chain.

Closes #142 