### PR TITLE
Implements support for DOM.setAttributesAsText()

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -23,6 +23,17 @@ public class Util {
     return item;
   }
 
+  public static <T1, T2> void throwIfNull(T1 item1, T2 item2) {
+    throwIfNull(item1);
+    throwIfNull(item2);
+  }
+
+  public static <T1, T2, T3> void throwIfNull(T1 item1, T2 item2, T3 item3) {
+    throwIfNull(item1);
+    throwIfNull(item2);
+    throwIfNull(item3);
+  }
+
   public static void throwIfNotNull(Object item) {
     if (item != null) {
       throw new IllegalStateException();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -185,4 +185,14 @@ public abstract class ChainedDescriptor<E> extends Descriptor {
 
   protected void onCopyAttributes(E element, AttributeAccumulator attributes) {
   }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void setAttributesAsText(Object element, String text) {
+    onSetAttributesAsText((E)element, text);
+  }
+
+  protected void onSetAttributesAsText(E element, String text) {
+    mSuper.setAttributesAsText(element, text);
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -30,6 +30,8 @@ public interface DOMProvider extends ThreadBound {
 
   public void setInspectModeEnabled(boolean enabled);
 
+  public void setAttributesAsText(Object element, String text);
+
   public static interface Factory {
     DOMProvider create();
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -32,4 +32,6 @@ public interface NodeDescriptor extends ThreadBound {
   public Object getChildAt(Object element, int index);
 
   public void copyAttributes(Object element, AttributeAccumulator attributes);
+
+  public void setAttributesAsText(Object element, String text);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -51,4 +51,8 @@ public final class ObjectDescriptor extends Descriptor {
   @Override
   public void copyAttributes(Object element, AttributeAccumulator attributes) {
   }
+
+  @Override
+  public void setAttributesAsText(Object element, String text) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -148,6 +148,16 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
     }
   }
 
+  @Override
+  public void setAttributesAsText(Object element, String text) {
+    verifyThreadAccess();
+
+    Descriptor descriptor = mDescriptorMap.get(element.getClass());
+    if (descriptor != null) {
+      descriptor.setAttributesAsText(element, text);
+    }
+  }
+
   // Descriptor.Host implementation
   @Override
   public Descriptor getDescriptor(Object element) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/MethodInvoker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/MethodInvoker.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements.android;
+
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tries to arbitrarily invoke single argument methods by name on an object instance by trying out
+ * different argument types.
+ */
+public class MethodInvoker {
+
+  private static final List<TypedMethodInvoker<?>> invokers = Arrays.asList(
+      new StringMethodInvoker(), new CharSequenceMethodInvoker(), new IntegerMethodInvoker(),
+      new FloatMethodInvoker(), new BooleanMethodInvoker());
+
+  /**
+   * Tries to invoke a method on receiver with a single argument by trying out different types
+   * for arg until it finds one that matches (or not). No exceptions are thrown on failure.
+   *
+   * @param methodName The method name to be invoked
+   * @param argument The single argument to be provided to the method
+   */
+  public void invoke(Object receiver, String methodName, String argument) {
+    Util.throwIfNull(receiver, methodName, argument);
+    int size = invokers.size();
+    for (int i = 0; i < size; ++i) {
+      final TypedMethodInvoker<?> invoker = invokers.get(i);
+      if (invoker.invoke(receiver, methodName, argument)) {
+        return;
+      }
+    }
+    LogUtil.w("Method with name " + methodName +
+              " not found for any of the MethodInvoker supported argument types.");
+  }
+
+  private static abstract class TypedMethodInvoker<T> {
+    private final Class<T> mArgType;
+
+    TypedMethodInvoker(Class<T> argType) {
+      mArgType = argType;
+    }
+
+    boolean invoke(Object receiver, String methodName, String argument) {
+      try {
+        Method method = receiver.getClass().getMethod(methodName, mArgType);
+        method.invoke(receiver, convertArgument(argument));
+        return true;
+      } catch (NoSuchMethodException ignored) {
+        // ignore
+      } catch (InvocationTargetException e) {
+        LogUtil.w("InvocationTargetException: " + e.getMessage());
+      } catch (IllegalAccessException e) {
+        LogUtil.w("IllegalAccessException: " + e.getMessage());
+      } catch (IllegalArgumentException e) {
+        LogUtil.w("IllegalArgumentException: " + e.getMessage());
+      }
+      return false;
+    }
+
+    abstract T convertArgument(String argument);
+  }
+
+  private static class StringMethodInvoker extends TypedMethodInvoker<String> {
+    StringMethodInvoker() {
+      super(String.class);
+    }
+
+    @Override
+    String convertArgument(String argument) {
+      return argument;
+    }
+  }
+
+  private static class CharSequenceMethodInvoker extends TypedMethodInvoker<CharSequence> {
+    CharSequenceMethodInvoker() {
+      super(CharSequence.class);
+    }
+
+    @Override
+    CharSequence convertArgument(String argument) {
+      return argument;
+    }
+  }
+
+  private static class IntegerMethodInvoker extends TypedMethodInvoker<Integer> {
+    IntegerMethodInvoker() {
+      super(int.class);
+    }
+
+    @Override
+    Integer convertArgument(String argument) {
+      return Integer.parseInt(argument);
+    }
+  }
+
+  private static class FloatMethodInvoker extends TypedMethodInvoker<Float> {
+    FloatMethodInvoker() {
+      super(float.class);
+    }
+
+    @Override
+    Float convertArgument(String argument) {
+      return Float.parseFloat(argument);
+    }
+  }
+
+  private static class BooleanMethodInvoker extends TypedMethodInvoker<Boolean> {
+    BooleanMethodInvoker() {
+      super(boolean.class);
+    }
+
+    @Override
+    Boolean convertArgument(String argument) {
+      return Boolean.parseBoolean(argument);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -10,16 +10,26 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.view.View;
-
 import com.facebook.stetho.common.StringUtil;
 import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 
 final class ViewDescriptor extends ChainedDescriptor<View> implements HighlightableDescriptor {
   private static final String ID_ATTRIBUTE_NAME = "id";
+
+  private final MethodInvoker mMethodInvoker;
+
+  public ViewDescriptor() {
+    this(new MethodInvoker());
+  }
+
+  public ViewDescriptor(MethodInvoker methodInvoker) {
+    mMethodInvoker = methodInvoker;
+  }
 
   @Override
   protected String onGetNodeName(View element) {
@@ -38,6 +48,16 @@ final class ViewDescriptor extends ChainedDescriptor<View> implements Highlighta
     }
   }
 
+  @Override
+  protected void onSetAttributesAsText(View element, String text) {
+    Map<String, String> attributeToValueMap = parseSetAttributesAsTextArg(text);
+    for (Map.Entry<String, String> entry : attributeToValueMap.entrySet()) {
+      String methodName = "set" + capitalize(entry.getKey());
+      String propertyValue = entry.getValue();
+      mMethodInvoker.invoke(element, methodName, propertyValue);
+    }
+  }
+
   @Nullable
   private static String getIdAttribute(View element) {
     int id = element.getId();
@@ -50,5 +70,14 @@ final class ViewDescriptor extends ChainedDescriptor<View> implements Highlighta
   @Override
   public View getViewForHighlighting(Object element) {
     return (View)element;
+  }
+
+  private static String capitalize(String str) {
+    if (str == null || str.length() == 0 || Character.isTitleCase(str.charAt(0))) {
+      return str;
+    }
+    StringBuilder buffer = new StringBuilder(str);
+    buffer.setCharAt(0, Character.toTitleCase(buffer.charAt(0)));
+    return buffer.toString();
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -32,11 +32,10 @@ import com.facebook.stetho.json.annotation.JsonProperty;
 
 import org.json.JSONObject;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Nullable;
 
 public class DOM implements ChromeDevtoolsDomain {
   private final ChromePeerManager mPeerManager;
@@ -143,6 +142,20 @@ public class DOM implements ChromeDevtoolsDomain {
     response.object = remoteObject;
 
     return response;
+  }
+
+  @ChromeDevtoolsMethod
+  public void setAttributesAsText(JsonRpcPeer peer, JSONObject params) {
+    final SetAttributesAsTextRequest request = mObjectMapper.convertValue(
+        params, SetAttributesAsTextRequest.class);
+    final Object object = mObjectIdMapper.getObjectForId(request.nodeId);
+
+    mDOMProvider.postAndWait(new Runnable() {
+      @Override
+      public void run() {
+        mDOMProvider.setAttributesAsText(object, request.text);
+      }
+    });
   }
 
   @ChromeDevtoolsMethod
@@ -491,6 +504,14 @@ public class DOM implements ChromeDevtoolsDomain {
 
     @JsonProperty
     public String objectGroup;
+  }
+
+  private static class SetAttributesAsTextRequest {
+    @JsonProperty(required = true)
+    public int nodeId;
+
+    @JsonProperty(required = true)
+    public String text;
   }
 
   private static class ResolveNodeResponse implements JsonRpcResult {

--- a/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/MethodInvokerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/MethodInvokerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Activity;
+import android.os.Build;
+import android.widget.CheckBox;
+import android.widget.TextView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+
+@Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
+@RunWith(RobolectricTestRunner.class)
+public class MethodInvokerTest {
+
+  private final Activity mActivity = Robolectric.setupActivity(Activity.class);
+  private final TextView mTextView = new TextView(mActivity);
+  private final CheckBox mCheckBox = new CheckBox(mActivity);
+  private final MethodInvoker mInvoker = new MethodInvoker();
+
+  @Before
+  public void setup() {
+  }
+
+  @Test
+  public void testSetCharSequence() {
+    mInvoker.invoke(mTextView, "setText", "Hello World");
+    assertEquals("Hello World", mTextView.getText().toString());
+  }
+
+  @Test
+  public void testSetInteger() {
+    mInvoker.invoke(mTextView, "setId", "2");
+    assertEquals(2, mTextView.getId());
+  }
+
+  @Test
+  public void testSetFloat() {
+    mInvoker.invoke(mTextView, "setTextSize", "34");
+    assertEquals(34f, mTextView.getTextSize(), 0);
+  }
+
+  @Test
+  public void testSetBoolean() {
+    mInvoker.invoke(mCheckBox, "setChecked", "true");
+    assertEquals(true, mCheckBox.isChecked());
+  }
+
+  @Test
+  public void testSetAttributeAsTextIgnoreUnknownAttribute() {
+    // Should not throw
+    mInvoker.invoke(mTextView, "setSomething", "foo");
+  }
+}

--- a/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
@@ -1,0 +1,60 @@
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Activity;
+import android.os.Build;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
+@RunWith(RobolectricTestRunner.class)
+public class ViewDescriptorTest {
+
+  private final MethodInvoker mMethodInvoker = mock(MethodInvoker.class);
+  private final ViewDescriptor mDescriptor = new ViewDescriptor(mMethodInvoker);
+  private final Activity mActivity = Robolectric.setupActivity(Activity.class);
+  private final TextView mTextView = new TextView(mActivity);
+  private final CheckBox mCheckBox = new CheckBox(mActivity);
+
+  @Test
+  public void testSetAttributeAsTextWithSetText() {
+    mDescriptor.setAttributesAsText(mTextView, "text=\"Hello World\"");
+    verify(mMethodInvoker).invoke(mTextView, "setText", "Hello World");
+  }
+
+  @Test
+  public void testSetAttributeAsTextWithSetId() {
+    mDescriptor.setAttributesAsText(mTextView, "id=\"2\"");
+    verify(mMethodInvoker).invoke(mTextView, "setId", "2");
+  }
+
+  @Test
+  public void testSetAttributeAsTextWithSetChecked() {
+    mDescriptor.setAttributesAsText(mCheckBox, "checked=\"true\"");
+    verify(mMethodInvoker).invoke(mCheckBox, "setChecked", "true");
+  }
+
+  @Test
+  public void testSetMultipleAttributesAsText() {
+    mDescriptor.setAttributesAsText(mTextView, "id=\"2\" text=\"Hello World\"");
+    verify(mMethodInvoker).invoke(mTextView, "setId", "2");
+    verify(mMethodInvoker).invoke(mTextView, "setText", "Hello World");
+  }
+
+  @Test
+  public void testSetAttributeAsTextIgnoreInvalidFormat() {
+    mDescriptor.setAttributesAsText(mTextView, "garbage");
+    verify(mMethodInvoker, never()).invoke(anyObject(), anyString(), anyString());
+  }
+}


### PR DESCRIPTION
Fixes #145 

This is my initial stab at implementing a new DOM request `setAttributesAsText()`.

Right now this correctly calls any setter that has a single argument of type `int`, `float`, `boolean`, `String` or `CharSequence` of `View` (and subclasses) using the `MethodInvoker`. 
Examples are `setTex()t`, `setId()`, `setAlpha()`, etc. More types can be supported by extending `TypedMethodInvoker`.

Question: 
* Do we need to send a response back after completed? 