### PR TITLE
Improve ViewGroupDescriptor by removing unnecessary stuff

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -10,12 +10,10 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
-import com.facebook.stetho.inspector.elements.Descriptor;
 
 import javax.annotation.Nullable;
 
@@ -25,7 +23,6 @@ final class WindowDescriptor extends ChainedDescriptor<Window> implements Highli
     View decorView = element.peekDecorView();
     if (decorView != null) {
       children.store(decorView);
-      registerDecorView(decorView);
     }
   }
 
@@ -34,14 +31,5 @@ final class WindowDescriptor extends ChainedDescriptor<Window> implements Highli
   public View getViewForHighlighting(Object element) {
     Window window = (Window) element;
     return window.peekDecorView();
-  }
-
-  private void registerDecorView(View decorView) {
-    if (decorView instanceof ViewGroup) {
-      Descriptor descriptor = getHost().getDescriptor(decorView);
-      if (descriptor instanceof ViewGroupDescriptor) {
-        ((ViewGroupDescriptor) descriptor).registerDecorView((ViewGroup) decorView);
-      }
-    }
   }
 }


### PR DESCRIPTION
Marking a `ViewGroup` as a `decorView` was a necessary optimization due to the old `getChildCount` + `getChildAt` protocol. Now that we've transitioned to `getChildren(Accumulator)`, we don't need to do linear scans in order to answer those questions. Technically, the linear scan adds up to a quadratic scan for decor views, but they only have 1 child so that didn't matter. It did make the code a bit nasty.

And since we don't need the decor view marking anymore, and since the `View` --> `Element` cache was moved out of `ViewGroupDescriptor.ElementContext` into `ViewGroupDescriptor` ( #206 ), that means we can just delete `ViewGroupDescriptor.ElementContext`. This saves 1 allocation per `ViewGroup`. Hoo-ray :)

Closes #205 