### PR TITLE
ignore meta-data for SQLite using WAL

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -38,7 +38,9 @@ import com.facebook.stetho.inspector.protocol.module.DatabaseConstants;
 public class DatabasePeerManager extends ChromePeerManager {
   private static final String[] UNINTERESTING_FILENAME_SUFFIXES = new String[]{
       "-journal",
-      "-uid"
+      "-shm",
+      "-uid",
+      "-wal"
   };
 
   private final Context mContext;


### PR DESCRIPTION
when enabling WAL for SQLite the files used for journaling change.

See: https://www.sqlite.org/wal.html