### PR TITLE
Fix RequestBodyHelper body inflation

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/RequestBodyHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/RequestBodyHelper.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterOutputStream;
 
 /**
  * Helper which manages provides computed request sizes as well as transparent decompression.
@@ -44,7 +44,7 @@ public class RequestBodyHelper {
     if (DecompressionHelper.GZIP_ENCODING.equals(contentEncoding)) {
       deflatingOutput = GunzippingOutputStream.create(deflatedOutput);
     } else if (DecompressionHelper.DEFLATE_ENCODING.equals(contentEncoding)) {
-      deflatingOutput = new DeflaterOutputStream(deflatedOutput);
+      deflatingOutput = new InflaterOutputStream(deflatedOutput);
     } else {
       deflatingOutput = deflatedOutput;
     }


### PR DESCRIPTION
Following up from #111 and testing #248 

This was using the wrong class (Deflate is the compression, inflate is the reverse). `InflaterOutputStream` properly inflates the request body, and works for our project when I tested out the change.

CC @jasta