### PR TITLE
Implementation of DialogFragment support for Elements

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/DialogFragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/DialogFragmentAccessor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common.android;
+
+import android.app.Dialog;
+
+public interface DialogFragmentAccessor<DIALOG_FRAGMENT, FRAGMENT, FRAGMENT_MANAGER>
+    extends FragmentAccessor<FRAGMENT, FRAGMENT_MANAGER> {
+  public Dialog getDialog(DIALOG_FRAGMENT dialogFragment);
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
@@ -15,7 +15,7 @@ import android.view.View;
 import javax.annotation.Nullable;
 
 public interface FragmentAccessor<FRAGMENT, FRAGMENT_MANAGER> {
-  public static final int NO_ID = View.NO_ID;
+  public static final int NO_ID = 0;
 
   @Nullable
   public FRAGMENT_MANAGER getFragmentManager(FRAGMENT fragment);

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
@@ -29,12 +29,14 @@ import java.util.List;
  * as opaque from the outside.
  *
  * @param <FRAGMENT>
+ * @param <DIALOG_FRAGMENT>
  * @param <FRAGMENT_MANAGER>
  * @param <FRAGMENT_ACTIVITY>
  */
 @NotThreadSafe
 public abstract class FragmentCompat<
     FRAGMENT,
+    DIALOG_FRAGMENT,
     FRAGMENT_MANAGER,
     FRAGMENT_ACTIVITY extends Activity> {
   private static FragmentCompat sFrameworkInstance;
@@ -69,8 +71,12 @@ public abstract class FragmentCompat<
   }
 
   public abstract Class<FRAGMENT> getFragmentClass();
+  public abstract Class<DIALOG_FRAGMENT> getDialogFragmentClass();
   public abstract Class<FRAGMENT_ACTIVITY> getFragmentActivityClass();
+
   public abstract FragmentAccessor<FRAGMENT, FRAGMENT_MANAGER> forFragment();
+  public abstract DialogFragmentAccessor<DIALOG_FRAGMENT, FRAGMENT, FRAGMENT_MANAGER>
+      forDialogFragment();
   public abstract FragmentManagerAccessor<FRAGMENT_MANAGER, FRAGMENT> forFragmentManager();
   public abstract FragmentActivityAccessor<FRAGMENT_ACTIVITY, FRAGMENT_MANAGER> forFragmentActivity();
 
@@ -100,5 +106,4 @@ public abstract class FragmentCompat<
           : null;
     }
   }
-
 }

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
@@ -11,6 +11,8 @@ package com.facebook.stetho.common.android;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.Dialog;
+import android.app.DialogFragment;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.res.Resources;
@@ -21,8 +23,9 @@ import javax.annotation.Nullable;
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 final class FragmentCompatFramework
-    extends FragmentCompat<Fragment, FragmentManager, Activity> {
+    extends FragmentCompat<Fragment, DialogFragment, FragmentManager, Activity> {
   private static final FragmentAccessorFrameworkHoneycomb sFragmentAccessor;
+  private static final DialogFragmentAccessorFramework sDialogFragmentAccessor;
   private static final FragmentManagerAccessorViaReflection<FragmentManager, Fragment>
       sFragmentManagerAccessor = new FragmentManagerAccessorViaReflection<>();
   private static final FragmentActivityAccessorFramework sFragmentActivityAccessor =
@@ -34,11 +37,18 @@ final class FragmentCompatFramework
     } else {
       sFragmentAccessor = new FragmentAccessorFrameworkHoneycomb();
     }
+
+    sDialogFragmentAccessor = new DialogFragmentAccessorFramework(sFragmentAccessor);
   }
 
   @Override
   public Class<Fragment> getFragmentClass() {
     return Fragment.class;
+  }
+
+  @Override
+  public Class<DialogFragment> getDialogFragmentClass() {
+    return DialogFragment.class;
   }
 
   @Override
@@ -49,6 +59,11 @@ final class FragmentCompatFramework
   @Override
   public FragmentAccessorFrameworkHoneycomb forFragment() {
     return sFragmentAccessor;
+  }
+
+  @Override
+  public DialogFragmentAccessorFramework forDialogFragment() {
+    return sDialogFragmentAccessor;
   }
 
   @Override
