### PR TITLE
Support PRAGMA statements explicitly

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -147,7 +147,8 @@ public class DatabasePeerManager extends ChromePeerManager {
         return executeUpdateDelete(database, query, handler);
       } else if (firstWord.equalsIgnoreCase("INSERT")) {
         return executeInsert(database, query, handler);
-      } else if (firstWord.equalsIgnoreCase("SELECT")) {
+      } else if (firstWord.equalsIgnoreCase("SELECT") ||
+          firstWord.equalsIgnoreCase("PRAGMA")) {
         return executeSelect(database, query, handler);
       } else {
         return executeRawQuery(database, query, handler);
@@ -202,6 +203,7 @@ public class DatabasePeerManager extends ChromePeerManager {
     database.execSQL(query);
     return handler.handleRawQuery();
   }
+
   private SQLiteDatabase openDatabase(String databaseName) throws SQLiteException {
     Util.throwIfNull(databaseName);
     File databaseFile = mContext.getDatabasePath(databaseName);


### PR DESCRIPTION
PRAGMA requires query/rawQuery to work and yields an error when we were
using execSQL anyway.  This simple change makes it possible to use
PRAGMA to yield results.

Closes #214