### PR TITLE
Add allocation profiler to Stetho.

### DIFF
--- a/stetho-sample/src/main/AndroidManifest.xml
+++ b/stetho-sample/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.facebook.stetho.sample">
 
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <application
       android:label="@string/app_name"
@@ -31,6 +32,10 @@
         android:name=".APODContentProvider"
         android:authorities="com.facebook.stetho.sample.apod"
         android:exported="false" />
+
+    <activity
+        android:label="@string/profiler_title"
+        android:name=".ProfilerActivity" />
 
   </application>
 

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
@@ -33,6 +33,7 @@ public class MainActivity extends Activity {
 
     findViewById(R.id.settings_btn).setOnClickListener(mMainButtonClicked);
     findViewById(R.id.apod_btn).setOnClickListener(mMainButtonClicked);
+    findViewById(R.id.profiler_btn).setOnClickListener(mMainButtonClicked);
   }
 
   private static boolean isStethoPresent() {
@@ -68,6 +69,8 @@ public class MainActivity extends Activity {
         SettingsActivity.show(MainActivity.this);
       } else if (id == R.id.apod_btn) {
         APODActivity.show(MainActivity.this);
+      } else if (id == R.id.profiler_btn) {
+        ProfilerActivity.show(MainActivity.this);
       }
     }
   };

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/ProfilerActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/ProfilerActivity.java
@@ -1,0 +1,159 @@
+package com.facebook.stetho.sample;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Environment;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.Toast;
+import com.facebook.stetho.heap.AllocationTracker;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProfilerActivity extends Activity {
+  private static final String TAG = "ProfilerActivity";
+
+  private CheckBox mMicroscopedProfile;
+
+  public static void show(Context context) {
+    context.startActivity(new Intent(context, ProfilerActivity.class));
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.profiler_activity);
+
+    mMicroscopedProfile = (CheckBox)findViewById(R.id.microscoped_profile);
+    findViewById(R.id.alloc_simple_btn).setOnClickListener(mProfileButtonClicked);
+    findViewById(R.id.alloc_gotcha_btn).setOnClickListener(mProfileButtonClicked);
+  }
+
+  private final View.OnClickListener mProfileButtonClicked = new View.OnClickListener() {
+    @Override
+    public void onClick(View v) {
+      boolean microscoped = mMicroscopedProfile.isChecked();
+      File microscopedPath = null;
+      if (microscoped) {
+        if (AllocationTracker.isStarted()) {
+          toast(getString(R.string.already_profiling));
+          return;
+        }
+        microscopedPath = new File(
+            Environment.getExternalStorageDirectory(),
+            "allocations.grimsey");
+        AllocationTracker.start(microscopedPath.getAbsolutePath());
+      }
+      try {
+        handleClick(v.getId());
+      } finally {
+        if (microscoped) {
+          AllocationTracker.stop();
+          toast("Wrote " + microscopedPath);
+        }
+      }
+    }
+
+    private void handleClick(int id) {
+      if (id == R.id.alloc_simple_btn) {
+        doAllocSimple();
+      } else if (id == R.id.alloc_gotcha_btn) {
+        doAllocGotcha();
+      }
+    }
+  };
+
+  private void toast(CharSequence text) {
+    Toast.makeText(this, text, Toast.LENGTH_SHORT).show();
+  }
+
+  /**
+   * Simple demonstration of commonplace allocations in Java applications.  Allocates
+   * approximately 300 objects, easily identifiable.
+   */
+  private static ArrayList<String> doAllocSimple() {
+    int stringListSize = 100;
+
+    // ArrayList and Object[]
+    ArrayList<String> stringList = new ArrayList<String>(stringListSize);
+
+    for (int i = 0; i < stringListSize; i++) {
+      // StringBuilder, char[], String.
+      String s = "String #" + i;
+      stringList.add(s);
+    }
+
+    return stringList;
+  }
+
+  /**
+   * Mock creation of a legacy form-encoded HTTP request body, demonstrating the serious
+   * gotchas that lurk within the Java runtime implementation.  Allocates a surprising 4000+
+   * objects, at a total size of 200KB+.
+   * <p />
+   * PSA: Do not use form-encoding.  Let Stetho explain why... :)
+   */
+  private static byte[] doAllocGotcha() {
+    int parameterMultiplier = 100;
+
+    // HashMap, Hashtable, Map.Entry[] (which will be reallocated/copied 4 or 5 times)
+    HashMap<String, Object> mQueryParameters = new HashMap<String, Object>();
+
+    // String[], and on first run the string literals themselves.
+    String[] parameterPrefixes = { "foo", "bar", "baz" };
+    for (int i = 0; i < parameterMultiplier; i++) {
+      String prefix = parameterPrefixes[i % parameterPrefixes.length];
+
+      // 2x StringBuilder, char[], String
+      String integerKey = prefix + "-int-" + i;
+      String stringKey = prefix + "-str-" + i;
+
+      // Map.Entry, Integer (for autoboxing)
+      mQueryParameters.put(integerKey, i + 1000);
+
+      // Map.Entry (but just wait until we URLEncode...)
+      mQueryParameters.put(stringKey, "!@#$&%*# ");
+    }
+
+    // StringBuilder, char[]
+    StringBuilder requestBuilder = new StringBuilder();
+
+    // EntrySet, Iterator<Map.Entry<>>
+    for (Map.Entry<String, Object> entry : mQueryParameters.entrySet()) {
+      // String (for Integer case only)
+      String valueString = entry.getValue().toString();
+
+      // Huge allocation bomb; see method for allocations...
+      formEncodePair(requestBuilder, entry.getKey(), valueString);
+    }
+
+    // String only, no copy
+    String request = requestBuilder.toString();
+
+    // byte[]
+    byte[] requestEncoded = request.getBytes();
+
+    return requestEncoded;
+  }
+
+  private static void formEncodePair(StringBuilder request, String key, String value) {
+    try {
+      if (request.length() > 0) {
+        request.append('&');
+      }
+      // Allocates many String/char[] pairs for each encoded segment.
+      request.append(URLEncoder.encode(key, "UTF-8"));
+      request.append('=');
+      request.append(URLEncoder.encode(value, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/stetho-sample/src/main/res/layout/main_activity.xml
+++ b/stetho-sample/src/main/res/layout/main_activity.xml
@@ -22,4 +22,12 @@
       android:layout_marginBottom="10dp"
       />
 
+    <Button
+      android:id="@+id/profiler_btn"
+      android:text="@string/profiler_btn"
+      android:layout_width="@dimen/main_button_width"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="10dp"
+      />
+
 </LinearLayout>

--- a/stetho-sample/src/main/res/layout/profiler_activity.xml
+++ b/stetho-sample/src/main/res/layout/profiler_activity.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:padding="15dp">
+
+  <CheckBox
+      android:id="@+id/microscoped_profile"
+      android:text="@string/microscoped_profile"
+      android:layout_width="@dimen/profiler_button_width"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="10dp"
+      android:checked="false"
+      />
+
+  <Button
+      android:id="@+id/alloc_simple_btn"
+      android:text="@string/alloc_simple_btn"
+      android:layout_width="@dimen/profiler_button_width"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="10dp"
+      />
+
+  <Button
+      android:id="@+id/alloc_gotcha_btn"
+      android:text="@string/alloc_gotcha_btn"
+      android:layout_width="@dimen/profiler_button_width"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="10dp"
+      />
+
+  <TextView
+      android:text="@string/profiler_disclaimer"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      />
+
+</LinearLayout>

--- a/stetho-sample/src/main/res/values/dimens.xml
+++ b/stetho-sample/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
   <dimen name="main_button_width">150dp</dimen>
   <dimen name="apod_image_width">90dp</dimen>
   <dimen name="apod_image_height">90dp</dimen>
+  <dimen name="profiler_button_width">220dp</dimen>
 </resources>

--- a/stetho-sample/src/main/res/values/strings.xml
+++ b/stetho-sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
   <string name="app_name">Stetho Sample</string>
   <string name="settings_btn">Settings</string>
   <string name="apod_btn">APOD RSS Feed</string>
+  <string name="profiler_btn">Profiler</string>
   <string name="settings_title">Settings</string>
   <string name="pref_category1_title">General</string>
   <string name="pref_checkbox_title">Boolean setting</string>
@@ -15,4 +16,12 @@
   <string name="pref_change_message">%1$s is now \'%2$s\'</string>
   <string name="apod_title">APOD Listing</string>
   <string name="stetho_missing">Stetho missing in %s build!</string>
+  <string name="profiler_title">Profiler Demo</string>
+  <string name="alloc_simple_btn">Simple Allocation Test</string>
+  <string name="alloc_gotcha_btn">Allocation Gotcha</string>
+  <string name="microscoped_profile">Write to file</string>
+  <string name="already_profiling">Already profiling!</string>
+  <string name="profiler_disclaimer">
+Note: first time profiles will include internal VM overhead
+  </string>
 </resources>

--- a/stetho/src/main/java/com/facebook/stetho/common/ManagedIntArray.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ManagedIntArray.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common;
+
+public class ManagedIntArray {
+  private int[] mData;
+  private int mSize;
+
+  public ManagedIntArray(int startingCapacity) {
+    mData = new int[startingCapacity];
+  }
+
+  public ManagedIntArray(ManagedIntArray a) {
+    int size = a.size();
+    mData = new int[size];
+    System.arraycopy(a.array(), 0, mData, 0, size);
+    mSize = size;
+  }
+
+  public void ensureCapacity(int capacity) {
+    growIfNecessary(capacity);
+  }
+
+  public int[] array() {
+    return mData;
+  }
+
+  public int size() {
+    return mSize;
+  }
+
+  public void add(int value) {
+    growIfNecessary(mSize + 1);
+    mData[mSize] = value;
+    mSize++;
+  }
+
+  public int get(int index) {
+    return mData[index];
+  }
+
+  public void reverse() {
+    int halfN = mSize / 2;
+    for (int i = 0, j = mSize; i < halfN; i++, j--) {
+      int tmp = mData[i];
+      mData[i] = mData[j];
+      mData[j] = tmp;
+    }
+  }
+
+  public void clear() {
+    mSize = 0;
+  }
+
+  private void growIfNecessary(int minCapacity) {
+    int currentCapacity = mData.length;
+    if (currentCapacity < minCapacity) {
+      int desiredCapacity = currentCapacity;
+      do {
+        desiredCapacity *= 2;
+      } while (desiredCapacity < minCapacity);
+
+      int[] newData = new int[desiredCapacity];
+      System.arraycopy(mData, 0, newData, 0, mSize);
+      mData = newData;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ManagedIntArray that = (ManagedIntArray) o;
+
+    if (mSize != that.mSize) return false;
+    for (int i = 0; i < mSize; i++) {
+      if (mData[i] != that.mData[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 0;
+    for (int i = 0; i < mSize; i++) {
+      result = 31 * result + mData[i];
+    }
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder b = new StringBuilder();
+
+    b.append('[');
+    if (mSize > 0) {
+      b.append(mData[0]);
+      for (int i = 1; i < mSize; i++) {
+        b.append(", ");
+        b.append(mData[i]);
+      }
+    }
+    b.append(']');
+
+    return b.toString();
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/heap/AllocationTracker.java
+++ b/stetho/src/main/java/com/facebook/stetho/heap/AllocationTracker.java
@@ -1,0 +1,194 @@
+package com.facebook.stetho.heap;
+
+import android.os.Debug;
+import android.os.Environment;
+import android.os.SystemClock;
+import com.facebook.stetho.common.LogUtil;
+import org.apache.harmony.dalvik.ddmc.DdmVmInternal;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Instrumented allocation tracker similar to {@link Debug#startAllocCounting()} but
+ * with the ability to inspect specific allocations.  Multiple file formats are supported,
+ * including one which loads in the Chrome Developer Tools UI.
+ *
+ * @see #start(String)
+ * @see #stop()
+ */
+public class AllocationTracker {
+  public static final int FORMAT_DDMS = 2;
+  public static final int FORMAT_GRIMSEY = 3;
+
+  @Nullable
+  private static volatile TrackingInfo sTrackingInfo;
+
+  private static final AtomicInteger sProfileCount = new AtomicInteger(0);
+
+  /**
+   * Begin recording allocations, storing the results in {@code nameOrPath}.  File format is
+   * determined automatically by suffix:
+   * <ul>
+   * <li>{@code .allocs} - DDMS' internal format, visualized by the Android Monitor tool</li>
+   * <li>{@code .grimsey} - Stetho's custom format, visualized by
+   * {@code ./scripts/allocviewer.py}</li>
+   * </ul>
+   * <p />
+   * Defaults to the Grimsey file format if none of the above are specified.
+   *
+   * @param nameOrPath Base name of the file or absolute path.  If basename is provided it will
+   *     be adjusted if necessary to store into
+   *     {@link Environment#getExternalStorageDirectory()}.
+   *
+   * @throws IllegalStateException Allocation tracking is already started.
+   */
+  public static void start(String nameOrPath) {
+    start(nameOrPath, determineFileFormat(nameOrPath));
+  }
+
+  private static int determineFileFormat(String nameOrPath) {
+    String suffix = getFilenameSuffix(nameOrPath);
+    switch (suffix) {
+      case ".allocs": return FORMAT_DDMS;
+      case ".grimsey":
+      default: return FORMAT_GRIMSEY;
+    }
+  }
+
+  @Nullable
+  private static String getFilenameSuffix(String filename) {
+    int dotIndex = filename.lastIndexOf('.');
+    if (dotIndex >= 0) {
+      return filename.substring(dotIndex, filename.length());
+    }
+    return null;
+  }
+
+  /**
+   * @see #start(String)
+   */
+  public static void start(String nameOrPath, int fileFormat) {
+    signalStart(determineStoragePath(nameOrPath).getPath(), fileFormat);
+    DdmVmInternal.enableRecentAllocations(true);
+    Debug.startAllocCounting();
+  }
+
+  private static File determineStoragePath(String filename) {
+    File file = new File(filename);
+    if (file.isAbsolute()) {
+      return file;
+    }
+    return new File(Environment.getExternalStorageDirectory(), filename);
+  }
+
+  /**
+   * Stop recording allocations and write the result to the file specified in
+   * {@link #start(String)}.
+   * <p/>
+   * This method may have significant overhead, possibly suspending the VM for a long period of
+   * time if there have been a large number of allocations.
+   */
+  public static void stop() {
+    Debug.stopAllocCounting();
+    int totalAllocCount = Debug.getGlobalAllocCount();
+    byte[] rawData = DdmVmInternal.getRecentAllocations();
+    DdmVmInternal.enableRecentAllocations(false);
+    saveDataQuietly(rawData, sProfileCount.incrementAndGet());
+    signalStop();
+    int capturedAllocCount = fastParseAllocationCount(rawData);
+    if (capturedAllocCount < totalAllocCount) {
+      LogUtil.e("Allocation tracking overrun: allocated " + totalAllocCount +
+          " (max " + capturedAllocCount + ")");
+    }
+    LogUtil.i("Processed " + capturedAllocCount + " allocations");
+  }
+
+  /**
+   * Quickly parse out the number of allocation entries.
+   *
+   * @see DdmAllocationParser
+   */
+  private static int fastParseAllocationCount(byte[] rawData) {
+    ByteBuffer buf = ByteBuffer.wrap(rawData);
+    return buf.getShort(3);
+  }
+
+  private static void saveDataQuietly(
+      byte[] rawData,
+      int snapshotNum) {
+    long startTimeMs = SystemClock.elapsedRealtime();
+    final TrackingInfo trackingInfo = sTrackingInfo;
+    try {
+      switch (trackingInfo.format) {
+        case FORMAT_DDMS:
+          saveRawData(trackingInfo.filename, rawData);
+          break;
+        case FORMAT_GRIMSEY:
+          saveGrimsey(trackingInfo.filename, rawData);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown format " + trackingInfo.format);
+      }
+      long elapsed = SystemClock.elapsedRealtime() - startTimeMs;
+      LogUtil.i("Wrote " + trackingInfo.filename + " in " + elapsed + " ms");
+    } catch (IOException e) {
+      LogUtil.e(e,
+          "Failed to write %s (do you have WRITE_EXTERNAL_STORAGE permission?)",
+          trackingInfo.filename);
+    }
+  }
+
+  /**
+   * Determine if {@link #start} has been called without a matching {@link #stop}.
+   */
+  public static boolean isStarted() {
+    return sTrackingInfo != null;
+  }
+
+  private static synchronized void signalStart(String filename, int fileFormat) {
+    if (sTrackingInfo != null) {
+      throw new IllegalStateException("Concurrent tracing not allowed");
+    }
+    sTrackingInfo = new TrackingInfo(filename, fileFormat);
+  }
+
+  private static void signalStop() {
+    sTrackingInfo = null;
+  }
+
+  private static void saveRawData(String file, byte[] rawData) throws IOException {
+    FileOutputStream out = new FileOutputStream(file);
+    try {
+      out.write(rawData);
+    } finally {
+      out.close();
+    }
+  }
+
+  private static void saveGrimsey(
+      String filename,
+      byte[] rawData) throws IOException {
+    GrimseyConverter writer = new GrimseyConverter(new FileOutputStream(filename));
+    try {
+      writer.writeDDMSData(rawData);
+    } finally {
+      writer.close();
+    }
+  }
+
+  private static class TrackingInfo {
+    public final String filename;
+    public final int format;
+
+    public TrackingInfo(String filename, int format) {
+      this.filename = filename;
+      this.format = format;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/heap/DdmAllocationParser.java
+++ b/stetho/src/main/java/com/facebook/stetho/heap/DdmAllocationParser.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.heap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+
+@NotThreadSafe
+public class DdmAllocationParser {
+  private final ByteBuffer mData;
+  @Nullable private EagerlyLoadedData mEagerlyLoadedData;
+  private int mNumAllocsRead;
+  private int mNumStackFramesRead;
+  private int mNumStackFramesExpected;
+
+  public DdmAllocationParser(ByteBuffer data) {
+    mData = data;
+    resetAllocationOffset();
+  }
+
+  public void resetAllocationOffset() {
+    mData.position(getHeader().headerLen);
+    mNumAllocsRead = 0;
+    mNumStackFramesRead = -1;
+    mNumStackFramesExpected = 0;
+  }
+
+  public boolean readNextAllocation(Allocation allocation) {
+    Header header = getHeader();
+    if (mNumAllocsRead == header.numAllocs) {
+      return false;
+    }
+
+    int entryStartPos = mData.position();
+
+    allocation.size = mData.getInt();
+    allocation.threadId = mData.getShort() & 0xffff;
+    allocation.classIndex = mData.getShort() & 0xffff;
+    allocation.stackDepth = mData.get() & 0xff;
+
+    mData.position(entryStartPos + header.entryHeaderLen);
+
+    mNumAllocsRead++;
+    mNumStackFramesRead = 0;
+    mNumStackFramesExpected = allocation.stackDepth;
+
+    return true;
+  }
+
+  public boolean readNextStackFrame(Method method) {
+    if (mNumStackFramesRead == mNumStackFramesExpected) {
+      return false;
+    }
+
+    int stackStartPos = mData.position();
+
+    method.classNameIndex = mData.getShort() & 0xffff;
+    method.nameIndex = mData.getShort() & 0xffff;
+
+    method.sourceIndex = mData.getShort() & 0xffff;
+    method.lineNumber = mData.getShort() & 0xffff;
+
+    mData.position(stackStartPos + getHeader().stackFrameLen);
+
+    mNumStackFramesRead++;
+    return true;
+  }
+
+  @Nonnull
+  public Header getHeader() {
+    return getEagerlyLoadedData().header;
+  }
+
+  public String getClassName(int index) {
+    return getEagerlyLoadedData().classNames[index];
+  }
+
+  public String getPrettyClassName(int index) {
+    return formatClassName(getClassName(index));
+  }
+
+  private static String formatClassName(String raw) {
+    StringBuilder pretty = new StringBuilder();
+
+    int array = 0;
+    int offset = 0;
+    while (raw.charAt(offset) == '[') {
+      offset++;
+      array++;
+    }
+
+    int len = raw.length() - offset;
+
+    // Handle fully qualified class name
+    if (len >= 2 && raw.charAt(offset) == 'L' && raw.charAt(offset + len - 1) == ';') {
+      pretty.append(raw.substring(offset + 1, offset + len - 1).replace('/', '.'));
+    } else {
+      String typeName = formatPrimitiveType(raw.charAt(offset));
+      if (typeName != null) {
+        pretty.append(typeName);
+      } else {
+        // Not sure what this is, just append it...
+        pretty.append(raw.substring(offset));
+      }
+    }
+
+    while (array-- > 0) {
+      pretty.append("[]");
+    }
+
+    return pretty.toString();
+  }
+
+  @Nullable
+  private static String formatPrimitiveType(char typeLabel) {
+    switch (typeLabel) {
+      case 'C': return "char";
+      case 'B': return "byte";
+      case 'Z': return "boolean";
+      case 'S': return "short";
+      case 'I': return "int";
+      case 'J': return "long"; // not a typo, J is long :)
+      case 'F': return "float";
+      case 'D': return "double";
+      default:
+        return null;
+    }
+  }
+
+  public String getMethodName(int index) {
+    return getEagerlyLoadedData().methodNames[index];
+  }
+
+  public String getSourceName(int index) {
+    return getEagerlyLoadedData().sourceNames[index];
+  }
+
+  @Nonnull
+  private EagerlyLoadedData getEagerlyLoadedData() {
+    if (mEagerlyLoadedData == null) {
+      mEagerlyLoadedData = readEagerlyLoadedData(mData);
+    }
+    return mEagerlyLoadedData;
+  }
+
+  private static EagerlyLoadedData readEagerlyLoadedData(ByteBuffer data) {
+    EagerlyLoadedData holder = new EagerlyLoadedData();
+    Header header = new Header();
+    holder.header = header;
+
+    data.position(0);
+    readHeader(header, data);
+
+    holder.classNames = new String[header.numClassNames];
+    holder.methodNames = new String[header.numMethodNames];
+    holder.sourceNames = new String[header.numSourceNames];
+
+    data.position(header.stringsOffset);
+    readStrings(holder.classNames, data);
+    readStrings(holder.methodNames, data);
+    readStrings(holder.sourceNames, data);
+
+    return holder;
+  }
+
+  private static void readHeader(Header header, ByteBuffer data) {
+    header.headerLen = data.get() & 0xff;
+    header.entryHeaderLen = data.get() & 0xff;
+    header.stackFrameLen = data.get() & 0xff;
+    header.numAllocs = data.getShort() & 0xffff;
+    header.stringsOffset = data.getInt();
+    header.numClassNames = data.getShort() & 0xffff;
+    header.numMethodNames = data.getShort() & 0xffff;
+    header.numSourceNames = data.getShort() & 0xffff;
+  }
+
+  private static void readStrings(String[] strings, ByteBuffer data) {
+    try {
+      for (int i = 0; i < strings.length; i++) {
+        int strLength = data.getInt();
+        int byteLength = strLength * 2;
+        strings[i] = new String(
+            data.array(),
+            data.arrayOffset() + data.position(),
+            byteLength,
+            "UTF-16");
+        data.position(data.position() + byteLength);
+      }
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static class EagerlyLoadedData {
+    public Header header;
+    public String[] classNames;
+    public String[] methodNames;
+    public String[] sourceNames;
+  }
+
+  public static class Header {
+    public int headerLen;
+    public int entryHeaderLen;
+    public int stackFrameLen;
+    public int numAllocs;
+    public int stringsOffset;
+    public int numClassNames;
+    public int numMethodNames;
+    public int numSourceNames;
+  }
+
+  public static class Allocation {
+    public int size;
+    public int threadId;
+    public int classIndex;
+    public int stackDepth;
+  }
+
+  public static class Method {
+    public int classNameIndex;
+    public int nameIndex;
+    public int sourceIndex;
+    public int lineNumber;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/heap/GrimseyConverter.java
+++ b/stetho/src/main/java/com/facebook/stetho/heap/GrimseyConverter.java
@@ -1,0 +1,477 @@
+package com.facebook.stetho.heap;
+
+import android.util.SparseArray;
+import android.util.SparseBooleanArray;
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.ManagedIntArray;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Formatter for the Stetho native format known as "Grimsey".
+ */
+@NotThreadSafe
+class GrimseyConverter {
+  /**
+   * DDMS captures limit the stack depth to 16 which means we have to apply a heuristic
+   * to guess whether a particular stack is part of a larger one already partly known.  For
+   * instance, suppose the max depth was 4 and we had a set of allocations that looked like:
+   *
+   * <pre>
+   *   java.lang.String
+   *     at Foo.formatDebugInfo
+   *     at Foo.doMethodInternal
+   *     at Foo.method
+   *     at Program.processInput
+   *
+   *   java.lang.Integer
+   *     at Bar.doMethodInternal
+   *     at Bar.method
+   *     at Program.processInput
+   *     at Program.main
+   *
+   *   java.util.ArrayList
+   *     at StringBuilder.toString
+   *     at StringBuilderUtil.format
+   *     at Foo.formatDebugInfo
+   *     at Foo.doMethodInternal
+   * </pre>
+   *
+   * A human interpreting this can easily assume that the tree should look like:
+   *
+   * <pre>
+   *   Program.main
+   *     Program.processInput
+   *       Foo.method
+   *         Foo.doMethodInternal
+   *           Foo.formatDebugInfo [java.lang.String]
+   *             StringBuilderUtil.format
+   *               StringBuilder.toString [java.util.ArrayList]
+   *       Bar.method
+   *         Bar.doMethodInternal [java.lang.Integer]
+   * </pre>
+   *
+   * Our algorithm takes a pessimistic approach and assumes that any caller of the outermost
+   * frame can be a possible caller and therefore may write ambiguous information in the
+   * resulting format.  It's necessary that the visualizer disambiguates accordingly.
+   */
+  private static final int DDMS_MAX_STACK_DEPTH = 16;
+
+  private static final int FORMAT_MAGIC = 0x12131415;
+  private static final int FORMAT_VERSION = 1;
+
+  private final CustomCodedOutputStream mOut;
+
+  public GrimseyConverter(OutputStream out) {
+    if (!(out instanceof BufferedOutputStream)) {
+      out = new BufferedOutputStream(out, 2048);
+    }
+    mOut = new CustomCodedOutputStream(out);
+  }
+
+  /**
+   * Write allocations from a raw DDMS data segment.  This class is responsible for both
+   * parsing and converting due to the fact that the parser can be greatly optimized
+   * when translating to the Grimsey format.
+   */
+  public void writeDDMSData(byte[] rawData) throws IOException {
+    DdmAllocationParser parser = new DdmAllocationParser(ByteBuffer.wrap(rawData));
+
+    DdmAllocationParser.Header header = parser.getHeader();
+    boolean[] knownClasses = new boolean[header.numClassNames];
+    HashMap<MethodKey, Integer> knownMethods = new HashMap<>(header.numMethodNames);
+    SparseArray<SparseBooleanArray> knownCallersByMethod = new SparseArray<>();
+
+    MethodKey scratchMethodKey = new MethodKey();
+    ManagedIntArray scratchStack = new ManagedIntArray(64);
+
+    writeHeader();
+
+    DdmAllocationParser.Allocation scratchAllocation = new DdmAllocationParser.Allocation();
+    DdmAllocationParser.Method scratchMethod = new DdmAllocationParser.Method();
+    while (parser.readNextAllocation(scratchAllocation)) {
+      writeClassDescriptorIfNew(parser, knownClasses, scratchAllocation.classIndex);
+
+      scratchStack.clear();
+      scratchStack.ensureCapacity(scratchAllocation.stackDepth);
+
+      // Stack traversal is from inner-most frames to outer-most.  That is, the 0th stack
+      // frame is the one which performed the allocation.
+      while (parser.readNextStackFrame(scratchMethod)) {
+        scratchMethodKey.set(scratchMethod);
+
+        writeClassDescriptorIfNew(parser, knownClasses, scratchMethod.classNameIndex);
+
+        Integer methodId = knownMethods.get(scratchMethodKey);
+        if (methodId == null) {
+          methodId = knownMethods.size();
+          StringBuilder methodName = new StringBuilder();
+          methodName.append(parser.getMethodName(scratchMethod.nameIndex));
+          methodName.append('(');
+          methodName.append(parser.getSourceName(scratchMethod.sourceIndex));
+          methodName.append(':');
+          methodName.append(scratchMethod.lineNumber);
+          methodName.append(')');
+          writeMethodDescriptor(
+              methodId,
+              scratchMethod.classNameIndex,
+              methodName.toString());
+          knownMethods.put(new MethodKey(scratchMethodKey), methodId);
+        }
+
+        scratchStack.add(methodId);
+      }
+
+      for (int i = 0; i < scratchAllocation.stackDepth - 1; i++) {
+        int methodId = scratchStack.get(i);
+        int callerMethodId = scratchStack.get(i + 1);
+        SparseBooleanArray callers = knownCallersByMethod.get(methodId);
+        if (callers == null) {
+          callers = new SparseBooleanArray(8);
+          knownCallersByMethod.put(methodId, callers);
+        }
+        callers.put(callerMethodId, true);
+      }
+    }
+
+    HashMap<ManagedIntArray, Integer> knownStacks = new HashMap<>();
+    ManagedIntArray scratchFullStack = new ManagedIntArray(64);
+
+    parser.resetAllocationOffset();
+
+    // Loop again now that we can reconstruct full call stacks
+    while (parser.readNextAllocation(scratchAllocation)) {
+      scratchStack.clear();
+      scratchStack.ensureCapacity(scratchAllocation.stackDepth);
+
+      while (parser.readNextStackFrame(scratchMethod)) {
+        scratchMethodKey.set(scratchMethod);
+        scratchStack.add(knownMethods.get(scratchMethodKey));
+      }
+
+      // Get the outer-most known frame and work back from there to try to reconstruct
+      // the full stack.
+      Integer stackId = knownStacks.get(scratchStack);
+      if (stackId == null) {
+        stackId = knownStacks.size();
+        knownStacks.put(new ManagedIntArray(scratchStack), stackId);
+
+        if (scratchStack.size() < DDMS_MAX_STACK_DEPTH) {
+          writeStackDescriptor(stackId, scratchStack);
+        } else {
+          scratchFullStack.clear();
+          scratchFullStack.ensureCapacity(scratchStack.size() + 24);
+          for (int i = 0; i < scratchStack.size(); i++) {
+            scratchFullStack.add(scratchStack.get(i));
+          }
+
+          int outermostMethodId = scratchStack.get(scratchStack.size() - 1);
+          SparseBooleanArray callers;
+          while (true) {
+            callers = knownCallersByMethod.get(outermostMethodId);
+            if (callers == null || callers.size() == 0) {
+              break;
+            }
+
+            int callersN = callers.size();
+            if (callersN > 1) {
+              // TODO: This is actually quite a serious limitation, though it is not
+              // currently known to happen in practice.  Need more testing/verification...
+              LogUtil.e("Ignoring multiple possible call stacks from: " + scratchStack);
+              LogUtil.e(
+                  " -> outermostMethodId=" + outermostMethodId +
+                      "; callers=" + callers);
+            }
+
+            outermostMethodId = callers.keyAt(0);
+            scratchFullStack.add(outermostMethodId);
+          }
+
+          writeStackDescriptor(stackId, scratchFullStack);
+        }
+      }
+
+      writeAllocation(
+          scratchAllocation.threadId,
+          scratchAllocation.size,
+          scratchAllocation.classIndex,
+          0 /* timestamp */,
+          stackId);
+    }
+  }
+
+  public void close() throws IOException {
+    Buffer.emptyPool();
+    mOut.close();
+  }
+
+  private void writeClassDescriptorIfNew(
+      DdmAllocationParser parser,
+      boolean[] knownClasses,
+      int classIndex)
+      throws IOException {
+    if (!knownClasses[classIndex]) {
+      writeClassDescriptor(classIndex, parser.getPrettyClassName(classIndex));
+      knownClasses[classIndex] = true;
+    }
+  }
+
+  private void swapAndRelease(
+      Buffer buffer,
+      CustomCodedOutputStream out,
+      SizeEncoding sizeEncoding) throws IOException {
+    byte[] data = buffer.buf.leakByteArray();
+    int size = buffer.buf.size();
+    switch (sizeEncoding) {
+      case PROTOBUF:
+        out.writeRawVarint32(size);
+        break;
+      case GRIMSEY:
+        out.writeRawLittleEndian32(size);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown encoding " + sizeEncoding);
+    }
+    out.writeRawBytes(data, 0, size);
+    buffer.release();
+  }
+
+  private void writeHeader() throws IOException {
+    Buffer buf = Buffer.acquire();
+    buf.out.writeUInt32(1 /* magic */, FORMAT_MAGIC);
+    buf.out.writeUInt32(2 /* format_version */, FORMAT_VERSION);
+    swapAndRelease(buf, mOut, SizeEncoding.GRIMSEY);
+  }
+
+  private void writeClassDescriptor(int classId, String className) throws IOException {
+    Buffer frame = Buffer.acquire();
+    frame.out.writeTagLengthDelim(1 /* class_descriptor */);
+    Buffer data = Buffer.acquire();
+    data.out.writeUInt32(1 /* class_id */, classId);
+    data.out.writeString(2 /* class_name */, className);
+    swapAndRelease(data, frame.out, SizeEncoding.PROTOBUF);
+    swapAndRelease(frame, mOut, SizeEncoding.GRIMSEY);
+  }
+
+  private void writeMethodDescriptor(int methodId, int classId, String methodName)
+      throws IOException {
+    Buffer frame = Buffer.acquire();
+    frame.out.writeTagLengthDelim(2 /* method_descriptor */);
+    Buffer data = Buffer.acquire();
+    data.out.writeUInt32(1 /* method_id */, methodId);
+    data.out.writeUInt32(2 /* class_id */, classId);
+    data.out.writeString(3 /* method_name */, methodName);
+    swapAndRelease(data, frame.out, SizeEncoding.PROTOBUF);
+    swapAndRelease(frame, mOut, SizeEncoding.GRIMSEY);
+  }
+
+  private void writeStackDescriptor(int stackId, ManagedIntArray frames) throws IOException {
+    Buffer frame = Buffer.acquire();
+    frame.out.writeTagLengthDelim(3 /* stack_descriptor */);
+    Buffer data = Buffer.acquire();
+    data.out.writeUInt32(1 /* stack_id */, stackId);
+    int N = frames.size();
+    for (int i = 0; i < N; i++) {
+      data.out.writeUInt32(2 /* method_id */, frames.get(i));
+    }
+    swapAndRelease(data, frame.out, SizeEncoding.PROTOBUF);
+    swapAndRelease(frame, mOut, SizeEncoding.GRIMSEY);
+  }
+
+  private void writeAllocation(
+      int threadId,
+      int size,
+      int classId,
+      int timestamp,
+      int stackId) throws IOException {
+    Buffer frame = Buffer.acquire();
+    frame.out.writeTagLengthDelim(4 /* allocation */);
+    Buffer data = Buffer.acquire();
+    data.out.writeUInt32(1 /* thread_id */, threadId);
+    data.out.writeUInt32(2 /* size */, size);
+    data.out.writeUInt32(3 /* class_id */, classId);
+    data.out.writeUInt32(4 /* timestamp */, timestamp);
+    data.out.writeUInt32(5 /* stack_id */, stackId);
+    swapAndRelease(data, frame.out, SizeEncoding.PROTOBUF);
+    swapAndRelease(frame, mOut, SizeEncoding.GRIMSEY);
+  }
+
+  private static class StackDescriptor {
+    public final int stackId;
+    public final ArrayList<Integer> methods;
+
+    public StackDescriptor(int stackId, ArrayList<Integer> methods) {
+      this.stackId = stackId;
+      this.methods = methods;
+    }
+  }
+
+  @NotThreadSafe
+  private static class MethodKey {
+    public int classIndex;
+    public int nameIndex;
+    public int filenameIndex;
+    public int lineNumber;
+
+    public MethodKey() {
+    }
+
+    public MethodKey(MethodKey other) {
+      set(other.classIndex, other.nameIndex, other.filenameIndex, other.lineNumber);
+    }
+
+    public void set(DdmAllocationParser.Method method) {
+      set(method.classNameIndex, method.nameIndex, method.sourceIndex, method.lineNumber);
+    }
+
+    public void set(int classIndex, int nameIndex, int filenameIndex, int lineNumber) {
+      this.classIndex = classIndex;
+      this.nameIndex = nameIndex;
+      this.filenameIndex = filenameIndex;
+      this.lineNumber = lineNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      MethodKey methodKey = (MethodKey) o;
+
+      if (classIndex != methodKey.classIndex) return false;
+      if (nameIndex != methodKey.nameIndex) return false;
+      if (filenameIndex != methodKey.filenameIndex) return false;
+      return lineNumber == methodKey.lineNumber;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = classIndex;
+      result = 31 * result + nameIndex;
+      result = 31 * result + filenameIndex;
+      result = 31 * result + lineNumber;
+      return result;
+    }
+  }
+
+  private enum SizeEncoding {
+    PROTOBUF,
+    GRIMSEY,
+  }
+
+  private static class CustomCodedOutputStream {
+    private final OutputStream mOut;
+
+    public CustomCodedOutputStream(OutputStream out) {
+      mOut = out;
+    }
+
+    public void writeUInt32(int fieldNumber, int value) throws IOException {
+      writeTagVarint(fieldNumber);
+      writeRawVarint32(value);
+    }
+
+    public void writeString(int fieldNumber, String value) throws IOException {
+      writeTagLengthDelim(fieldNumber);
+      byte[] valueBytes = value.getBytes("UTF-8");
+      writeRawVarint32(valueBytes.length);
+      writeRawBytes(valueBytes);
+    }
+
+    public void writeTagVarint(int fieldNumber) throws IOException {
+      writeRawVarint32(makeTag(fieldNumber, 0 /* WIRETYPE_VARINT */));
+    }
+
+    public void writeTagLengthDelim(int fieldNumber) throws IOException {
+      writeRawVarint32(makeTag(fieldNumber, 2 /* WIRETYPE_LENGTH_DELIMITED */));
+    }
+
+    public static int makeTag(int fieldNumber, int wireType) {
+      return (fieldNumber << 3) | wireType;
+    }
+
+    public void writeRawVarint32(int value) throws IOException {
+      while (true) {
+        if ((value & ~0x7F) == 0) {
+          writeRawByte(value);
+          return;
+        } else {
+          writeRawByte((value & 0x7F) | 0x80);
+          value >>>= 7;
+        }
+      }
+    }
+
+    public void writeRawLittleEndian32(int value) throws IOException {
+      writeRawByte(value & 0xff);
+      writeRawByte((value >> 8) & 0xff);
+      writeRawByte((value >> 16) & 0xff);
+      writeRawByte((value >> 24) & 0xff);
+    }
+
+    public void writeRawByte(int value) throws IOException {
+      mOut.write(value);
+    }
+
+    public void writeRawBytes(byte[] value) throws IOException {
+      mOut.write(value);
+    }
+
+    public void writeRawBytes(byte[] value, int offset, int length) throws IOException {
+      mOut.write(value, offset, length);
+    }
+
+    public void close() throws IOException {
+      mOut.close();
+    }
+  }
+
+  private static class LeakyByteArrayOutputStream extends ByteArrayOutputStream {
+    public byte[] leakByteArray() {
+      return buf;
+    }
+  }
+
+  @NotThreadSafe
+  private static class Buffer {
+    @Nullable private static Buffer head;
+    @Nullable private Buffer next;
+
+    public final LeakyByteArrayOutputStream buf;
+    public final CustomCodedOutputStream out;
+
+    public static Buffer acquire() {
+      Buffer prevHead = head;
+      if (head != null) {
+        head = head.next;
+        return prevHead;
+      } else {
+        return new Buffer();
+      }
+    }
+
+    public static void emptyPool() {
+      head = null;
+    }
+
+    public Buffer() {
+      buf = new LeakyByteArrayOutputStream();
+      out = new CustomCodedOutputStream(buf);
+    }
+
+    public void release() {
+      buf.reset();
+
+      next = head;
+      head = this;
+    }
+  }
+}

--- a/stetho/src/main/java/org/apache/harmony/dalvik/ddmc/DdmVmInternal.java
+++ b/stetho/src/main/java/org/apache/harmony/dalvik/ddmc/DdmVmInternal.java
@@ -1,0 +1,9 @@
+package org.apache.harmony.dalvik.ddmc;
+
+// Linker stub for:
+// https://android.googlesource.com/platform/libcore/+/android-5.1.0_r1/dalvik/src/main/java/org/apache/harmony/dalvik/ddmc/DdmVmInternal.java
+public class DdmVmInternal {
+    native public static void enableRecentAllocations(boolean enable);
+    native public static boolean getRecentAllocationStatus();
+    native public static byte[] getRecentAllocations();
+}


### PR DESCRIPTION
This introduces a UI that demonstrates how the functionality can be used
and adds support to do microscoped instrumentation with output to the
newly introduced Grimsey file format.

Ultimately the intention is to wire up a comprehensive toolchain that
can interoperate between Chrome's allocation profiler ("Heap Timeline")
and a more advanced / customized toolchain available for the Grimsey
format.