### PR TITLE
Fix crash in Elements when it's not the startup tab

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDOMProvider.java
@@ -35,6 +35,8 @@ import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.NodeDescriptor;
 import com.facebook.stetho.inspector.elements.ObjectDescriptor;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +50,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
   private final AndroidDOMRoot mDOMRoot;
   private final ViewHighlighter mHighlighter;
   private final InspectModeHandler mInspectModeHandler;
-  private Listener mListener;
+  private @Nullable Listener mListener;
 
   // We don't yet have an an implementation for reliably detecting fine-grained changes in the
   // View tree. So, for now at least, we have a timer that runs every so often and just reports
@@ -147,7 +149,7 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
     if (mListener == null && mIsReportChangesTimerPosted) {
       mIsReportChangesTimerPosted = false;
       removeCallbacks(mReportChangesTimer);
-    } else  if (mListener != null && !mIsReportChangesTimerPosted) {
+    } else if (mListener != null && !mIsReportChangesTimerPosted) {
       mIsReportChangesTimerPosted = true;
       postDelayed(mReportChangesTimer, REPORT_CHANGED_INTERVAL_MS);
     }
@@ -213,12 +215,16 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
 
   @Override
   public void onAttributeModified(Object element, String name, String value) {
-    mListener.onAttributeModified(element, name, value);
+    if (mListener != null) {
+      mListener.onAttributeModified(element, name, value);
+    }
   }
 
   @Override
   public void onAttributeRemoved(Object element, String name) {
-    mListener.onAttributeRemoved(element, name);
+    if (mListener != null) {
+      mListener.onAttributeRemoved(element, name);
+    }
   }
 
   // AndroidDescriptorHost implementation
@@ -349,7 +355,9 @@ final class AndroidDOMProvider implements DOMProvider, AndroidDescriptorHost {
               mHighlighter.setHighlightedView(view, INSPECT_HOVER_COLOR);
 
               if (event.getAction() == MotionEvent.ACTION_UP) {
-                mListener.onInspectRequested(view);
+                if (mListener != null) {
+                  mListener.onInspectRequested(view);
+                }
               }
             }
           }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -102,6 +102,7 @@ public class DOM implements ChromeDevtoolsDomain {
         if (mShadowDOM == null) {
           mShadowDOM = new ShadowDOM(mDOMProvider.getRootElement());
           createShadowDOMUpdate().commit();
+          mDOMProvider.setListener(new ProviderListener());
         } else if (rootElement != mShadowDOM.getRootElement()) {
           // We don't support changing the root element. This is handled differently by the
           // protocol than updates to an existing DOM, and we don't have any case in our
@@ -402,12 +403,7 @@ public class DOM implements ChromeDevtoolsDomain {
     @Override
     protected synchronized void onFirstPeerRegistered() {
       mDOMProvider = mDOMProviderFactory.create();
-      mDOMProvider.postAndWait(new Runnable() {
-        @Override
-        public void run() {
-          mDOMProvider.setListener(new ProviderListener());
-        }
-      });
+      // We dont call mDOMProvider.setListener() until the first DOM.getDocument request.
     }
 
     @Override


### PR DESCRIPTION
`AndroidDOMProvider` was always trying to push updates over to `DOM`, but `DOM` hadn't created its `mShadowDOM` yet. Woops.

This NPE actually found a performance issue: even if the Elements tab isn't clicked on, we were still running our diffing workflow which rescans the whole UI tree every second. We shouldn't be running this code until you click on the Elements tab, which causes the first `DOM.getDocument()` call, which is a much better time to boot that up.

Closes #215 