### PR TITLE
Fix copyright headers hopefully for the last time :)

### DIFF
--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;
 

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;
 

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.sample;
 

--- a/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;
 

--- a/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;
 

--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2015-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.common;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.common.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
@@ -1,4 +1,3 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
 /*
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
@@ -7,7 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/RawDumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/RawDumpappHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamFramer.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamFramer.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamingDumpappHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/StreamingDumpappHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp;
 

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.dumpapp.plugins;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.database;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DOMProvider.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProviderFactory.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DOMHiddenView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DOMHiddenView.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.elements.android;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.stetho.inspector.helper;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.helper;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.network;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2015-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.protocol.module;
 

--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketHttpServerConnection.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;
 

--- a/stetho/src/main/java/com/facebook/stetho/server/RegistryInitializer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/RegistryInitializer.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;
 

--- a/stetho/src/main/java/com/facebook/stetho/server/SecureHttpRequestHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SecureHttpRequestHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.server;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/CompositeInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/CompositeInputStream.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.websocket;
 

--- a/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-//
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 package com.facebook.stetho.inspector.database;
 


### PR DESCRIPTION
The IntelliJ copyright settings are now part of the repo and new
developers should automagically import them to not cause this problem in
the future.