### PR TITLE
Autodetect stetho-js-rhino and use it

### DIFF
--- a/stetho-js-rhino/README.md
+++ b/stetho-js-rhino/README.md
@@ -21,26 +21,8 @@ or Maven:
 Make sure that you depend on the main `stetho` dependency too.
 
 ### Putting it together
-The JavaScript integration is similar to standard Stetho integration.
-The main difference is with the WebKitInspector used.
-There is a simple initialization step which occurs in your `Application` class:
-
-```java
-public class MyApplication extends Application {
-  public void onCreate() {
-    super.onCreate();
-+   JsRuntimeBuilder jsRuntimeBuilder = new JsRuntimeBuilder(this);
-    Stetho.initialize(
-        Stetho.newInitializerBuilder(this)
-            .enableDumpapp(Stetho.defaultDumperPluginsProvider(this))
--           .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(context))
-+           .enableWebKitInspector(jsRuntimeBuilder.jsInspectorModulesProvider())
-            .build());
-  }
-}
-```
-
-You can still use other Stetho plugins with this approach, for instance the network helpers stetho-okhttp and stetho-urlconnection will still work if activated properly.
+The Rhino JavaScript integration is automatically detected by Stetho and is
+enabled simply by adding the `stetho-js-rhino` dependency to your project.
 
 ### How it works
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -9,6 +9,7 @@
 
 package com.facebook.stetho.inspector.protocol.module;
 
+import android.content.Context;
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.inspector.console.RuntimeRepl;
 import com.facebook.stetho.inspector.console.RuntimeReplFactory;
@@ -20,6 +21,7 @@ import com.facebook.stetho.inspector.jsonrpc.JsonRpcResult;
 import com.facebook.stetho.inspector.jsonrpc.protocol.JsonRpcError;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsMethod;
+import com.facebook.stetho.inspector.runtime.RhinoDetectingRuntimeReplFactory;
 import com.facebook.stetho.json.ObjectMapper;
 import com.facebook.stetho.json.annotation.JsonProperty;
 import com.facebook.stetho.json.annotation.JsonValue;
@@ -49,8 +51,27 @@ public class Runtime implements ChromeDevtoolsDomain {
 
   private final RuntimeReplFactory mReplFactory;
 
+  /**
+   * @deprecated Provided for ABI compatibility
+   * @see Runtime(Context)
+   */
+  @Deprecated
   public Runtime() {
-    this(new DefaultRuntimeReplFactory());
+    this(new RuntimeReplFactory() {
+      @Override
+      public RuntimeRepl newInstance() {
+        return new RuntimeRepl() {
+          @Override
+          public Object evaluate(String expression) throws Throwable {
+            return "Not supported with legacy Runtime module";
+          }
+        };
+      }
+    });
+  }
+
+  public Runtime(Context context) {
+    this(new RhinoDetectingRuntimeReplFactory(context));
   }
 
   public Runtime(RuntimeReplFactory replFactory) {
@@ -560,15 +581,4 @@ public class Runtime implements ChromeDevtoolsDomain {
     }
   }
 
-  private static class DefaultRuntimeReplFactory implements RuntimeReplFactory {
-    @Override
-    public RuntimeRepl newInstance() {
-      return new RuntimeRepl() {
-        @Override
-        public Object evaluate(String expression) throws Exception {
-          return "Not supported";
-        }
-      };
-    }
-  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/runtime/RhinoDetectingRuntimeReplFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/runtime/RhinoDetectingRuntimeReplFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.runtime;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.inspector.console.RuntimeRepl;
+import com.facebook.stetho.inspector.console.RuntimeReplFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Attempts to locate stetho-js-rhino in the classpath and use it if available.  Otherwise falls
+ * back to a no-op version which informs folks that they can include stetho-js-rhino for more
+ * advanced functionality.
+ * <p />
+ * Eventually we should develop a kind of service locator somehow to make this more discoverable
+ * and generalized.  For now with only one official implementation however it seems like overkill.
+ */
+public class RhinoDetectingRuntimeReplFactory implements RuntimeReplFactory {
+  private final Context mContext;
+
+  private boolean mSearchedForRhinoJs;
+  private RuntimeReplFactory mRhinoReplFactory;
+  private RuntimeException mRhinoJsUnexpectedError;
+
+  public RhinoDetectingRuntimeReplFactory(Context context) {
+    mContext = context;
+  }
+
+  @Override
+  public RuntimeRepl newInstance() {
+    if (!mSearchedForRhinoJs) {
+      mSearchedForRhinoJs = true;
+      try {
+        mRhinoReplFactory = findRhinoReplFactory(mContext);
+      } catch (RuntimeException e) {
+        mRhinoJsUnexpectedError = e;
+      }
+    }
+    if (mRhinoReplFactory != null) {
+      return mRhinoReplFactory.newInstance();
+    } else {
+      return new RuntimeRepl() {
+        @Override
+        public Object evaluate(String expression) throws Exception {
+          if (mRhinoJsUnexpectedError != null) {
+            return "stetho-js-rhino threw: " + mRhinoJsUnexpectedError.toString();
+          } else {
+            return "Not supported without stetho-js-rhino dependency";
+          }
+        }
+      };
+    }
+  }
+
+  @Nullable
+  private static RuntimeReplFactory findRhinoReplFactory(Context context) throws RuntimeException {
+    try {
+      Class<?> jsRuntimeReplFactory =
+          Class.forName("com.facebook.stetho.rhino.JsRuntimeReplFactoryBuilder");
+      Method defaultFactoryMethod =
+          jsRuntimeReplFactory.getDeclaredMethod("defaultFactory", Context.class);
+      return (RuntimeReplFactory) defaultFactoryMethod.invoke(null, context);
+    } catch (ClassNotFoundException e) {
+      LogUtil.i("Error finding stetho-js-rhino, cannot enable console evaluation!");
+      return null;
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
This diff focuses on making stetho-js-rhino a bit more of a first-party
citizen in Stetho, with the default implementation both detecting it
more conveniently and automatically using it if available or
recommending users add it to the classpath so that it will be
autodetected.