@@ -105,6 +120,55 @@ final class FragmentCompatFramework
     @Override
     public FragmentManager getChildFragmentManager(Fragment fragment) {
       return fragment.getChildFragmentManager();
+    }
+  }
+
+  private static class DialogFragmentAccessorFramework
+      implements DialogFragmentAccessor<DialogFragment, Fragment, FragmentManager> {
+    private final FragmentAccessor<Fragment, FragmentManager> mFragmentAccessor;
+
+    public DialogFragmentAccessorFramework(
+        FragmentAccessor<Fragment, FragmentManager> fragmentAccessor) {
+      mFragmentAccessor = fragmentAccessor;
+    }
+
+    @Override
+    public Dialog getDialog(DialogFragment dialogFragment) {
+      return dialogFragment.getDialog();
+    }
+
+    @Nullable
+    @Override
+    public FragmentManager getFragmentManager(Fragment fragment) {
+      return mFragmentAccessor.getFragmentManager(fragment);
+    }
+
+    @Override
+    public Resources getResources(Fragment fragment) {
+      return mFragmentAccessor.getResources(fragment);
+    }
+
+    @Override
+    public int getId(Fragment fragment) {
+      return mFragmentAccessor.getId(fragment);
+    }
+
+    @Nullable
+    @Override
+    public String getTag(Fragment fragment) {
+      return mFragmentAccessor.getTag(fragment);
+    }
+
+    @Nullable
+    @Override
+    public View getView(Fragment fragment) {
+      return mFragmentAccessor.getView(fragment);
+    }
+
+    @Nullable
+    @Override
+    public FragmentManager getChildFragmentManager(Fragment fragment) {
+      return mFragmentAccessor.getChildFragmentManager(fragment);
     }
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
@@ -9,7 +9,9 @@
 
 package com.facebook.stetho.common.android;
 
+import android.app.Dialog;
 import android.content.res.Resources;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
@@ -18,9 +20,11 @@ import android.view.View;
 import javax.annotation.Nullable;
 
 final class FragmentCompatSupportLib
-    extends FragmentCompat<Fragment, FragmentManager, FragmentActivity> {
+    extends FragmentCompat<Fragment, DialogFragment, FragmentManager, FragmentActivity> {
   private static final FragmentAccessorSupportLib sFragmentAccessor =
       new FragmentAccessorSupportLib();
+  private static final DialogFragmentAccessorSupportLib sDialogFragmentAccessor =
+      new DialogFragmentAccessorSupportLib();
   private static final FragmentManagerAccessorViaReflection<FragmentManager, Fragment>
       sFragmentManagerAccessor = new FragmentManagerAccessorViaReflection<>();
   private static final FragmentActivityAccessorSupportLib sFragmentActivityAccessor =
@@ -32,6 +36,11 @@ final class FragmentCompatSupportLib
   }
 
   @Override
+  public Class<DialogFragment> getDialogFragmentClass() {
+    return DialogFragment.class;
+  }
+
+  @Override
   public Class<FragmentActivity> getFragmentActivityClass() {
     return FragmentActivity.class;
   }
@@ -39,6 +48,11 @@ final class FragmentCompatSupportLib
   @Override
   public FragmentAccessorSupportLib forFragment() {
     return sFragmentAccessor;
+  }
+
+  @Override
+  public DialogFragmentAccessorSupportLib forDialogFragment() {
+    return sDialogFragmentAccessor;
   }
 
   @Override
@@ -85,6 +99,15 @@ final class FragmentCompatSupportLib
     @Override
     public FragmentManager getChildFragmentManager(Fragment fragment) {
       return fragment.getChildFragmentManager();
+    }
+  }
+
+  private static class DialogFragmentAccessorSupportLib
+      extends FragmentAccessorSupportLib
+      implements DialogFragmentAccessor<DialogFragment, Fragment, FragmentManager> {
+    @Override
+    public Dialog getDialog(DialogFragment dialogFragment) {
+      return dialogFragment.getDialog();
     }
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
@@ -20,6 +20,22 @@ public final class FragmentCompatUtil {
   private FragmentCompatUtil() {
   }
 
+  public static boolean isDialogFragment(Object fragment) {
+    FragmentCompat supportLib = FragmentCompat.getSupportLibInstance();
+    if (supportLib != null &&
+        supportLib.getDialogFragmentClass().isInstance(fragment)) {
+      return true;
+    }
+
+    FragmentCompat framework = FragmentCompat.getFrameworkInstance();
+    if (framework != null &&
+        framework.getDialogFragmentClass().isInstance(fragment)) {
+      return true;
+    }
+
+    return false;
+  }
+
   @Nullable
   public static Object findFragmentForView(View view) {
     Activity activity = ViewUtil.tryGetActivity(view);
@@ -62,10 +78,12 @@ public final class FragmentCompatUtil {
       FragmentCompat compat,
       Activity activity,
       View view) {
-    return findFragmentForViewInFragmentManager(
-        compat,
-        compat.forFragmentActivity().getFragmentManager(activity),
-        view);
+    Object fragmentManager = compat.forFragmentActivity().getFragmentManager(activity);
+    if (fragmentManager != null) {
+      return findFragmentForViewInFragmentManager(compat, fragmentManager, view);
+    } else {
+      return null;
+    }
   }
 
   @Nullable
@@ -76,7 +94,7 @@ public final class FragmentCompatUtil {
     List<?> fragments = compat.forFragmentManager().getAddedFragments(fragmentManager);
 
     if (fragments != null) {
-      for (int i = 0; i < fragments.size(); ++i) {
+      for (int i = 0, N = fragments.size(); i < N; ++i) {
         Object fragment = fragments.get(i);
         Object result = findFragmentForViewInFragment(compat, fragment, view);
         if (result != null) {

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -12,6 +12,7 @@ package com.facebook.stetho.common.android;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.PointF;
 import android.os.Build;
 import android.view.View;
@@ -148,14 +149,31 @@ public final class ViewUtil {
     }
 
     Context context = view.getContext();
-    if (context instanceof Activity) {
-      return (Activity)context;
+
+    Activity activityFromContext = tryGetActivity(context);
+    if (activityFromContext != null) {
+      return activityFromContext;
     }
 
     ViewParent parent = view.getParent();
     if (parent instanceof View) {
       View parentView = (View)parent;
       return tryGetActivity(parentView);
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private static Activity tryGetActivity(Context context) {
+    while (context != null) {
+      if (context instanceof Activity) {
+        return (Activity) context;
+      } else if (context instanceof ContextWrapper) {
+        context = ((ContextWrapper) context).getBaseContext();
+      } else {
+        return null;
+      }
     }
 
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.common.Accumulator;
+import com.facebook.stetho.common.ThreadBound;
+import com.facebook.stetho.common.Util;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class derives from {@link Descriptor} and provides a canonical implementation of
+ * {@link ChainedDescriptor}.<p/>
+ *
+ * This class implements the thread safety enforcement policy prescribed by
+ * {@link ThreadBound}. Namely, that {@link #verifyThreadAccess()}} needs to be called in the
+ * prologue for every method. Your derived class SHOULD NOT call {@link #verifyThreadAccess()}} in
+ * any of its on___() methods.<p/>
+ *
+ * (NOTE: As an optimization, {@link #verifyThreadAccess()} is not actually called in the
+ * prologue for every method. Instead, we rely on {@link DOMProvider#getNodeDescriptor(Object)}
+ * calling it in order to get most of our enforcement coverage. We still call
+ * {@link #verifyThreadAccess()} in a few important methods such as {@link #hook(Object)} and
+ * {@link #unhook(Object)} (anything that writes or is potentially really dangerous if misused).<p/>
+ *
+ * @param <E> the class that this descriptor will be describing for {@link DOMProvider} and
+ * {@link com.facebook.stetho.inspector.protocol.module.DOM}
+ */
+public abstract class AbstractChainedDescriptor<E> extends Descriptor implements ChainedDescriptor {
+
+  private Descriptor mSuper;
+
+  public void setSuper(Descriptor superDescriptor) {
+    Util.throwIfNull(superDescriptor);
+
+    if (superDescriptor != mSuper) {
+      if (mSuper != null) {
+        throw new IllegalStateException();
+      }
+      mSuper = superDescriptor;
+    }
+  }
+
+  final Descriptor getSuper() {
+    return mSuper;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void hook(Object element) {
+    verifyThreadAccess();
+    mSuper.hook(element);
+    onHook((E) element);
+  }
+
+  protected void onHook(E element) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void unhook(Object element) {
+    verifyThreadAccess();
+    onUnhook((E) element);
+    mSuper.unhook(element);
+  }
+
+  protected void onUnhook(E element) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final NodeType getNodeType(Object element) {
+    return onGetNodeType((E) element);
+  }
+
+  protected NodeType onGetNodeType(E element) {
+    return mSuper.getNodeType(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getNodeName(Object element) {
+    return onGetNodeName((E) element);
+  }
+
+  protected String onGetNodeName(E element) {
+    return mSuper.getNodeName(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getLocalName(Object element) {
+    return onGetLocalName((E) element);
+  }
+
+  protected String onGetLocalName(E element) {
+    return mSuper.getLocalName(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final String getNodeValue(Object element) {
+    return onGetNodeValue((E) element);
+  }
+
+  @Nullable
+  public String onGetNodeValue(E element) {
+    return mSuper.getNodeValue(element);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void getChildren(Object element, Accumulator<Object> children) {
+    mSuper.getChildren(element, children);
+    onGetChildren((E) element, children);
+  }
+
+  protected void onGetChildren(E element, Accumulator<Object> children) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void getAttributes(Object element, AttributeAccumulator attributes) {
+    mSuper.getAttributes(element, attributes);
+    onGetAttributes((E) element, attributes);
+  }
+
+  protected void onGetAttributes(E element, AttributeAccumulator attributes) {
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void setAttributesAsText(Object element, String text) {
+    onSetAttributesAsText((E) element, text);
+  }
+
+  protected void onSetAttributesAsText(E element, String text) {
+    mSuper.setAttributesAsText(element, text);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -23,13 +23,13 @@ public abstract class Descriptor implements NodeDescriptor {
   protected Descriptor() {
   }
 
-  void initialize(Host host) {
+  final void initialize(Host host) {
     Util.throwIfNull(host);
     Util.throwIfNotNull(mHost);
     mHost = host;
   }
 
-  boolean isInitialized() {
+  final boolean isInitialized() {
     return mHost != null;
   }
 
@@ -73,13 +73,13 @@ public abstract class Descriptor implements NodeDescriptor {
    * @param text the text argument to be parsed
    * @return a map of attributes to their respective values to be set.
    */
-  protected Map<String, String> parseSetAttributesAsTextArg(String text) {
+  protected static Map<String, String> parseSetAttributesAsTextArg(String text) {
     String value = "";
     String key = "";
     StringBuilder buffer = new StringBuilder();
     Map<String, String> keyValuePairs = new HashMap<>();
     boolean isInsideQuotes = false;
-    for (int i = 0; i < text.length(); ++i) {
+    for (int i = 0, N = text.length(); i < N; ++i) {
       final char c = text.charAt(i);
       if (c == '=') {
         key = buffer.toString();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public final class DescriptorMap {
-  private final Map<Class<?>, Descriptor> mMap = new IdentityHashMap<Class<?>, Descriptor>();
+  private final Map<Class<?>, Descriptor> mMap = new IdentityHashMap<>();
   private boolean mIsInitializing;
   private Descriptor.Host mHost;
 
@@ -53,7 +53,6 @@ public final class DescriptorMap {
     Util.throwIfNotNull(mHost);
 
     mHost = host;
-
     return this;
   }
 
@@ -67,7 +66,7 @@ public final class DescriptorMap {
       final Descriptor descriptor = mMap.get(elementClass);
 
       if (descriptor instanceof ChainedDescriptor) {
-        final ChainedDescriptor<?> chainedDescriptor = (ChainedDescriptor<?>) descriptor;
+        final ChainedDescriptor chainedDescriptor = (ChainedDescriptor) descriptor;
         Class<?> superClass = elementClass.getSuperclass();
         Descriptor superDescriptor = getImpl(superClass);
         chainedDescriptor.setSuper(superDescriptor);
@@ -94,10 +93,8 @@ public final class DescriptorMap {
       if (descriptor != null) {
         return descriptor;
       }
-
       theClass = theClass.getSuperclass();
     }
-
     return null;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -15,10 +15,18 @@ import android.view.Window;
 
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.common.StringUtil;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.common.android.FragmentActivityAccessor;
+import com.facebook.stetho.common.android.FragmentCompat;
+import com.facebook.stetho.common.android.FragmentManagerAccessor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.Descriptor;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
 
 final class ActivityDescriptor
-    extends ChainedDescriptor<Activity> implements HighlightableDescriptor {
+    extends AbstractChainedDescriptor<Activity> implements HighlightableDescriptor {
   @Override
   protected String onGetNodeName(Activity element) {
     String className = element.getClass().getName();
@@ -27,6 +35,9 @@ final class ActivityDescriptor
 
   @Override
   protected void onGetChildren(Activity element, Accumulator<Object> children) {
+    getDialogFragments(FragmentCompat.getSupportLibInstance(), element, children);
+    getDialogFragments(FragmentCompat.getFrameworkInstance(), element, children);
+
     Window window = element.getWindow();
     if (window != null) {
       children.store(window);
@@ -35,13 +46,41 @@ final class ActivityDescriptor
 
   @Override
   public View getViewForHighlighting(Object element) {
-    if (getHost() instanceof AndroidDescriptorHost) {
-      final AndroidDescriptorHost host = (AndroidDescriptorHost)getHost();
+    final Descriptor.Host host = getHost();
+    if (host instanceof AndroidDescriptorHost) {
       Activity activity = (Activity)element;
       Window window = activity.getWindow();
-      return host.getHighlightingView(window);
+      return ((AndroidDescriptorHost) host).getHighlightingView(window);
     }
 
     return null;
+  }
+
+  private static void getDialogFragments(
+      @Nullable FragmentCompat compat,
+      Activity activity,
+      Accumulator<Object> accumulator) {
+    if (compat == null || !compat.getFragmentActivityClass().isInstance(activity)) {
+      return;
+    }
+
+    FragmentActivityAccessor activityAccessor = compat.forFragmentActivity();
+    Object fragmentManager = activityAccessor.getFragmentManager(activity);
+    if (fragmentManager == null) {
+      return;
+    }
+
+    FragmentManagerAccessor fragmentManagerAccessor = compat.forFragmentManager();
+    List<Object> addedFragments = fragmentManagerAccessor.getAddedFragments(fragmentManager);
+    if (addedFragments == null) {
+      return;
+    }
+
+    for (int i = 0, N = addedFragments.size(); i < N; ++i) {
+      final Object fragment = addedFragments.get(i);
+      if (compat.getDialogFragmentClass().isInstance(fragment)) {
+        accumulator.store(fragment);
+      }
+    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -11,6 +11,7 @@ package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Activity;
 import android.app.Application;
+import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.os.Handler;
@@ -77,7 +78,9 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
         .beginInit()
         .register(Activity.class, new ActivityDescriptor())
         .register(AndroidDOMRoot.class, mDOMRoot)
-        .register(Application.class, new ApplicationDescriptor());
+        .register(Application.class, new ApplicationDescriptor())
+        .register(Dialog.class, new DialogDescriptor());
+    DialogFragmentDescriptor.register(mDescriptorMap);
     FragmentDescriptor.register(mDescriptorMap)
         .register(Object.class, new ObjectDescriptor())
         .register(TextView.class, new TextViewDescriptor())

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMRoot.java
@@ -13,12 +13,12 @@ import android.app.Application;
 
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.common.Util;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.NodeType;
 
 // For the root, we use 1 object for both element and descriptor.
 
-final class AndroidDOMRoot extends ChainedDescriptor<AndroidDOMRoot> {
+final class AndroidDOMRoot extends AbstractChainedDescriptor<AndroidDOMRoot> {
   private final Application mApplication;
 
   public AndroidDOMRoot(Application application) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -13,7 +13,7 @@ import android.app.Activity;
 import android.app.Application;
 
 import com.facebook.stetho.common.Accumulator;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.NodeType;
 
 import java.util.Collections;
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
-final class ApplicationDescriptor extends ChainedDescriptor<Application> {
+final class ApplicationDescriptor extends AbstractChainedDescriptor<Application> {
   private final Map<Application, ElementContext> mElementToContextMap =
       Collections.synchronizedMap(new IdentityHashMap<Application, ElementContext>());
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
@@ -9,28 +9,34 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.app.Dialog;
 import android.view.View;
 import android.view.Window;
-
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.Descriptor;
 
 import javax.annotation.Nullable;
 
-final class WindowDescriptor extends AbstractChainedDescriptor<Window>
-    implements HighlightableDescriptor {
+final class DialogDescriptor
+    extends AbstractChainedDescriptor<Dialog> implements HighlightableDescriptor {
   @Override
-  protected void onGetChildren(Window element, Accumulator<Object> children) {
-    View decorView = element.peekDecorView();
-    if (decorView != null) {
-      children.store(decorView);
+  protected void onGetChildren(Dialog element, Accumulator<Object> children) {
+    Window window = element.getWindow();
+    if (window != null) {
+      children.store(window);
     }
   }
 
-  @Override
   @Nullable
+  @Override
   public View getViewForHighlighting(Object element) {
-    Window window = (Window) element;
-    return window.peekDecorView();
+    final Descriptor.Host host = getHost();
+    if (host instanceof AndroidDescriptorHost) {
+      final Dialog dialog = (Dialog) element;
+      return ((AndroidDescriptorHost) host).getHighlightingView(dialog.getWindow());
+    }
+
+    return null;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.app.Dialog;
+import android.view.View;
+
+import com.facebook.stetho.common.Accumulator;
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.common.android.DialogFragmentAccessor;
+import com.facebook.stetho.common.android.FragmentCompat;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
+import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.Descriptor;
+import com.facebook.stetho.inspector.elements.DescriptorMap;
+import com.facebook.stetho.inspector.elements.NodeType;
+
+import javax.annotation.Nullable;
+
+final class DialogFragmentDescriptor
+    extends Descriptor implements ChainedDescriptor, HighlightableDescriptor {
+  private final DialogFragmentAccessor mAccessor;
+  private Descriptor mSuper;
+
+  public static DescriptorMap register(DescriptorMap map) {
+    maybeRegister(map, FragmentCompat.getSupportLibInstance());
+    maybeRegister(map, FragmentCompat.getFrameworkInstance());
+    return map;
+  }
+
+  private static void maybeRegister(DescriptorMap map, @Nullable FragmentCompat compat) {
+    if (compat != null) {
+      Class<?> dialogFragmentClass = compat.getDialogFragmentClass();
+      LogUtil.d("Adding support for %s", dialogFragmentClass);
+      map.register(dialogFragmentClass, new DialogFragmentDescriptor(compat));
+    }
+  }
+
+  private DialogFragmentDescriptor(FragmentCompat compat) {
+    mAccessor = compat.forDialogFragment();
+  }
+
+  @Override
+  public void setSuper(Descriptor superDescriptor) {
+    Util.throwIfNull(superDescriptor);
+
+    if (superDescriptor != mSuper) {
+      if (mSuper != null) {
+        throw new IllegalStateException();
+      }
+      mSuper = superDescriptor;
+    }
+  }
+
+  @Override
+  public void hook(Object element) {
+    mSuper.hook(element);
+  }
+
+  @Override
+  public void unhook(Object element) {
+    mSuper.unhook(element);
+  }
+
+  @Override
+  public NodeType getNodeType(Object element) {
+    return mSuper.getNodeType(element);
+  }
+
+  @Override
+  public String getNodeName(Object element) {
+    return mSuper.getNodeName(element);
+  }
+
+  @Override
+  public String getLocalName(Object element) {
+    return mSuper.getLocalName(element);
+  }
+
+  @Nullable
+  @Override
+  public String getNodeValue(Object element) {
+    return mSuper.getNodeValue(element);
+  }
+
+  @Override
+  public void getChildren(Object element, Accumulator<Object> children) {
+    /**
+     * We do NOT want the children from our super-{@link Descriptor}, which is probably
+     * {@link FragmentDescriptor}. We only want to emit the {@link Dialog}, not the {@link View}.
+     * Therefore, we don't call mSuper.getChildren(), and this is the reason why we don't derive
+     * from {@link AbstractChainedDescriptor} (it doesn't allow a non-chained implementation of
+     * {@link Descriptor#getChildren(Object, Accumulator)}).
+     */
+    children.store(mAccessor.getDialog(element));
+  }
+
+  @Override
+  public void getAttributes(Object element, AttributeAccumulator attributes) {
+    mSuper.getAttributes(element, attributes);
+  }
+
+  @Override
+  public void setAttributesAsText(Object element, String text) {
+    mSuper.setAttributesAsText(element, text);
+  }
+
+  @Nullable
+  @Override
+  public View getViewForHighlighting(Object element) {
+    final Descriptor.Host host = getHost();
+    if (host instanceof AndroidDescriptorHost) {
+      Dialog dialog = mAccessor.getDialog(element);
+      return ((AndroidDescriptorHost) host).getHighlightingView(dialog);
+    }
+
+    return null;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -17,13 +17,13 @@ import com.facebook.stetho.common.android.FragmentAccessor;
 import com.facebook.stetho.common.android.FragmentCompat;
 import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 
 import javax.annotation.Nullable;
 
 final class FragmentDescriptor
-    extends ChainedDescriptor<Object> implements HighlightableDescriptor {
+    extends AbstractChainedDescriptor<Object> implements HighlightableDescriptor {
   private static final String ID_ATTRIBUTE_NAME = "id";
   private static final String TAG_ATTRIBUTE_NAME = "tag";
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -15,13 +15,13 @@ import android.widget.TextView;
 
 import com.facebook.stetho.common.Util;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
-final class TextViewDescriptor extends ChainedDescriptor<TextView> {
+final class TextViewDescriptor extends AbstractChainedDescriptor<TextView> {
   private static final String TEXT_ATTRIBUTE_NAME = "text";
 
   private final Map<TextView, ElementContext> mElementToContextMap =

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -13,12 +13,12 @@ import android.view.View;
 import com.facebook.stetho.common.StringUtil;
 import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 
-final class ViewDescriptor extends ChainedDescriptor<View> implements HighlightableDescriptor {
+final class ViewDescriptor extends AbstractChainedDescriptor<View> implements HighlightableDescriptor {
   private static final String ID_ATTRIBUTE_NAME = "id";
 
   private final MethodInvoker mMethodInvoker;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -14,13 +14,13 @@ import android.view.ViewGroup;
 
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.common.android.FragmentCompatUtil;
-import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
+final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup> {
   /**
    * This is a cache that maps from a View to the Fragment that contains it. If the View isn't
    * contained by a Fragment, then this maps the View to itself. For Views contained by Fragments,
@@ -59,8 +59,14 @@ final class ViewGroupDescriptor extends ChainedDescriptor<ViewGroup> {
       mViewToElementMap.remove(childView);
     }
 
+    /**
+     * Note that we do NOT emit DialogFragments. Those get emitted via ActivityDescriptor.
+     * We do the check here so that we can also cache the cost of calling
+     * {@link FragmentCompatUtil#isDialogFragment(Object)}.
+     */
+
     Object fragment = FragmentCompatUtil.findFragmentForView(childView);
-    if (fragment != null) {
+    if (fragment != null && !FragmentCompatUtil.isDialogFragment(fragment)) {
       mViewToElementMap.put(childView, fragment);
       return fragment;
     } else {


### PR DESCRIPTION
This adds support for `DialogFragment`s in the Elements tab. This code is actually pretty straightforward now that tree diffing is checked in ( #204 ), without which I had code with all sorts of clowney timers and stuff.

I refactored `ChainedDescriptor` to be an interface, with `AbstractChainedDescriptor` sitting on top of it as the canonical implementation. I did this because `DialogFragmentDescriptor` has the unique problem of needing to *not* pass-through to its super-descriptor's implementation of `getChildren()`. If it did, then it would emit both the `View` and the `Window` which contains the `View`. Not only would this be silly, but it causes an infinite loop and would break all sorts of stuff that assume each element can only appear once in the DOM tree. I chose this approach because the code was much simpler, and free of future bug and clown hazards, versus allowing classes that derive from `AbstractChainedDescriptor` to override the non-"on" methods (e.g. to implement a non-chained version of `getChildren`).

Note that this does *not* add support for `Dialog`s that aren't attached to a `DialogFragment`. If anyone needs that then we can go ahead and add support for it, but for now it's just so much simpler to just support `DialogFragment`.

Closes #193