### PR TITLE
Added the ability to inspect an element's style

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -259,7 +259,6 @@ public class Stetho {
 
     public Iterable<ChromeDevtoolsDomain> finish() {
       provideIfDesired(new Console());
-      provideIfDesired(new CSS());
       provideIfDesired(new Debugger());
       if (Build.VERSION.SDK_INT >= AndroidDOMConstants.MIN_API_LEVEL) {
         Document document = new Document(
@@ -267,6 +266,7 @@ public class Stetho {
                 (Application) mContext.getApplicationContext()));
 
         provideIfDesired(new DOM(document));
+        provideIfDesired(new CSS(document));
       }
       provideIfDesired(new DOMStorage(mContext));
       provideIfDesired(new HeapProfiler());

--- a/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
@@ -65,6 +65,10 @@ public final class ListUtil {
     }
   }
 
+  public static <T> List<T> newImmutableList(T item) {
+    return new OneItemImmutableList<>(item);
+  }
+
   private static interface ImmutableList<E> extends List<E>, RandomAccess {
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -144,4 +144,14 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   protected void onSetAttributesAsText(E element, String text) {
     mSuper.setAttributesAsText(element, text);
   }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void getStyles(Object element, StyleAccumulator accumulator) {
+    mSuper.getStyles(element, accumulator);
+    onGetStyles((E) element, accumulator);
+  }
+
+  protected void onGetStyles(E element, StyleAccumulator accumulator) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -140,6 +140,12 @@ public final class Document extends ThreadBoundProxy {
     mDocumentProvider.setAttributesAsText(element, text);
   }
 
+  public void getElementStyles(Object element, StyleAccumulator styleAccumulator) {
+    NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
+
+    nodeDescriptor.getStyles(element, styleAccumulator);
+  }
+
   public DocumentView getDocumentView() {
     verifyThreadAccess();
     return mShadowDocument;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -33,4 +33,6 @@ public interface NodeDescriptor extends ThreadBound {
   void getAttributes(Object element, AttributeAccumulator attributes);
 
   void setAttributesAsText(Object element, String text);
+
+  void getStyles(Object element, StyleAccumulator accumulator);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -51,4 +51,8 @@ public final class ObjectDescriptor extends Descriptor {
   @Override
   public void setAttributesAsText(Object element, String text) {
   }
+
+  @Override
+  public void getStyles(Object element, StyleAccumulator accumulator) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Origin.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Origin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.json.annotation.JsonValue;
+
+public enum Origin {
+  INJECTED("injected"),
+  USER_AGENT("user-agent"),
+  INSPECTOR("inspector"),
+  REGULAR("regular");
+
+  private final String mValue;
+
+  Origin(String value) {
+    mValue = value;
+  }
+
+  @JsonValue
+  public String getProtocolValue() {
+    return mValue;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleAccumulator.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+public interface StyleAccumulator {
+  void store(String name, String value, boolean isDefault);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -23,6 +23,7 @@ import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.NodeType;
+import com.facebook.stetho.inspector.elements.StyleAccumulator;
 
 import javax.annotation.Nullable;
 
@@ -124,5 +125,9 @@ final class DialogFragmentDescriptor
     }
 
     return null;
+  }
+
+  @Override
+  public void getStyles(Object element, StyleAccumulator styles) {
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -10,18 +10,94 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.view.View;
+import android.view.ViewDebug;
+import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.StringUtil;
 import com.facebook.stetho.common.android.ResourcesUtil;
-import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.AttributeAccumulator;
+import com.facebook.stetho.inspector.elements.StyleAccumulator;
+import com.facebook.stetho.inspector.helper.IntegerFormatter;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 final class ViewDescriptor extends AbstractChainedDescriptor<View> implements HighlightableDescriptor {
-  private static final String ID_ATTRIBUTE_NAME = "id";
+  private static final String ID_NAME = "id";
+  private static final String NONE_VALUE = "(none)";
+  private static final String NONE_MAPPING = "<no mapping>";
 
   private final MethodInvoker mMethodInvoker;
+
+  /**
+   * NOTE: Only access this via {@link #getWordBoundaryPattern}.
+   */
+  @Nullable
+  private Pattern mWordBoundaryPattern;
+
+  /**
+   * NOTE: Only access this via {@link #getViewProperties}.
+   */
+  @Nullable
+  @GuardedBy("this")
+  private volatile List<ViewCSSProperty> mViewProperties;
+
+  private Pattern getWordBoundaryPattern() {
+    if (mWordBoundaryPattern == null) {
+      mWordBoundaryPattern = Pattern.compile("(?<=\\p{Lower})(?=\\p{Upper})");
+    }
+
+    return mWordBoundaryPattern;
+  }
+
+  private List<ViewCSSProperty> getViewProperties() {
+    if (mViewProperties == null) {
+      synchronized (this) {
+        if (mViewProperties == null) {
+          List<ViewCSSProperty> props = new ArrayList<>();
+
+          for (final Method method : View.class.getDeclaredMethods()) {
+            ViewDebug.ExportedProperty annotation =
+                method.getAnnotation(
+                    ViewDebug.ExportedProperty.class);
+
+            if (annotation != null) {
+              props.add(new MethodBackedCSSProperty(
+                  method,
+                  convertViewPropertyNameToCSSName(method.getName()),
+                  annotation));
+            }
+          }
+
+          for (final Field field : View.class.getDeclaredFields()) {
+            ViewDebug.ExportedProperty annotation =
+                field.getAnnotation(
+                    ViewDebug.ExportedProperty.class);
+
+            if (annotation != null) {
+              props.add(new FieldBackedCSSProperty(
+                  field,
+                  convertViewPropertyNameToCSSName(field.getName()),
+                  annotation));
+            }
+          }
+
+          mViewProperties = Collections.unmodifiableList(props);
+        }
+      }
+    }
+
+    return mViewProperties;
+  }
 
   public ViewDescriptor() {
     this(new MethodInvoker());
@@ -44,7 +120,7 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
   protected void onGetAttributes(View element, AttributeAccumulator attributes) {
     String id = getIdAttribute(element);
     if (id != null) {
-      attributes.store(ID_ATTRIBUTE_NAME, id);
+      attributes.store(ID_NAME, id);
     }
   }
 
@@ -69,7 +145,190 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
 
   @Override
   public View getViewForHighlighting(Object element) {
-    return (View)element;
+    return (View) element;
+  }
+
+  @Override
+  protected void onGetStyles(View element, StyleAccumulator styles) {
+
+    List<ViewCSSProperty> properties = getViewProperties();
+    for (int i = 0, size = properties.size(); i < size; i++) {
+      ViewCSSProperty property = properties.get(i);
+      try {
+        getStyleFromValue(
+            element,
+            property.getCSSName(),
+            property.getValue(element),
+            property.getAnnotation(),
+            styles);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        LogUtil.e(e, "failed to get style property " + property.getCSSName() +
+            " of element= " + element.toString());
+      }
+    }
+  }
+
+  private static boolean canIntBeMappedToString(@Nullable ViewDebug.ExportedProperty annotation) {
+    return annotation != null
+        && annotation.mapping() != null
+        && annotation.mapping().length > 0;
+  }
+
+  private static String mapIntToStringUsingAnnotation(
+      int value,
+      @Nullable ViewDebug.ExportedProperty annotation) {
+    if (!canIntBeMappedToString(annotation)) {
+      throw new IllegalStateException("Cannot map using this annotation");
+    }
+
+    for (ViewDebug.IntToString map : annotation.mapping()) {
+      if (map.from() == value) {
+        return map.to();
+      }
+    }
+
+    // no mapping was found even though one was expected ):
+    return NONE_MAPPING;
+  }
+
+  private static boolean canFlagsBeMappedToString(@Nullable ViewDebug.ExportedProperty annotation) {
+    return annotation != null
+        && annotation.flagMapping() != null
+        && annotation.flagMapping().length > 0;
+  }
+
+  private static String mapFlagsToStringUsingAnnotation(
+      int value,
+      @Nullable ViewDebug.ExportedProperty annotation) {
+    if (!canFlagsBeMappedToString(annotation)) {
+      throw new IllegalStateException("Cannot map using this annotation");
+    }
+
+    StringBuilder stringBuilder = null;
+    boolean atLeastOneFlag = false;
+
+    for (ViewDebug.FlagToString flagToString : annotation.flagMapping()) {
+      if (flagToString.outputIf() == ((value & flagToString.mask()) == flagToString.equals())) {
+        if (stringBuilder == null) {
+          stringBuilder = new StringBuilder();
+        }
+
+        if (atLeastOneFlag) {
+          stringBuilder.append(" | ");
+        }
+
+        stringBuilder.append(flagToString.name());
+        atLeastOneFlag = true;
+      }
+    }
+
+    if (atLeastOneFlag) {
+      return stringBuilder.toString();
+    } else {
+      return NONE_MAPPING;
+    }
+  }
+
+  private static boolean isDefaultValue(
+      Float value) {
+    return value == 0.0f;
+  }
+
+  private static boolean isDefaultValue(
+      Integer value,
+      @Nullable ViewDebug.ExportedProperty annotation) {
+    // Mappable ints should always be shown, because enums don't necessarily have
+    // logical "default" values. Thus we mark all of them as not default, so that they
+    // show up in the inspector.
+    if (canFlagsBeMappedToString(annotation) || canIntBeMappedToString(annotation)) {
+      return false;
+    }
+
+    return value == 0;
+  }
+
+  private String convertViewPropertyNameToCSSName(String getterName) {
+    // Split string by uppercase characters. Thankfully since
+    // this is the android source we don't have to worry about
+    // internationalization funk.
+
+    String[] words = getWordBoundaryPattern().split(getterName);
+
+    StringBuilder result = new StringBuilder();
+
+    for (int i = 0; i < words.length; i++) {
+      if (words[i].equals("get") || words[i].equals("m")) {
+        continue;
+      }
+
+      result.append(words[i].toLowerCase());
+
+      if (i < words.length - 1) {
+        result.append('-');
+      }
+    }
+
+    return result.toString();
+  }
+
+  private void getStyleFromValue(
+      View element,
+      String name,
+      Object value,
+      @Nullable ViewDebug.ExportedProperty annotation,
+      StyleAccumulator styles) {
+
+    if (name.equals(ID_NAME)) {
+      getIdStyle(element, styles);
+    } else if (value instanceof Integer) {
+      getStyleFromInteger(name, (Integer) value, annotation, styles);
+    } else if (value instanceof Float) {
+      getStyleFromFloat(name, (Float) value, annotation, styles);
+    }
+  }
+
+  private void getIdStyle(
+      View element,
+      StyleAccumulator styles) {
+
+    @Nullable String id = getIdAttribute(element);
+
+    if (id == null) {
+      styles.store(ID_NAME, NONE_VALUE, false);
+    } else {
+      styles.store(ID_NAME, id, false);
+    }
+  }
+
+  private void getStyleFromInteger(
+      String name,
+      Integer value,
+      @Nullable ViewDebug.ExportedProperty annotation,
+      StyleAccumulator styles) {
+
+    String intValueStr = IntegerFormatter.getInstance().format(value, annotation);
+
+    if (canIntBeMappedToString(annotation)) {
+      styles.store(
+          name,
+          intValueStr + " (" + mapIntToStringUsingAnnotation(value, annotation) + ")",
+          false);
+    } else if (canFlagsBeMappedToString(annotation)) {
+      styles.store(
+          name,
+          intValueStr + " (" + mapFlagsToStringUsingAnnotation(value, annotation) + ")",
+          false);
+    } else {
+      styles.store(name, intValueStr, isDefaultValue(value, annotation));
+    }
+  }
+
+  private void getStyleFromFloat(
+      String name,
+      Float value,
+      @Nullable ViewDebug.ExportedProperty annotation,
+      StyleAccumulator styles) {
+    styles.store(name, String.valueOf(value), isDefaultValue(value));
   }
 
   private static String capitalize(String str) {
@@ -79,5 +338,62 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
     StringBuilder buffer = new StringBuilder(str);
     buffer.setCharAt(0, Character.toTitleCase(buffer.charAt(0)));
     return buffer.toString();
+  }
+
+  private final class FieldBackedCSSProperty extends ViewCSSProperty {
+    private final Field mField;
+
+    public FieldBackedCSSProperty(
+        Field field,
+        String cssName,
+        @Nullable ViewDebug.ExportedProperty annotation) {
+      super(cssName, annotation);
+      mField = field;
+      mField.setAccessible(true);
+    }
+
+    @Override
+    public Object getValue(View view) throws InvocationTargetException, IllegalAccessException {
+      return mField.get(view);
+    }
+  }
+
+  private final class MethodBackedCSSProperty extends ViewCSSProperty {
+    private final Method mMethod;
+
+    public MethodBackedCSSProperty(
+        Method method,
+        String cssName,
+        @Nullable ViewDebug.ExportedProperty annotation) {
+      super(cssName, annotation);
+      mMethod = method;
+      mMethod.setAccessible(true);
+    }
+
+    @Override
+    public Object getValue(View view) throws InvocationTargetException, IllegalAccessException {
+      return mMethod.invoke(view);
+    }
+  }
+
+  private abstract class ViewCSSProperty {
+    private final String mCSSName;
+    private final ViewDebug.ExportedProperty mAnnotation;
+
+    public ViewCSSProperty(String cssName, @Nullable ViewDebug.ExportedProperty annotation) {
+      mCSSName = cssName;
+      mAnnotation = annotation;
+    }
+
+    public final String getCSSName() {
+      return mCSSName;
+    }
+
+    public abstract Object getValue(View view)
+        throws InvocationTargetException, IllegalAccessException;
+
+    public final @Nullable ViewDebug.ExportedProperty getAnnotation() {
+      return mAnnotation;
+    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/IntegerFormatter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/IntegerFormatter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.helper;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.view.ViewDebug;
+
+public class IntegerFormatter {
+  private static IntegerFormatter cachedFormatter;
+
+  public static IntegerFormatter getInstance() {
+    if (cachedFormatter == null) {
+      synchronized (IntegerFormatter.class) {
+        if (cachedFormatter == null) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            cachedFormatter = new IntegerFormatterWithHex();
+          } else {
+            cachedFormatter = new IntegerFormatter();
+          }
+        }
+      }
+    }
+
+    return cachedFormatter;
+  }
+
+  private IntegerFormatter() {
+  }
+
+  public String format(Integer integer, @Nullable ViewDebug.ExportedProperty annotation) {
+    return String.valueOf(integer);
+  }
+
+  private static class IntegerFormatterWithHex extends IntegerFormatter {
+    @Override
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public String format(Integer integer, @Nullable ViewDebug.ExportedProperty annotation) {
+      if (annotation != null && annotation.formatToHexString()) {
+        return "0x" + Integer.toHexString(integer);
+      }
+
+      return super.format(integer, annotation);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -9,19 +9,36 @@
 
 package com.facebook.stetho.inspector.protocol.module;
 
-import java.util.Collections;
-import java.util.List;
-
+import com.facebook.stetho.common.ListUtil;
+import com.facebook.stetho.common.LogUtil;
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.elements.Document;
+import com.facebook.stetho.inspector.elements.Origin;
+import com.facebook.stetho.inspector.elements.StyleAccumulator;
+import com.facebook.stetho.inspector.helper.ChromePeerManager;
+import com.facebook.stetho.inspector.helper.PeersRegisteredListener;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcPeer;
 import com.facebook.stetho.inspector.jsonrpc.JsonRpcResult;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsMethod;
+import com.facebook.stetho.json.ObjectMapper;
 import com.facebook.stetho.json.annotation.JsonProperty;
-
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class CSS implements ChromeDevtoolsDomain {
-  public CSS() {
+  private final ChromePeerManager mPeerManager;
+  private final Document mDocument;
+  private final ObjectMapper mObjectMapper;
+
+  public CSS(Document document) {
+    mDocument = Util.throwIfNull(document);
+    mObjectMapper = new ObjectMapper();
+    mPeerManager = new ChromePeerManager();
+    mPeerManager.setListener(new PeerManagerListener());
   }
 
   @ChromeDevtoolsMethod
@@ -33,18 +50,286 @@ public class CSS implements ChromeDevtoolsDomain {
   }
 
   @ChromeDevtoolsMethod
-  public JsonRpcResult getSupportedCSSProperties(JsonRpcPeer peer, JSONObject params) {
-    GetSupportedCSSPropertiesResponse response = new GetSupportedCSSPropertiesResponse();
-    response.cssProperties = Collections.emptyList();
-    return response;
+  public JsonRpcResult getComputedStyleForNode(JsonRpcPeer peer, JSONObject params) {
+    final GetComputedStyleForNodeRequest request = mObjectMapper.convertValue(
+        params,
+        GetComputedStyleForNodeRequest.class);
+
+    final GetComputedStyleForNodeResult result = new GetComputedStyleForNodeResult();
+    result.computedStyle = new ArrayList<>();
+
+    mDocument.postAndWait(new Runnable() {
+      @Override
+      public void run() {
+        Object element = mDocument.getElementForNodeId(request.nodeId);
+
+        if (element == null) {
+          LogUtil.e("Tried to get the style of an element that does not exist, using nodeid=" +
+              request.nodeId);
+
+          return;
+        }
+
+        mDocument.getElementStyles(
+            element,
+            new StyleAccumulator() {
+              @Override
+              public void store(String name, String value, boolean isDefault) {
+                if (!isDefault) {
+                  CSSComputedStyleProperty property = new CSSComputedStyleProperty();
+                  property.name = name;
+                  property.value = value;
+
+                  result.computedStyle.add(property);
+                }
+              }
+            });
+      }
+    });
+
+    return result;
   }
 
-  private static class GetSupportedCSSPropertiesResponse implements JsonRpcResult {
+  @ChromeDevtoolsMethod
+  public JsonRpcResult getMatchedStylesForNode(JsonRpcPeer peer, JSONObject params) {
+    final GetMatchedStylesForNodeRequest request = mObjectMapper.convertValue(
+        params,
+        GetMatchedStylesForNodeRequest.class);
+
+    final GetMatchedStylesForNodeResult result = new GetMatchedStylesForNodeResult();
+
+    final RuleMatch match = new RuleMatch();
+
+    result.matchedCSSRules = ListUtil.newImmutableList(match);
+
+    match.matchingSelectors = ListUtil.newImmutableList(0);
+
+    Selector selector = new Selector();
+    selector.value = "<this_element>";
+
+    CSSRule rule = new CSSRule();
+
+    rule.origin = Origin.REGULAR;
+    rule.selectorList = new SelectorList();
+
+    rule.selectorList.selectors = ListUtil.newImmutableList(selector);
+
+    rule.style = new CSSStyle();
+    rule.style.cssProperties = new ArrayList<>();
+
+    match.rule = rule;
+
+    rule.style.shorthandEntries = Collections.emptyList();
+
+    mDocument.postAndWait(new Runnable() {
+      @Override
+      public void run() {
+        Object elementForNodeId = mDocument.getElementForNodeId(request.nodeId);
+
+        if (elementForNodeId == null) {
+          LogUtil.w("Failed to get style of an element that does not exist, nodeid=" +
+              request.nodeId);
+          return;
+        }
+
+        mDocument.getElementStyles(
+            elementForNodeId,
+            new StyleAccumulator() {
+              @Override
+              public void store(String name, String value, boolean isDefault) {
+                if (!isDefault) {
+                  CSSProperty property = new CSSProperty();
+                  property.name = name;
+                  property.value = value;
+
+                  match.rule.style.cssProperties.add(property);
+                }
+              }
+            });
+      }
+    });
+
+    result.inherited = Collections.emptyList();
+    result.pseudoElements = Collections.emptyList();
+
+    return result;
+  }
+
+  private final class PeerManagerListener extends PeersRegisteredListener {
+    @Override
+    protected synchronized void onFirstPeerRegistered() {
+      mDocument.addRef();
+    }
+
+    @Override
+    protected synchronized void onLastPeerUnregistered() {
+      mDocument.release();
+    }
+  }
+
+  private static class CSSComputedStyleProperty {
     @JsonProperty(required = true)
-    public List<CSSPropertyInfo> cssProperties;
+    public String name;
+
+    @JsonProperty(required = true)
+    public String value;
   }
 
-  private static class CSSPropertyInfo {
-    // Incomplete
+  private static class RuleMatch {
+    @JsonProperty
+    public CSSRule rule;
+
+    @JsonProperty
+    public List<Integer> matchingSelectors;
+  }
+
+  private static class SelectorList {
+    @JsonProperty
+    public List<Selector> selectors;
+
+    @JsonProperty
+    public String text;
+  }
+
+  private static class SourceRange {
+    @JsonProperty(required = true)
+    public int startLine;
+
+    @JsonProperty(required = true)
+    public int startColumn;
+
+    @JsonProperty(required = true)
+    public int endLine;
+
+    @JsonProperty(required = true)
+    public int endColumn;
+  }
+
+  private static class Selector {
+    @JsonProperty(required = true)
+    public String value;
+
+    @JsonProperty
+    public SourceRange range;
+  }
+
+  private static class CSSRule {
+    @JsonProperty
+    public String styleSheetId;
+
+    @JsonProperty(required = true)
+    public SelectorList selectorList;
+
+    @JsonProperty
+    public Origin origin;
+
+    @JsonProperty
+    public CSSStyle style;
+  }
+
+  private static class CSSStyle {
+    @JsonProperty
+    public String styleSheetId;
+
+    @JsonProperty(required = true)
+    public List<CSSProperty> cssProperties;
+
+    @JsonProperty
+    public List<ShorthandEntry> shorthandEntries;
+
+    @JsonProperty
+    public String cssText;
+
+    @JsonProperty
+    public SourceRange range;
+  }
+
+  private static class ShorthandEntry {
+    @JsonProperty(required = true)
+    public String name;
+
+    @JsonProperty(required = true)
+    public String value;
+
+    @JsonProperty
+    public Boolean imporant;
+  }
+
+  private static class CSSProperty {
+    @JsonProperty(required = true)
+    public String name;
+
+    @JsonProperty(required = true)
+    public String value;
+
+    @JsonProperty
+    public Boolean important;
+
+    @JsonProperty
+    public Boolean implicit;
+
+    @JsonProperty
+    public String text;
+
+    @JsonProperty
+    public Boolean parsedOk;
+
+    @JsonProperty
+    public Boolean disabled;
+
+    @JsonProperty
+    public SourceRange range;
+  }
+
+  private static class PseudoIdMatches {
+    @JsonProperty(required = true)
+    public int pseudoId;
+
+    @JsonProperty(required = true)
+    public List<RuleMatch> matches;
+
+    public PseudoIdMatches() {
+      this.matches = new ArrayList<>();
+    }
+  }
+
+  private static class GetComputedStyleForNodeRequest {
+    @JsonProperty(required = true)
+    public int nodeId;
+  }
+
+  private static class InheritedStyleEntry {
+    @JsonProperty(required = true)
+    public CSSStyle inlineStyle;
+
+    @JsonProperty(required = true)
+    public List<RuleMatch> matchedCSSRules;
+  }
+
+  private static class GetComputedStyleForNodeResult implements JsonRpcResult {
+    @JsonProperty(required = true)
+    public List<CSSComputedStyleProperty> computedStyle;
+  }
+
+  private static class GetMatchedStylesForNodeRequest implements JsonRpcResult {
+    @JsonProperty(required = true)
+    public int nodeId;
+
+    @JsonProperty
+    public Boolean excludePseudo;
+
+    @JsonProperty
+    public Boolean excludeInherited;
+  }
+
+  private static class GetMatchedStylesForNodeResult implements JsonRpcResult {
+    @JsonProperty
+    public List<RuleMatch> matchedCSSRules;
+
+    @JsonProperty
+    public List<PseudoIdMatches> pseudoElements;
+
+    @JsonProperty
+    public List<InheritedStyleEntry> inherited;
   }
 }


### PR DESCRIPTION
This pull request adds the ability to view the style of an element that is selected in the elements tree using the same UI as what is shown in the styles tab when inspecting an element of a webpage.

Some gotchas:

* The names of style properties shown are not copied verbatim from the names of fields in the `View` class, but are translated to a format that Chrome understands. For example, `View` has a field called `paddingLeft`, but in order for that to be rendered correctly in Chrome, it needs to be transmitted as `padding-left`. 

* Default values are not transmitted, unless they are of an enum type, in which case they are *always* transmitted.

* Due to inconsistencies between annotations present on certain Android SDK versions, some fields that are enums are not translated into their string representation. This is unfortunate, but the only way to get around it is by special-casing those one or two cases, which is probably not viable long-term.

Some things that would be nice to add in the future:

* Inferring some way the element's style 'class', so that the styles aren't all aggregated into one blob. Same with style inheritance.

* In Chrome you can edit these CSS properties, but here you can't. Maybe a future project? Would probably relatively simple to add.

Style inspection of Stetho's 'Settings' button:

<p align="center">
<img src="https://cloud.githubusercontent.com/assets/2636237/9415188/5872116c-47f2-11e5-8764-ebb2bd43bcbf.png">

<img src="https://cloud.githubusercontent.com/assets/2636237/9415244/ad7b3350-47f2-11e5-97de-7d84772b3021.png">
</p>