### PR TITLE
Introduce plugin framework for Console tab evaluation support

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.console;
+
+/**
+ * Allows callers to specify their own Console tab REPL for the DevTools UI.  This is part of
+ * early support for a possible optionally included default implementation for Android.
+ * <p />
+ * Experimental API.  Depend on it at your own risk...
+ */
+public interface RuntimeRepl {
+  public Object evaluate(String expression) throws Exception;
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
@@ -9,12 +9,6 @@
 
 package com.facebook.stetho.inspector.console;
 
-/**
- * Allows callers to specify their own Console tab REPL for the DevTools UI.  This is part of
- * early support for a possible optionally included default implementation for Android.
- * <p />
- * Experimental API.  Depend on it at your own risk...
- */
 public interface RuntimeRepl {
   public Object evaluate(String expression) throws Exception;
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
@@ -10,5 +10,5 @@
 package com.facebook.stetho.inspector.console;
 
 public interface RuntimeRepl {
-  public Object evaluate(String expression) throws Exception;
+  public Object evaluate(String expression) throws Throwable;
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeReplFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeReplFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.console;
+
+/**
+ * Allows callers to specify their own Console tab REPL for the DevTools UI.  This is part of
+ * early support for a possible optionally included default implementation for Android.
+ * <p />
+ * A new {@link RuntimeRepl} instances is created for each unique peer such that memory
+ * can be garbage collected when the peer disconnects.
+ * <p />
+ * This is provided as part of an experimental API.  Depend on it at your own risk...
+ */
+public interface RuntimeReplFactory {
+  public RuntimeRepl newInstance();
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -13,6 +13,7 @@ package com.facebook.stetho.inspector.protocol.module;
 
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.inspector.console.RuntimeRepl;
+import com.facebook.stetho.inspector.console.RuntimeReplFactory;
 import com.facebook.stetho.inspector.helper.ObjectIdMapper;
 import com.facebook.stetho.inspector.jsonrpc.DisconnectReceiver;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcException;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class Runtime implements ChromeDevtoolsDomain {
   private final ObjectMapper mObjectMapper = new ObjectMapper();
@@ -47,19 +49,14 @@ public class Runtime implements ChromeDevtoolsDomain {
   private static final Map<JsonRpcPeer, Session> sSessions =
       Collections.synchronizedMap(new HashMap<JsonRpcPeer, Session>());
 
-  private final RuntimeRepl mRepl;
+  private final RuntimeReplFactory mReplFactory;
 
   public Runtime() {
-    this(new RuntimeRepl() {
-      @Override
-      public Object evaluate(String expression) {
-        return "Not supported (yet)";
-      }
-    });
+    this(new DefaultRuntimeReplFactory());
   }
 
-  public Runtime(RuntimeRepl repl) {
-    mRepl = repl;
+  public Runtime(RuntimeReplFactory replFactory) {
+    mReplFactory = replFactory;
   }
 
   public static int mapObject(JsonRpcPeer peer, Object object) {
@@ -132,7 +129,7 @@ public class Runtime implements ChromeDevtoolsDomain {
 
   @ChromeDevtoolsMethod
   public JsonRpcResult evaluate(JsonRpcPeer peer, JSONObject params) {
-    return getSession(peer).evaluate(mRepl, params);
+    return getSession(peer).evaluate(mReplFactory, params);
   }
 
   @ChromeDevtoolsMethod
@@ -167,6 +164,9 @@ public class Runtime implements ChromeDevtoolsDomain {
   private static class Session {
     private final ObjectIdMapper mObjects = new ObjectIdMapper();
     private final ObjectMapper mObjectMapper = new ObjectMapper();
+
+    @Nullable
+    private RuntimeRepl mRepl;
 
     public ObjectIdMapper getObjects() {
       return mObjects;
@@ -223,7 +223,7 @@ public class Runtime implements ChromeDevtoolsDomain {
       return result;
     }
 
-    public EvaluateResponse evaluate(RuntimeRepl repl, JSONObject params) {
+    public EvaluateResponse evaluate(RuntimeReplFactory replFactory, JSONObject params) {
       EvaluateRequest request = mObjectMapper.convertValue(params, EvaluateRequest.class);
 
       try {
@@ -231,11 +231,20 @@ public class Runtime implements ChromeDevtoolsDomain {
           return buildExceptionResponse("Not supported by FAB");
         }
 
+        RuntimeRepl repl = getRepl(replFactory);
         Object result = repl.evaluate(request.expression);
         return buildNormalResponse(result);
       } catch (Exception e) {
         return buildExceptionResponse(e);
       }
+    }
+
+    @Nonnull
+    private synchronized RuntimeRepl getRepl(RuntimeReplFactory replFactory) {
+      if (mRepl == null) {
+        mRepl = replFactory.newInstance();
+      }
+      return mRepl;
     }
 
     private EvaluateResponse buildNormalResponse(Object retval) {
@@ -550,6 +559,18 @@ public class Runtime implements ChromeDevtoolsDomain {
     @JsonValue
     public String getProtocolValue() {
       return mProtocolValue;
+    }
+  }
+
+  private static class DefaultRuntimeReplFactory implements RuntimeReplFactory {
+    @Override
+    public RuntimeRepl newInstance() {
+      return new RuntimeRepl() {
+        @Override
+        public Object evaluate(String expression) throws Exception {
+          return "Not supported";
+        }
+      };
     }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -234,8 +234,8 @@ public class Runtime implements ChromeDevtoolsDomain {
         RuntimeRepl repl = getRepl(replFactory);
         Object result = repl.evaluate(request.expression);
         return buildNormalResponse(result);
-      } catch (Exception e) {
-        return buildExceptionResponse(e);
+      } catch (Throwable t) {
+        return buildExceptionResponse(t);
       }
     }
 


### PR DESCRIPTION
This allows third parties to provide their own REPL implementation to
interpret commands from the Console.  Eventually we'd like to explore
possibly using bsh or some other Java evaluation framework that is
enabled if detected in the classpath.  This is the first small step in
that direction.

Tested that exception processing and arbitrary object return types do
indeed work.