### PR TITLE
Clarify and enforce thread safety contract of DOMProvider et. al.

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/ThreadBound.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ThreadBound.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common;
+
+import java.lang.IllegalStateException;
+
+/**
+ * Implemented by an object whose methods must be called on a specific thread. If a method is
+ * called from a disallowed thread then {@link IllegalStateException} will be thrown.
+ * To marshal a call to the correct thread, you can use {@link #postAndWait(UncheckedCallable)} or
+ * {@link #postAndWait(Runnable)}, both of which complete synchronously.
+ */
+public interface ThreadBound {
+  /**
+   * Checks whether the current thread has access to this object.
+   * @return true if this thread has access to this object; otherwise false
+   */
+  public boolean checkThreadAccess();
+
+  /**
+   * Enforces that the current thread has access to this object.
+   * @throws IllegalStateException if the current thread does not have access to this object
+   */
+  public void verifyThreadAccess();
+
+  /**
+   * Synchronously executes an {@link UncheckedCallable} on the thread that this object is bound to,
+   * and returns its result.
+   * @param c the {@link UncheckedCallable} to execute
+   * @param <V> the return type of the {@link UncheckedCallable}
+   * @return the return value from {@link UncheckedCallable#call()}
+   * @throws RuntimeException if the {@link UncheckedCallable} could not be executed (the cause
+   * will be null), or if {@link UncheckedCallable#call()} threw an exception (the cause will be the
+   * exception that it threw).
+   */
+  public <V> V postAndWait(UncheckedCallable<V> c);
+
+  /**
+   * Synchronously executes a {@link Runnable} on the thread that this object is bound to.
+   * @param r the {@link Runnable} to execute
+   * @throws RuntimeException if the {@link Runnable} could not be executed (the cause will be
+   * null), or if {@link Runnable#run()} threw an exception (the cause will be the exception that
+   * it threw).
+   */
+  public void postAndWait(Runnable r);
+}
+

