### PR TITLE
Add schema caching functionality for async pretty printing

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterSchemaManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterSchemaManager.java
@@ -17,33 +17,33 @@ import java.util.Map;
 
 public final class AsyncPrettyPrinterSchemaManager {
   private static AsyncPrettyPrinterSchemaManager sSchemaManager;
-  private Map<URL, String> sSchemaCache;
+  private Map<URL, String> mSchemaCache;
 
-  public static void ensureInitialized() {
+  private static void ensureInitialized() {
     if (sSchemaManager == null) {
       sSchemaManager = new AsyncPrettyPrinterSchemaManager(new HashMap<URL, String>());
     }
   }
 
   private AsyncPrettyPrinterSchemaManager(Map<URL, String> schemaCache) {
-    sSchemaCache = schemaCache;
+    mSchemaCache = schemaCache;
   }
 
   public synchronized void put(URL schemaUrl, String schema) {
-      sSchemaCache.put(schemaUrl, schema);
+    mSchemaCache.put(schemaUrl, schema);
   }
 
   @Nullable
   public synchronized String get(URL schemaUrl) {
-    return sSchemaCache.get(schemaUrl);
+    return mSchemaCache.get(schemaUrl);
   }
 
-  @Nullable
   public static AsyncPrettyPrinterSchemaManager getInstance() {
+    ensureInitialized();
     return sSchemaManager;
   }
 
   public void clearCache() {
-    sSchemaCache = new HashMap<>();
+    mSchemaCache = new HashMap<>();
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterSchemaManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterSchemaManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+import javax.annotation.Nullable;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class AsyncPrettyPrinterSchemaManager {
+  private static AsyncPrettyPrinterSchemaManager sSchemaManager;
+  private Map<URL, String> sSchemaCache;
+
+  public static void ensureInitialized() {
+    if (sSchemaManager == null) {
+      sSchemaManager = new AsyncPrettyPrinterSchemaManager(new HashMap<URL, String>());
+    }
+  }
+
+  private AsyncPrettyPrinterSchemaManager(Map<URL, String> schemaCache) {
+    sSchemaCache = schemaCache;
+  }
+
+  public synchronized void put(URL schemaUrl, String schema) {
+      sSchemaCache.put(schemaUrl, schema);
+  }
+
+  @Nullable
+  public synchronized String get(URL schemaUrl) {
+    return sSchemaCache.get(schemaUrl);
+  }
+
+  @Nullable
+  public static AsyncPrettyPrinterSchemaManager getInstance() {
+    return sSchemaManager;
+  }
+
+  public void clearCache() {
+    sSchemaCache = new HashMap<>();
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import android.util.Log;
 import com.facebook.stetho.common.ExceptionUtil;
 import com.facebook.stetho.common.Util;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import android.util.Log;
 import com.facebook.stetho.common.ExceptionUtil;
 import com.facebook.stetho.common.Util;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -65,9 +65,6 @@ public class NetworkPeerManager extends ChromePeerManager {
         mAsyncPrettyPrinterRegistry = new AsyncPrettyPrinterRegistry();
         mPrettyPrinterInitializer.populatePrettyPrinters(mAsyncPrettyPrinterRegistry);
       }
-      if (AsyncPrettyPrinterSchemaManager.getInstance() == null) {
-        AsyncPrettyPrinterSchemaManager.ensureInitialized();
-      }
       mResponseBodyFileManager.cleanupFiles();
     }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -65,6 +65,9 @@ public class NetworkPeerManager extends ChromePeerManager {
         mAsyncPrettyPrinterRegistry = new AsyncPrettyPrinterRegistry();
         mPrettyPrinterInitializer.populatePrettyPrinters(mAsyncPrettyPrinterRegistry);
       }
+      if (AsyncPrettyPrinterSchemaManager.getInstance() == null) {
+        AsyncPrettyPrinterSchemaManager.ensureInitialized();
+      }
       mResponseBodyFileManager.cleanupFiles();
     }
 
@@ -72,6 +75,7 @@ public class NetworkPeerManager extends ChromePeerManager {
     protected void onLastPeerUnregistered() {
       mResponseBodyFileManager.cleanupFiles();
       AsyncPrettyPrinterExecutorHolder.shutdown();
+      AsyncPrettyPrinterSchemaManager.getInstance().clearCache();
     }
   };
 }

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
@@ -75,7 +75,6 @@ public class AsyncPrettyPrintResponseBodyTest {
   public void setup() {
     mPrettyPrinterTestFactory = new PrettyPrinterTestFactory();
     mAsyncPrettyPrinterRegistry = new AsyncPrettyPrinterRegistry();
-    AsyncPrettyPrinterSchemaManager.ensureInitialized();
     mAsyncPrettyPrinterRegistry.register(TEST_HEADER_NAME, mPrettyPrinterTestFactory);
     AsyncPrettyPrinterExecutorHolder.ensureInitialized();
   }

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
@@ -19,10 +19,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Matchers.any;
 
-import com.facebook.stetho.inspector.network.AsyncPrettyPrinter;
-import com.facebook.stetho.inspector.network.AsyncPrettyPrinterExecutorHolder;
-import dalvik.annotation.TestTargetClass;
+import com.facebook.stetho.inspector.network.AsyncPrettyPrinterSchemaManager;
+
 import org.junit.Before;
+import org.junit.runner.RunWith;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -37,6 +37,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +48,7 @@ public class AsyncPrettyPrintResponseBodyTest {
   private static final String TEST_HEADER_NAME = "header name";
   private static final String TEST_HEADER_VALUE = "header value";
   private static final String PRETTY_PRINT_PREFIX = "pretty printed result: ";
+  private static final String TEST_URL = "https://www.facebook.com";
   private static final String[] UNREGISTERED_HEADER_NAMES = {"unregistered header name 1",
       "unregistered header name 2",
       "unregistered header name 3"};
@@ -67,24 +69,27 @@ public class AsyncPrettyPrintResponseBodyTest {
 
   private AsyncPrettyPrinterRegistry mAsyncPrettyPrinterRegistry;
   private PrettyPrinterTestFactory mPrettyPrinterTestFactory;
-  private ResponseBodyFileManager mResponseBodyFileManager;
+  private AsyncPrettyPrinterSchemaManager mAsyncPrettyPrinterSchemaFileManager;
 
   @Before
   public void setup() {
     mPrettyPrinterTestFactory = new PrettyPrinterTestFactory();
-    mResponseBodyFileManager = mock(ResponseBodyFileManager.class);
     mAsyncPrettyPrinterRegistry = new AsyncPrettyPrinterRegistry();
+    AsyncPrettyPrinterSchemaManager.ensureInitialized();
     mAsyncPrettyPrinterRegistry.register(TEST_HEADER_NAME, mPrettyPrinterTestFactory);
     AsyncPrettyPrinterExecutorHolder.ensureInitialized();
   }
 
   @Test
   public void testAsyncPrettyPrinterResult() throws IOException {
+
     StringWriter out = new StringWriter();
     PrintWriter writer = new PrintWriter(out);
     AsyncPrettyPrinter mAsyncPrettyPrinter = mPrettyPrinterTestFactory.getInstance(
         TEST_HEADER_NAME,
         TEST_HEADER_VALUE);
+    assert(mPrettyPrinterTestFactory != null);
+    assert(mAsyncPrettyPrinter != null);
     mAsyncPrettyPrinter.printTo(writer, mInputStream);
     assertEquals(PRETTY_PRINT_PREFIX + Arrays.toString(TEST_RESPONSE_BODY), out.toString());
   }
@@ -173,7 +178,7 @@ public class AsyncPrettyPrintResponseBodyTest {
     @Nullable
     protected MatchResult matchAndParseHeader(String headerName, String headerValue) {
       if (headerName.equals(TEST_HEADER_NAME) && headerValue.equals(TEST_HEADER_VALUE)) {
-        return new MatchResult("https://www.facebook.com", PrettyPrinterDisplayType.TEXT);
+        return new MatchResult(TEST_URL, PrettyPrinterDisplayType.TEXT);
       } else {
         return null;
       }

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
@@ -19,10 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Matchers.any;
 
-import com.facebook.stetho.inspector.network.AsyncPrettyPrinterSchemaManager;
-
 import org.junit.Before;
-import org.junit.runner.RunWith;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -81,7 +78,6 @@ public class AsyncPrettyPrintResponseBodyTest {
 
   @Test
   public void testAsyncPrettyPrinterResult() throws IOException {
-
     StringWriter out = new StringWriter();
     PrintWriter writer = new PrintWriter(out);
     AsyncPrettyPrinter mAsyncPrettyPrinter = mPrettyPrinterTestFactory.getInstance(


### PR DESCRIPTION
Right now, one schema is downloaded for every pretty printing instantiated. Often times, async pretty printers use the same schema. 
