### PR TITLE
Use first-party test support in gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
-        classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 28 14:53:04 PST 2015
+#Sat May 09 15:41:17 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -20,8 +20,6 @@ android {
     }
 }
 
-apply plugin: 'android-unit-test'
-
 dependencies {
     compile project(':stetho')
     compile 'com.google.code.findbugs:jsr305:2.0.1'

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -13,8 +13,6 @@ android {
     }
 }
 
-apply plugin: 'android-unit-test'
-
 dependencies {
     compile 'commons-cli:commons-cli:1.2'
     compile 'com.google.code.findbugs:jsr305:2.0.1'


### PR DESCRIPTION
First party unit testing support is available in the android gradle build tools since version 1.1.0 ([more info](http://tools.android.com/tech-docs/new-build-system)).

This means we don't need to use a custom test plugin and can use the latest gradle build tools, which was incompatiple with the `android-unit-test` plugin.

With this, we get syntax highlighting and autocompletion support for the tests in Android Studio, which was also not available before version 1.1.0