### PR TITLE
Rhino autodetect singleton (based on jasta:rhino-autodetect)

### DIFF
--- a/stetho-js-rhino/README.md
+++ b/stetho-js-rhino/README.md
@@ -21,8 +21,19 @@ or Maven:
 Make sure that you depend on the main `stetho` dependency too.
 
 ### Putting it together
+
 The Rhino JavaScript integration is automatically detected by Stetho and is
 enabled simply by adding the `stetho-js-rhino` dependency to your project.
+
+If you want to configure the JavaScript environment you can pass your own variables, classes, packages and functions
+by getting a handle to the runtime factory:
+
+```java
+JsRuntimeReplFactoryBuilder jsRuntimeFactory = JsRuntimeReplFactoryBuilder.getInstance(context);
+jsRuntimeFactory.addVariable("foo", "bar"); // Pass to JavaScript  var foo = "bar";
+```
+
+For more details see the next sections.
 
 ### How it works
 

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
@@ -49,6 +49,11 @@ public class JsRuntimeReplFactoryBuilder {
   private static final String SOURCE_NAME = "chrome";
 
   /**
+   * Singleton instance.
+   */
+  private static volatile JsRuntimeReplFactoryBuilder sInstance;
+
+  /**
    * Android application context.
    */
   private final android.content.Context mContext;
@@ -74,11 +79,18 @@ public class JsRuntimeReplFactoryBuilder {
    */
   private final Map<String, Function> mFunctions = new HashMap<>();
 
-  public static RuntimeReplFactory defaultFactory(@NonNull android.content.Context context) {
-    return new JsRuntimeReplFactoryBuilder(context).build();
+  public static synchronized JsRuntimeReplFactoryBuilder getInstance(@NonNull android.content.Context context) {
+    if (sInstance == null) {
+      sInstance = new JsRuntimeReplFactoryBuilder(context);
+    }
+    return sInstance;
   }
 
-  public JsRuntimeReplFactoryBuilder(@NonNull android.content.Context context) {
+  public static synchronized RuntimeReplFactory defaultFactory(@NonNull android.content.Context context) {
+    return getInstance(context).build();
+  }
+
+  private JsRuntimeReplFactoryBuilder(@NonNull android.content.Context context) {
     mContext = context;
 
     // We import the app's package name by default

--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -274,7 +274,7 @@ public class Stetho {
       provideIfDesired(new Network(mContext));
       provideIfDesired(new Page(mContext));
       provideIfDesired(new Profiler());
-      provideIfDesired(new Runtime());
+      provideIfDesired(new Runtime(mContext));
       provideIfDesired(new Worker());
       if (Build.VERSION.SDK_INT >= DatabaseConstants.MIN_API_LEVEL) {
         provideIfDesired(new Database(mContext, new DefaultDatabaseFilesProvider(mContext)));


### PR DESCRIPTION
This is an enhancement to the branch jasta:rhino-autodetect that provides an easy way for apps to configure the JavaScript runtime while using the new built-in autodtection.

Sorry if I don't reply in the next two weeks, I'll be in holidays and I might not have access to network (or even a laptop).