--- a/stetho/src/main/java/com/facebook/stetho/common/UncheckedCallable.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/UncheckedCallable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common;
+
+/**
+ * A task that returns a result. Implementers define a single method with no arguments called
+ * {@code call}.
+ *
+ * <p>This interface is identical to {@link java.util.concurrent.Callable} but without the checked
+ * exception.
+ *
+ * @param <V> the result type of method {@code call}
+ */
+public interface UncheckedCallable<V> {
+  public V call();
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
@@ -11,38 +11,106 @@ package com.facebook.stetho.common.android;
 
 import android.os.Handler;
 import android.os.Looper;
+import com.facebook.stetho.common.UncheckedCallable;
+import com.facebook.stetho.common.Util;
 
 public final class HandlerUtil {
   private HandlerUtil() {
   }
 
-  public static boolean postAndWait(Handler handler, final Runnable r) {
-    if (Looper.myLooper() == handler.getLooper()) {
-      r.run();
-      return true;
-    }
-
-    WaitableRunnable wrapper = new WaitableRunnable(r);
-    if (!handler.post(wrapper)) {
-      return false;
-    }
-
-    wrapper.join();
-    return true;
+  /**
+   * Checks whether the current thread is the same thread that the {@link Handler} is associated
+   * with.
+   * @return true if the current thread is the same thread that the {@link Handler} is associated
+   * with; otherwise false.
+   */
+  public static boolean checkThreadAccess(Handler handler) {
+    return Looper.myLooper() == handler.getLooper();
   }
 
-  private static final class WaitableRunnable implements Runnable {
-    private final Runnable mRunnable;
-    private boolean mIsDone;
+  /**
+   * Enforces that the current thread is the same thread that the {@link Handler} is associated
+   * with.
+   * @throws IllegalStateException if the current thread is not the same thread that the
+   * {@link Handler} is associated with.
+   */
+  public static void verifyThreadAccess(Handler handler) {
+    Util.throwIfNot(checkThreadAccess(handler));
+  }
 
-    public WaitableRunnable(Runnable runnable) {
-      mRunnable = runnable;
+  /**
+   * Synchronously executes an {@link UncheckedCallable} on the thread that this Handler is
+   * associated with, and returns its result.
+   * @param c the {@link UncheckedCallable} to execute
+   * @param <V> the return type of the {@link UncheckedCallable}
+   * @return the return value from {@link UncheckedCallable#call()}
+   * @throws RuntimeException if the {@link UncheckedCallable} could not be executed (the cause
+   * will be null), or if {@link UncheckedCallable#call()} threw an exception (the cause will be the
+   * exception that it threw).
+   */
+  public static <V> V postAndWait(Handler handler, final UncheckedCallable<V> c) {
+    if (checkThreadAccess(handler)) {
+      try {
+        return c.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    WaitableRunnable<V> wrapper = new WaitableRunnable<V>() {
+      @Override
+      protected V onRun() {
+        return c.call();
+      }
+    };
+
+    return wrapper.invoke(handler);
+  }
+
+  /**
+   * Synchronously executes a {@link Runnable} on the thread that this Handler is associated with.
+   * @param r the {@link Runnable} to execute
+   * @throws RuntimeException if the {@link Runnable} could not be executed (the cause will be
+   * null), or if {@link Runnable#run()} threw an exception (the cause will be the exception that
+   * it threw).
+   */
+  public static void postAndWait(Handler handler, final Runnable r) {
+    if (checkThreadAccess(handler)) {
+      try {
+        r.run();
+        return;
+      } catch (RuntimeException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    WaitableRunnable<Void> wrapper = new WaitableRunnable<Void>() {
+      @Override
+      protected Void onRun() {
+        r.run();
+        return null;
+      }
+    };
+
+    wrapper.invoke(handler);
+  }
+
+  private static abstract class WaitableRunnable<V> implements Runnable {
+    private boolean mIsDone;
+    private V mValue;
+    private Exception mException;
+
+    protected WaitableRunnable() {
     }
 
     @Override
-    public void run() {
+    public final void run() {
       try {
-        mRunnable.run();
+        mValue = onRun();
+        mException = null;
+      } catch (Exception e) {
+        mValue = null;
+        mException = e;
       } finally {
         synchronized (this) {
           mIsDone = true;
@@ -51,7 +119,23 @@ public final class HandlerUtil {
       }
     }
 
-    public void join() {
+    protected abstract V onRun();
+
+    public V invoke(Handler handler) {
+      if (!handler.post(this)) {
+        throw new RuntimeException("Handler.post() returned false");
+      }
+
+      join();
+
+      if (mException != null) {
+        throw new RuntimeException(mException);
+      }
+
+      return mValue;
+    }
+
+    private void join() {
       synchronized (this) {
         while (!mIsDone) {
           try {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -2,17 +2,58 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import com.facebook.stetho.common.ThreadBound;
 import com.facebook.stetho.common.Util;
 
 import javax.annotation.Nullable;
 
+/**
+ * This class implements {@link Descriptor} in a way that is specially understood by
+ * {@link DescriptorMap}. When implemented and registered for a class {@link E}, an instance of this
+ * class will automatically be chained to the {@link Descriptor} which is registered for {@link E}'s
+ * next super class. If {@link E}'s immediate super class doesn't have a descriptor registered for
+ * it, but the super-super class does, then that will be used. This allows you to implement
+ * {@link Descriptor} for any class without having to worry about describing anything about the
+ * super class, and without having to know which {@link Descriptor} is registered for that super
+ * class.
+ *
+ * <p>For example, let's say you wanted to write a {@link Descriptor} for
+ * {@link android.widget.ListView}. You can certainly derive from {@link Descriptor} and write
+ * code to describe everything exposed by {@link android.widget.ListView},
+ * {@link android.view.ViewGroup}, {@link android.view.View}, and {@link java.lang.Object}. Or you
+ * can implement descriptors for each of these classes and create a parallel inheritance
+ * hierarchy (e.g. your descriptor for {@link android.view.ViewGroup} would derive from your
+ * descriptor for {@link android.view.View}, at which point you have to worry about things like
+ * aggregating the results of {@link Descriptor#getChildAt(Object, int)} and so on. In both cases
+ * you'll also have a lot of messy unchecked casts to worry about.</p>
+ *
+ * <p>Or, you can derive from {@link ChainedDescriptor} and then only worry about describing what
+ * {@link android.widget.ListView} adds to or changes from {@link android.view.ViewGroup}.
+ * Aggregation and casting are handled for you. You're also protected from the fragility that
+ * would occur if a {@link Descriptor} was later implemented for something in-between
+ * {@link android.view.ViewGroup} and {@link android.widget.ListView}, such as
+ * {@link android.widget.AbsListView}. Your descriptor will automatically chain to and benefit from
+ * the descriptor registered for the nearest super class.</p>
+ *
+ * <p>This class also implements the thread safety enforcement policy prescribed by
+ * {@link ThreadBound}. Namely, that {@link #verifyThreadAccess()}} needs to be called in the
+ * prologue for every method. Your derived class SHOULD NOT call {@link #verifyThreadAccess()}} in
+ * any of its on___() methods.
+ * </p>
+ *
+ * <p>(NOTE: As an optimization, {@link #verifyThreadAccess()} is not actually called in the
+ * prologue for every method. Instead, we rely on {@link DOMProvider#getNodeDescriptor(Object)}
+ * calling it in order to get most of our enforcement coverage. We still call
+ * {@link #verifyThreadAccess()} in a few important methods such as {@link #hook(Object)} and
+ * {@link #unhook(Object)} (anything that writes or is potentially really dangerous if misused).
+ *
+ * @param <E> the class that this descriptor will be describing for {@link DOMProvider} and
+ * {@link com.facebook.stetho.inspector.protocol.module.DOM}
+ */
 public abstract class ChainedDescriptor<E> extends Descriptor {
+
   private Descriptor mSuper;
 
-  // This is used by DescriptorMap to hook us up to whatever handles E's super class.
-  // This method is idempotent in the sense that once you call it with a specific
-  // reference you must either 1) never call it again, or 2) call it again with that
-  // same reference.
   final void setSuper(Descriptor superDescriptor) {
     Util.throwIfNull(superDescriptor);
 
@@ -31,6 +72,7 @@ public abstract class ChainedDescriptor<E> extends Descriptor {
   @Override
   @SuppressWarnings("unchecked")
   public final void hook(Object element) {
+    verifyThreadAccess();
     mSuper.hook(element);
     onHook((E)element);
   }
@@ -41,6 +83,7 @@ public abstract class ChainedDescriptor<E> extends Descriptor {
   @Override
   @SuppressWarnings("unchecked")
   public final void unhook(Object element) {
+    verifyThreadAccess();
     onUnhook((E)element);
     mSuper.unhook(element);
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -2,14 +2,14 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import com.facebook.stetho.common.ThreadBound;
+
 import javax.annotation.Nullable;
 
-public interface DOMProvider {
+public interface DOMProvider extends ThreadBound {
   public void setListener(Listener listener);
 
   public void dispose();
-
-  public boolean postAndWait(Runnable r);
 
   @Nullable
   public Object getRootElement();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -2,6 +2,8 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import com.facebook.stetho.common.ThreadBound;
+import com.facebook.stetho.common.UncheckedCallable;
 import com.facebook.stetho.common.Util;
 
 import javax.annotation.Nullable;
@@ -26,7 +28,27 @@ public abstract class Descriptor implements NodeDescriptor {
     return mHost;
   }
 
-  public interface Host {
+  @Override
+  public final boolean checkThreadAccess() {
+    return getHost().checkThreadAccess();
+  }
+
+  @Override
+  public final void verifyThreadAccess() {
+    getHost().verifyThreadAccess();
+  }
+
+  @Override
+  public final <V> V postAndWait(UncheckedCallable<V> c) {
+    return getHost().postAndWait(c);
+  }
+
+  @Override
+  public final void postAndWait(Runnable r) {
+    getHost().postAndWait(r);
+  }
+
+  public interface Host extends ThreadBound {
     @Nullable
     public Descriptor getDescriptor(@Nullable Object element);
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -2,9 +2,11 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import com.facebook.stetho.common.ThreadBound;
+
 import javax.annotation.Nullable;
 
-public interface NodeDescriptor {
+public interface NodeDescriptor extends ThreadBound {
   public void hook(Object element);
 
   public void unhook(Object element);

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -41,6 +41,7 @@ final class ActivityDescriptor
       Window window = activity.getWindow();
       return host.getHighlightingView(window);
     }
+
     return null;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -4,7 +4,6 @@ package com.facebook.stetho.inspector.elements.android;
 
 import android.annotation.TargetApi;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;


### PR DESCRIPTION
This introduces a new interface, ThreadBound, which provides methods for dealing with the UI thread safety contract that we need to enforce w.r.t. Android UI objects. We are also much more stringent about verifying that calls are being made on the correct thread.

Closes #167