### PR TITLE
Add APOD dumper

### DIFF
--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/APODDumperPlugin.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/APODDumperPlugin.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.sample;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import com.facebook.stetho.dumpapp.ArgsHelper;
+import com.facebook.stetho.dumpapp.DumpException;
+import com.facebook.stetho.dumpapp.DumpUsageException;
+import com.facebook.stetho.dumpapp.DumperContext;
+import com.facebook.stetho.dumpapp.DumperPlugin;
+
+import java.io.PrintStream;
+import java.util.Iterator;
+
+public class APODDumperPlugin implements DumperPlugin {
+
+  private static final String NAME = "apod";
+
+  private static final String CMD_LIST = "list";
+  private static final String CMD_CLEAR = "clear";
+  private static final String CMD_DELETE = "delete";
+  private static final String CMD_REFRESH = "refresh";
+
+  private final ContentResolver mContentResolver;
+  private final APODRssFetcher mAPODRssFetcher;
+
+  public APODDumperPlugin(ContentResolver contentResolver) {
+    mContentResolver = contentResolver;
+    mAPODRssFetcher = new APODRssFetcher(mContentResolver);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public void dump(DumperContext dumpContext) throws DumpException {
+    PrintStream writer = dumpContext.getStdout();
+    Iterator<String> argsIter = dumpContext.getArgsAsList().iterator();
+
+    String command = ArgsHelper.nextOptionalArg(argsIter, null);
+
+    if (CMD_LIST.equalsIgnoreCase(command)) {
+      doList(writer);
+    } else if (CMD_DELETE.equalsIgnoreCase(command)) {
+      doRemove(writer, argsIter);
+    } else if (CMD_CLEAR.equalsIgnoreCase(command)) {
+      doClear(writer);
+    } else if (CMD_REFRESH.equalsIgnoreCase(command)) {
+      doRefresh(writer);
+    } else {
+      usage(writer);
+      if (command != null) {
+        throw new DumpUsageException("Unknown command: " + command);
+      }
+    }
+  }
+
+  private void doList(PrintStream writer) {
+    Cursor cursor = mContentResolver.query(
+        APODContract.CONTENT_URI,
+        null /* projection */,
+        null /* selection */,
+        null /* selectionArgs */,
+        APODContract.Columns._ID);
+
+    int count = 0;
+
+    while (cursor.moveToNext()) {
+      writer.println(String.format("Row #%d", count++));
+      for (int i = 0; i < cursor.getColumnCount(); ++i) {
+        writer.println(String.format("  %s: %s", cursor.getColumnName(i), cursor.getString(i)));
+      }
+    }
+
+    writer.println();
+  }
+
+  private void doRemove(PrintStream writer, Iterator<String> argsIter) throws DumpUsageException {
+    String rowId = ArgsHelper.nextArg(argsIter, "Expected rowId");
+
+    delete(writer, APODContract.Columns._ID + "=?", new String[] {rowId});
+  }
+
+  private void doClear(PrintStream writer) {
+    delete(writer, null, null);
+  }
+
+  private void doRefresh(PrintStream writer) {
+    mAPODRssFetcher.fetchAndStore();
+    writer.println("Submitted request to fetch new data");
+  }
+
+  private void delete(PrintStream writer, String where, String[] args) {
+    int result = mContentResolver.delete(APODContract.CONTENT_URI, where, args);
+
+    writer.println("Removed " + result + " rows.");
+  }
+
+  private static void usage(PrintStream writer) {
+    final String cmdName = "dumpapp " + NAME;
+    final String usagePrefix = "Usage: " + cmdName + " ";
+
+    writer.println(usagePrefix + "<command> [command-options]");
+    writer.print(usagePrefix + CMD_LIST);
+    writer.println();
+    writer.print(usagePrefix + CMD_CLEAR);
+    writer.println();
+    writer.print(usagePrefix + CMD_DELETE + " <rowId>");
+    writer.println();
+    writer.print(usagePrefix + CMD_REFRESH);
+    writer.println();
+  }
+}

--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
@@ -11,7 +11,6 @@ package com.facebook.stetho.sample;
 
 import java.util.ArrayList;
 
-import android.app.Application;
 import android.content.Context;
 
 import com.facebook.stetho.DumperPluginsProvider;
@@ -45,6 +44,7 @@ public class SampleDebugApplication extends SampleApplication {
         plugins.add(defaultPlugin);
       }
       plugins.add(new HelloWorldDumperPlugin());
+      plugins.add(new APODDumperPlugin(mContext.getContentResolver()));
       return plugins;
     }
   }

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
@@ -61,6 +61,7 @@ public class APODContentProvider extends ContentProvider {
   public Uri insert(Uri uri, ContentValues values) {
     SQLiteDatabase db = mOpenHelper.getWritableDatabase();
     long id = db.insert(APODContract.TABLE_NAME, null /* nullColumnHack */, values);
+    notifyChange();
     return uri.buildUpon().appendEncodedPath(String.valueOf(id)).build();
   }
 
@@ -68,6 +69,7 @@ public class APODContentProvider extends ContentProvider {
   public int delete(Uri uri, String selection, String[] selectionArgs) {
     SQLiteDatabase db = mOpenHelper.getWritableDatabase();
     int count = db.delete(APODContract.TABLE_NAME, selection, selectionArgs);
+    notifyChange();
     return count;
   }
 
@@ -75,6 +77,7 @@ public class APODContentProvider extends ContentProvider {
   public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
     SQLiteDatabase db = mOpenHelper.getWritableDatabase();
     int count = db.update(APODContract.TABLE_NAME, values, selection, selectionArgs);
+    notifyChange();
     return count;
   }
 


### PR DESCRIPTION
This adds a basic ContentProvider dumper for the APODContentProvider.
It supports clear/delete/list.
See https://gist.github.com/a351d105269845215c77 for sample output

It also fixes the APODContentProvider where it was not calling
notifyChange() on various write paths.