### PR TITLE
Fix registration flow for Async Pretty Printer

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterInitializer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterInitializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.network;
+
+/**
+ * Interface that is called if AsyncPrettyPrinterRegistry is unpopulated when
+ * the first peer connects to Stetho. It is responsible for registering header
+ * names and their corresponding pretty printers
+ */
+public interface AsyncPrettyPrinterInitializer {
+
+  /**
+   * Populates AsyncPrettyPrinterRegistry with header names and their corresponding pretty
+   * printers. This is responsible for registering all {@link AsyncPrettyPrinter} to the
+   * provided registry.
+   * @param registry
+   */
+  void populatePrettyPrinters(AsyncPrettyPrinterRegistry registry);
+
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -158,7 +158,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
   }
 
   @Nullable
-   static AsyncPrettyPrinter initAsyncPrettyPrinterForResponse(
+  private static AsyncPrettyPrinter initAsyncPrettyPrinterForResponse(
       InspectorResponse response,
       NetworkPeerManager peerManager) {
     AsyncPrettyPrinterRegistry registry = peerManager.getAsyncPrettyPrinterRegistry();
@@ -184,17 +184,20 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
     }
   }
 
+  //@VisibleForTesting
   @Nullable
-  private static AsyncPrettyPrinter createPrettyPrinterForResponse(
+  static AsyncPrettyPrinter createPrettyPrinterForResponse(
       InspectorResponse response,
-      AsyncPrettyPrinterRegistry registry) {
-    for (int i = 0, count = response.headerCount(); i < count; i++) {
-      AsyncPrettyPrinterFactory factory = registry.lookup(response.headerName(i));
-      if (factory != null) {
-        AsyncPrettyPrinter asyncPrettyPrinter = factory.getInstance(
-            response.headerName(i),
-            response.headerValue(i));
-        return asyncPrettyPrinter;
+      @Nullable AsyncPrettyPrinterRegistry registry) {
+    if (registry != null) {
+      for (int i = 0, count = response.headerCount(); i < count; i++) {
+        AsyncPrettyPrinterFactory factory = registry.lookup(response.headerName(i));
+        if (factory != null) {
+          AsyncPrettyPrinter asyncPrettyPrinter = factory.getInstance(
+              response.headerName(i),
+              response.headerValue(i));
+          return asyncPrettyPrinter;
+        }
       }
     }
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -14,12 +14,13 @@ import java.util.List;
 
 import android.content.Context;
 
+import com.facebook.stetho.common.Util;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcException;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcPeer;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcResult;
 import com.facebook.stetho.inspector.jsonrpc.protocol.JsonRpcError;
+import com.facebook.stetho.inspector.network.AsyncPrettyPrinterInitializer;
 import com.facebook.stetho.inspector.network.NetworkPeerManager;
-import com.facebook.stetho.inspector.network.AsyncPrettyPrinterRegistry;
 import com.facebook.stetho.inspector.network.ResponseBodyData;
 import com.facebook.stetho.inspector.network.ResponseBodyFileManager;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
@@ -87,8 +88,16 @@ public class Network implements ChromeDevtoolsDomain {
     return response;
   }
 
-  public AsyncPrettyPrinterRegistry getAsyncPrettyPrinterRegistry() {
-    return mNetworkPeerManager.getAsyncPrettyPrinterRegistry();
+  /**
+   * Method that allows callers to provide an {@link AsyncPrettyPrinterInitializer} that is
+   * responsible for registering all
+   * {@link com.facebook.stetho.inspector.network.AsyncPrettyPrinter}.
+   * Note that AsyncPrettyPrinterInitializer cannot be null and can only be set once.
+   * @param initializer
+   */
+  public void setPrettyPrinterInitializer(AsyncPrettyPrinterInitializer initializer) {
+    Util.throwIfNull(initializer);
+    mNetworkPeerManager.setPrettyPrinterInitializer(initializer);
   }
 
   private static class GetResponseBodyResponse implements JsonRpcResult {


### PR DESCRIPTION
Right now, pretty printers are instantiated and registered at the start up path. This PR moves these steps to onFirstPeerRegistered() for NetworkPeerManager's listener. 