### PR TITLE
Change version to 1.2.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-VERSION_NAME=1.1.1
+VERSION_NAME=1.2.0-SNAPSHOT
 GROUP=com.facebook.stetho


### PR DESCRIPTION
This was supposed to be done after 1.1.1 was cut but I must have forgot.
Sigh, we need to bring in the gradle release plugin :)