### PR TITLE
Add support for EXPLAIN queries run via Web SQL console.

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -9,7 +9,6 @@
 
 package com.facebook.stetho.inspector.database;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -143,19 +142,20 @@ public class DatabasePeerManager extends ChromePeerManager {
     Util.throwIfNull(handler);
     SQLiteDatabase database = openDatabase(databaseName);
     try {
-      String firstWord = getFirstWord(query);
-
-      if (firstWord.equalsIgnoreCase("UPDATE") || firstWord.equalsIgnoreCase("DELETE")) {
-        return executeUpdateDelete(database, query, handler);
-      } else if (firstWord.equalsIgnoreCase("INSERT")) {
-        return executeInsert(database, query, handler);
-      } else if (firstWord.equalsIgnoreCase("SELECT") ||
-          firstWord.equalsIgnoreCase("PRAGMA")) {
-        return executeSelect(database, query, handler);
-      } else {
-        return executeRawQuery(database, query, handler);
+      String firstWordUpperCase = getFirstWord(query).toUpperCase();
+      switch (firstWordUpperCase) {
+        case "UPDATE":
+        case "DELETE":
+          return executeUpdateDelete(database, query, handler);
+        case "INSERT":
+          return executeInsert(database, query, handler);
+        case "SELECT":
+        case "PRAGMA":
+        case "EXPLAIN":
+          return executeSelect(database, query, handler);
+        default:
+          return executeRawQuery(database, query, handler);
       }
-
     } finally {
       database.close();
     }


### PR DESCRIPTION
Hello,

I noticed that `EXPLAIN` queries run via the Web SQL console were failing with the error: *Queries can be performed using SQLiteDatabase query or rawQuery methods only.*

I tried to add `EXPLAIN` support by going through the path for `SELECT`, and sure enough, I got back a usable result. 