### PR TITLE
Fix crash when the support library is present but not used for a particular Activity

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
@@ -69,6 +69,7 @@ public abstract class FragmentCompat<
   }
 
   public abstract Class<FRAGMENT> getFragmentClass();
+  public abstract Class<FRAGMENT_ACTIVITY> getFragmentActivityClass();
   public abstract FragmentAccessor<FRAGMENT, FRAGMENT_MANAGER> forFragment();
   public abstract FragmentManagerAccessor<FRAGMENT_MANAGER, FRAGMENT> forFragmentManager();
   public abstract FragmentActivityAccessor<FRAGMENT_ACTIVITY, FRAGMENT_MANAGER> forFragmentActivity();

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
@@ -43,6 +43,11 @@ final class FragmentCompatFramework
   }
 
   @Override
+  public Class<Activity> getFragmentActivityClass() {
+    return Activity.class;
+  }
+
+  @Override
   public FragmentAccessorFrameworkHoneycomb forFragment() {
     return sFragmentAccessor;
   }

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
@@ -33,6 +33,11 @@ final class FragmentCompatSupportLib
   }
 
   @Override
+  public Class<FragmentActivity> getFragmentActivityClass() {
+    return FragmentActivity.class;
+  }
+
+  @Override
   public FragmentAccessorSupportLib forFragment() {
     return sFragmentAccessor;
   }

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
@@ -26,13 +26,20 @@ public final class FragmentCompatUtil {
   @Nullable
   private static Object findFragmentForViewInActivity(Activity activity, View view) {
     FragmentCompat supportLib = FragmentCompat.getSupportLibInstance();
-    if (supportLib != null) {
+
+    // Try the support library version if it is present and the activity is FragmentActivity.
+    if (supportLib != null &&
+        supportLib.getFragmentActivityClass() == activity.getClass()) {
       Object fragment = findFragmentForViewInActivity(supportLib, activity, view);
       if (fragment != null) {
         return fragment;
       }
     }
 
+    // Try the actual Android runtime version if we are on a sufficiently high API level for it to
+    // exist.  Note that technically we can have both the support library and the framework
+    // version in the same object instance due to FragmentActivity extending Activity (which has
+    // fragment support in the system).
     FragmentCompat framework = FragmentCompat.getFrameworkInstance();
     if (framework != null) {
       Object fragment = findFragmentForViewInActivity(framework, activity, view);

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
@@ -29,7 +29,7 @@ public final class FragmentCompatUtil {
 
     // Try the support library version if it is present and the activity is FragmentActivity.
     if (supportLib != null &&
-        supportLib.getFragmentActivityClass() == activity.getClass()) {
+        supportLib.getFragmentActivityClass().isInstance(activity)) {
       Object fragment = findFragmentForViewInActivity(supportLib, activity, view);
       if (fragment != null) {
         return fragment;


### PR DESCRIPTION
This is done by simply checking whether we have an instance of
FragmentActivity before taking the support library path.  The framework
path doesn't need this check since it's impossible that if we have an
Activity and we are on a sufficiently high API level that the Activity
doesn't have fragment support.

Closes #176