### PR TITLE
Fix Fragment support in Elements tab

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
@@ -24,8 +24,7 @@ final class FragmentCompatFramework
     extends FragmentCompat<Fragment, FragmentManager, Activity> {
   private static final FragmentAccessorFrameworkHoneycomb sFragmentAccessor;
   private static final FragmentManagerAccessorViaReflection<FragmentManager, Fragment>
-      sFragmentManagerAccessor =
-          new FragmentManagerAccessorViaReflection<>(FragmentManager.class);
+      sFragmentManagerAccessor = new FragmentManagerAccessorViaReflection<>();
   private static final FragmentActivityAccessorFramework sFragmentActivityAccessor =
       new FragmentActivityAccessorFramework();
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
@@ -22,8 +22,7 @@ final class FragmentCompatSupportLib
   private static final FragmentAccessorSupportLib sFragmentAccessor =
       new FragmentAccessorSupportLib();
   private static final FragmentManagerAccessorViaReflection<FragmentManager, Fragment>
-      sFragmentManagerAccessor =
-          new FragmentManagerAccessorViaReflection<>(FragmentManager.class);
+      sFragmentManagerAccessor = new FragmentManagerAccessorViaReflection<>();
   private static final FragmentActivityAccessorSupportLib sFragmentActivityAccessor =
       new FragmentActivityAccessorSupportLib();
 


### PR DESCRIPTION
This one is deceptively fragile because FragmentManager is an abstract class and we actually need to pull mAdded from the derived class FragmentManagerImpl.

Closes #182 
