### PR TITLE
add interfaces and registry for async pretty print 

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -36,6 +36,7 @@ import com.facebook.stetho.inspector.ChromeDiscoveryHandler;
 import com.facebook.stetho.inspector.elements.android.ActivityTracker;
 import com.facebook.stetho.inspector.elements.android.AndroidDOMConstants;
 import com.facebook.stetho.inspector.elements.android.AndroidDOMProviderFactory;
+import com.facebook.stetho.inspector.network.DefaultAsyncPrettyPrinterRegistry;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.module.CSS;
 import com.facebook.stetho.inspector.protocol.module.Console;
@@ -141,7 +142,7 @@ public class Stetho {
         modules.add(new DOMStorage(context));
         modules.add(new HeapProfiler());
         modules.add(new Inspector());
-        modules.add(new Network(context));
+        modules.add(new Network(context, new DefaultAsyncPrettyPrinterRegistry()));
         modules.add(new Page(context));
         modules.add(new Profiler());
         modules.add(new Runtime());

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+public interface AsyncPrettyPrinter {
+  String print(byte[] payload);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+public interface AsyncPrettyPrinterFactory {
+  AsyncPrettyPrinter getInstance(String headerName, String headerValue);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterRegistry.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterRegistry.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+public interface AsyncPrettyPrinterRegistry {
+  public boolean register (String headerName, AsyncPrettyPrinterFactory factory);
+  public AsyncPrettyPrinterFactory lookup (String headerName);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultAsyncPrettyPrinterRegistry.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultAsyncPrettyPrinterRegistry.java
@@ -19,16 +19,7 @@ public class DefaultAsyncPrettyPrinterRegistry implements AsyncPrettyPrinterRegi
 
   @GuardedBy("this")
   private final Map<String, AsyncPrettyPrinterFactory> mRegistry = new HashMap<>();
-
-  private static DefaultAsyncPrettyPrinterRegistry sInstance;
-
-  public static synchronized DefaultAsyncPrettyPrinterRegistry getInstance() {
-    if (sInstance == null) {
-      sInstance = new DefaultAsyncPrettyPrinterRegistry();
-    }
-    return sInstance;
-  }
-
+  
   public synchronized boolean register(String headerName, AsyncPrettyPrinterFactory factory) {
     if (mRegistry.containsKey(headerName)) {
       return false;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultAsyncPrettyPrinterRegistry.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultAsyncPrettyPrinterRegistry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultAsyncPrettyPrinterRegistry implements AsyncPrettyPrinterRegistry {
+
+  @GuardedBy("this")
+  private final Map<String, AsyncPrettyPrinterFactory> mRegistry = new HashMap<>();
+
+  private static DefaultAsyncPrettyPrinterRegistry sInstance;
+
+  public static synchronized DefaultAsyncPrettyPrinterRegistry getInstance() {
+    if (sInstance == null) {
+      sInstance = new DefaultAsyncPrettyPrinterRegistry();
+    }
+    return sInstance;
+  }
+
+  public synchronized boolean register(String headerName, AsyncPrettyPrinterFactory factory) {
+    if (mRegistry.containsKey(headerName)) {
+      return false;
+    }
+    mRegistry.put(headerName, factory);
+    return true;
+  }
+
+  @Nullable
+  public synchronized AsyncPrettyPrinterFactory lookup(String headerName) {
+    return mRegistry.get(headerName);
+  }
+
+  public synchronized void unregister(String headerName) {
+    mRegistry.remove(headerName);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -21,23 +21,31 @@ public class NetworkPeerManager extends ChromePeerManager {
 
   private final ResponseBodyFileManager mResponseBodyFileManager;
 
+  private final AsyncPrettyPrinterRegistry mAsyncPrettyPrinterRegistry;
+
   @Nullable
   public static synchronized NetworkPeerManager getInstanceOrNull() {
     return sInstance;
   }
 
-  public static synchronized NetworkPeerManager getOrCreateInstance(Context context) {
+  public static synchronized NetworkPeerManager getOrCreateInstance(
+      Context context,
+      AsyncPrettyPrinterRegistry prettyPrinterRegistry) {
     if (sInstance == null) {
       sInstance = new NetworkPeerManager(
           new ResponseBodyFileManager(
-              context.getApplicationContext()));
+              context.getApplicationContext()),
+          prettyPrinterRegistry);
     }
     return sInstance;
   }
 
-  public NetworkPeerManager(ResponseBodyFileManager responseBodyFileManager) {
+  public NetworkPeerManager(
+      ResponseBodyFileManager responseBodyFileManager,
+      AsyncPrettyPrinterRegistry asyncPrettyPrinterRegistry) {
     mResponseBodyFileManager = responseBodyFileManager;
     setListener(mTempFileCleanup);
+    mAsyncPrettyPrinterRegistry = asyncPrettyPrinterRegistry;
   }
 
   public ResponseBodyFileManager getResponseBodyFileManager() {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -19,6 +19,7 @@ import com.facebook.stetho.inspector.jsonrpc.JsonRpcPeer;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcResult;
 import com.facebook.stetho.inspector.jsonrpc.protocol.JsonRpcError;
 import com.facebook.stetho.inspector.network.NetworkPeerManager;
+import com.facebook.stetho.inspector.network.AsyncPrettyPrinterRegistry;
 import com.facebook.stetho.inspector.network.ResponseBodyData;
 import com.facebook.stetho.inspector.network.ResponseBodyFileManager;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
@@ -33,8 +34,10 @@ public class Network implements ChromeDevtoolsDomain {
   private final NetworkPeerManager mNetworkPeerManager;
   private final ResponseBodyFileManager mResponseBodyFileManager;
 
-  public Network(Context context) {
-    mNetworkPeerManager = NetworkPeerManager.getOrCreateInstance(context);
+  public Network(Context context, AsyncPrettyPrinterRegistry asyncPrettyPrinterRegistry) {
+    mNetworkPeerManager = NetworkPeerManager.getOrCreateInstance(
+        context,
+        asyncPrettyPrinterRegistry);
     mResponseBodyFileManager = mNetworkPeerManager.getResponseBodyFileManager();
   }
 


### PR DESCRIPTION
This commit adds two interfaces to be used for AsyncPrettyPrinter. It also adds DefaultAsyncPrettyPrinterRegistry which will be used to register header name to their respective async pretty printers.