### PR TITLE
Further refine DefaultInspectorModulesBuilder

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -12,6 +12,8 @@ package com.facebook.stetho;
 import com.facebook.stetho.dumpapp.plugins.CrashDumperPlugin;
 import com.facebook.stetho.dumpapp.plugins.FilesDumperPlugin;
 import com.facebook.stetho.dumpapp.plugins.HprofDumperPlugin;
+import com.facebook.stetho.inspector.console.RuntimeReplFactory;
+import com.facebook.stetho.inspector.database.DatabaseFilesProvider;
 import com.facebook.stetho.inspector.database.DefaultDatabaseFilesProvider;
 import javax.annotation.Nullable;
 
@@ -36,6 +38,7 @@ import com.facebook.stetho.dumpapp.plugins.SharedPreferencesDumperPlugin;
 import com.facebook.stetho.inspector.ChromeDevtoolsServer;
 import com.facebook.stetho.inspector.ChromeDiscoveryHandler;
 import com.facebook.stetho.inspector.elements.Document;
+import com.facebook.stetho.inspector.elements.DocumentProviderFactory;
 import com.facebook.stetho.inspector.elements.android.ActivityTracker;
 import com.facebook.stetho.inspector.elements.android.AndroidDOMConstants;
 import com.facebook.stetho.inspector.elements.android.AndroidDocumentProviderFactory;
@@ -54,6 +57,7 @@ import com.facebook.stetho.inspector.protocol.module.Page;
 import com.facebook.stetho.inspector.protocol.module.Profiler;
 import com.facebook.stetho.inspector.protocol.module.Runtime;
 import com.facebook.stetho.inspector.protocol.module.Worker;
+import com.facebook.stetho.inspector.runtime.RhinoDetectingRuntimeReplFactory;
 import com.facebook.stetho.server.LocalSocketHttpServer;
 import com.facebook.stetho.server.RegistryInitializer;
 import com.facebook.stetho.websocket.WebSocketHandler;
@@ -202,6 +206,11 @@ public class Stetho {
     }
   }
 
+  /**
+   * Convenience mechanism to extend the default set of dumper plugins provided by Stetho.
+   *
+   * @see #initializeWithDefaults(Context)
+   */
   public static final class DefaultDumperPluginsBuilder {
     private final Context mContext;
     private final PluginBuilder<DumperPlugin> mDelegate = new PluginBuilder<>();
@@ -234,14 +243,65 @@ public class Stetho {
     }
   }
 
+  /**
+   * Configuration mechanism to customize the behaviour of the standard set of inspector
+   * modules satisfying the Chrome DevTools protocol.  Note that while it is still technically
+   * possible to manually control these modules, this API is strongly discouraged and will not
+   * necessarily be supported in future releases.
+   */
   public static final class DefaultInspectorModulesBuilder {
-    private final Context mContext;
+    private final Application mContext;
     private final PluginBuilder<ChromeDevtoolsDomain> mDelegate = new PluginBuilder<>();
 
+    @Nullable private DocumentProviderFactory mDocumentProvider;
+    @Nullable private RuntimeReplFactory mRuntimeRepl;
+    @Nullable private DatabaseFilesProvider mDatabaseFiles;
+
     public DefaultInspectorModulesBuilder(Context context) {
-      mContext = context;
+      mContext = (Application)context.getApplicationContext();
     }
 
+    /**
+     * Provide a custom document provider factory which can operate on the logical DOM exposed to
+     * Chrome in the Elements tab.  An Android View hierarchy instance is provided by
+     * default if this method is not called.
+     * <p />
+     * <i>Experimental.</i>  This API may be changed or removed in the future.
+     */
+    public DefaultInspectorModulesBuilder documentProvider(DocumentProviderFactory factory) {
+      mDocumentProvider = factory;
+      return this;
+    }
+
+    /**
+     * Provide a custom runtime REPL (read-eval-print loop) implementation for the Console tab.
+     * By default an implementation will be provided for you that automatically detects
+     * the existence of {@code stetho-js-rhino} (Mozilla's Rhino engine) and uses it if available.
+     * <p />
+     * To customize the Rhino implementation, see {@code stetho-js-rhino} documentation.
+     */
+    public DefaultInspectorModulesBuilder runtimeRepl(RuntimeReplFactory factory) {
+      mRuntimeRepl = factory;
+      return this;
+    }
+
+    /**
+     * Customize the location of database files that Stetho will propogate in the UI.  Android's
+     * {@link Context#getDatabasePath} method will be used by default if not overridden here.
+     */
+    public DefaultInspectorModulesBuilder databaseFiles(DatabaseFilesProvider provider) {
+      mDatabaseFiles = provider;
+      return this;
+    }
+
+    /**
+     * Provide either a new domain module or override an existing one.
+     *
+     * @deprecated This fine-grained control of the devtools modules is no longer supportable
+     *     given the lack of isolation of modules in the actual protocol (many cross dependencies
+     *     emerge when you implement more and more of the real protocol).
+     */
+    @Deprecated
     public DefaultInspectorModulesBuilder provide(ChromeDevtoolsDomain module) {
       mDelegate.provide(module.getClass().getName(), module);
       return this;
@@ -252,6 +312,14 @@ public class Stetho {
       return this;
     }
 
+    /**
+     * Remove an existing domain module.
+     *
+     * @deprecated This fine-grained control of the devtools modules is no longer supportable
+     *     given the lack of isolation of modules in the actual protocol (many cross dependencies
+     *     emerge when you implement more and more of the real protocol).
+     */
+    @Deprecated
     public DefaultInspectorModulesBuilder remove(String moduleName) {
       mDelegate.remove(moduleName);
       return this;
@@ -261,11 +329,9 @@ public class Stetho {
       provideIfDesired(new Console());
       provideIfDesired(new CSS());
       provideIfDesired(new Debugger());
-      if (Build.VERSION.SDK_INT >= AndroidDOMConstants.MIN_API_LEVEL) {
-        Document document = new Document(
-            new AndroidDocumentProviderFactory(
-                (Application) mContext.getApplicationContext()));
-
+      DocumentProviderFactory documentModel = resolveDocumentProvider();
+      if (documentModel != null) {
+        Document document = new Document(documentModel);
         provideIfDesired(new DOM(document));
       }
       provideIfDesired(new DOMStorage(mContext));
@@ -274,12 +340,32 @@ public class Stetho {
       provideIfDesired(new Network(mContext));
       provideIfDesired(new Page(mContext));
       provideIfDesired(new Profiler());
-      provideIfDesired(new Runtime(mContext));
+      provideIfDesired(
+          new Runtime(
+              mRuntimeRepl != null ?
+              mRuntimeRepl :
+              new RhinoDetectingRuntimeReplFactory(mContext)));
       provideIfDesired(new Worker());
       if (Build.VERSION.SDK_INT >= DatabaseConstants.MIN_API_LEVEL) {
-        provideIfDesired(new Database(mContext, new DefaultDatabaseFilesProvider(mContext)));
+        provideIfDesired(
+            new Database(
+                mContext,
+                mDatabaseFiles != null ?
+                    mDatabaseFiles :
+                    new DefaultDatabaseFilesProvider(mContext)));
       }
       return mDelegate.finish();
+    }
+
+    @Nullable
+    private DocumentProviderFactory resolveDocumentProvider() {
+      if (mDocumentProvider != null) {
+        return mDocumentProvider;
+      }
+      if (Build.VERSION.SDK_INT >= AndroidDOMConstants.MIN_API_LEVEL) {
+        return new AndroidDocumentProviderFactory(mContext);
+      }
+      return null;
     }
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -28,7 +28,7 @@ import java.util.Queue;
 import java.util.regex.Pattern;
 
 public final class Document extends ThreadBoundProxy {
-  private final DocumentProvider.Factory mFactory;
+  private final DocumentProviderFactory mFactory;
   private final ObjectIdMapper mObjectIdMapper;
   private final Queue<Object> mCachedUpdateQueue;
 
@@ -42,7 +42,7 @@ public final class Document extends ThreadBoundProxy {
   @GuardedBy("this")
   private int mReferenceCounter;
 
-  public Document(DocumentProvider.Factory factory) {
+  public Document(DocumentProviderFactory factory) {
     super(factory);
 
     mFactory = factory;
@@ -616,7 +616,7 @@ public final class Document extends ThreadBoundProxy {
     }
   }
 
-  private final class ProviderListener implements DocumentProvider.Listener {
+  private final class ProviderListener implements DocumentProviderListener {
     @Override
     public void onPossiblyChanged() {
       updateTree();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProvider.java
@@ -13,8 +13,14 @@ import com.facebook.stetho.common.ThreadBound;
 
 import javax.annotation.Nullable;
 
+/**
+ * Provides a document that can be rendered in Chrome's Elements tab (conforming loosely to the
+ * W3C DOM to the degree specified in this API).
+ *
+ * @see DocumentProviderFactory
+ */
 public interface DocumentProvider extends ThreadBound {
-  void setListener(Listener listener);
+  void setListener(DocumentProviderListener listener);
 
   void dispose();
 
@@ -31,24 +37,4 @@ public interface DocumentProvider extends ThreadBound {
   void setInspectModeEnabled(boolean enabled);
 
   void setAttributesAsText(Object element, String text);
-
-  interface Factory extends ThreadBound {
-    DocumentProvider create();
-  }
-
-  interface Listener {
-    void onPossiblyChanged();
-
-    void onAttributeModified(
-        Object element,
-        String name,
-        String value);
-
-    void onAttributeRemoved(
-        Object element,
-        String name);
-
-    void onInspectRequested(
-        Object element);
-  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+import com.facebook.stetho.common.ThreadBound;
+
+/**
+ * Factory mechanism to dynamically construct the document provider.  This allows for lazy
+ * initialization and memory cleanup when DevTools instances disconnect.
+ */
+public interface DocumentProviderFactory extends ThreadBound {
+  DocumentProvider create();
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+public interface DocumentProviderListener {
+  void onPossiblyChanged();
+
+  void onAttributeModified(
+      Object element,
+      String name,
+      String value);
+
+  void onAttributeRemoved(
+      Object element,
+      String name);
+
+  void onInspectRequested(
+      Object element);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -14,7 +14,6 @@ import android.app.Application;
 import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Canvas;
-import android.os.Handler;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,13 +24,12 @@ import android.widget.TextView;
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.common.Predicate;
 import com.facebook.stetho.common.ThreadBound;
-import com.facebook.stetho.common.UncheckedCallable;
 import com.facebook.stetho.common.Util;
-import com.facebook.stetho.common.android.HandlerUtil;
 import com.facebook.stetho.common.android.ViewUtil;
 import com.facebook.stetho.inspector.elements.DocumentProvider;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
+import com.facebook.stetho.inspector.elements.DocumentProviderListener;
 import com.facebook.stetho.inspector.elements.NodeDescriptor;
 import com.facebook.stetho.inspector.elements.ObjectDescriptor;
 import com.facebook.stetho.inspector.helper.ThreadBoundProxy;
@@ -51,7 +49,7 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
   private final AndroidDocumentRoot mDocumentRoot;
   private final ViewHighlighter mHighlighter;
   private final InspectModeHandler mInspectModeHandler;
-  private @Nullable Listener mListener;
+  private @Nullable DocumentProviderListener mListener;
 
   // We don't yet have an an implementation for reliably detecting fine-grained changes in the
   // View tree. So, for now at least, we have a timer that runs every so often and just reports
@@ -110,7 +108,7 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
   }
 
   @Override
-  public void setListener(Listener listener) {
+  public void setListener(DocumentProviderListener listener) {
     verifyThreadAccess();
 
     mListener = listener;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
@@ -18,9 +18,10 @@ import com.facebook.stetho.common.UncheckedCallable;
 import com.facebook.stetho.common.Util;
 import com.facebook.stetho.common.android.HandlerUtil;
 import com.facebook.stetho.inspector.elements.DocumentProvider;
+import com.facebook.stetho.inspector.elements.DocumentProviderFactory;
 
 public final class AndroidDocumentProviderFactory
-    implements DocumentProvider.Factory, ThreadBound {
+    implements DocumentProviderFactory, ThreadBound {
   private final Application mApplication;
   private final Handler mHandler;
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.protocol.module;
 
 import android.content.Context;
+import com.facebook.stetho.Stetho;
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.inspector.console.RuntimeRepl;
 import com.facebook.stetho.inspector.console.RuntimeReplFactory;
@@ -53,7 +54,9 @@ public class Runtime implements ChromeDevtoolsDomain {
 
   /**
    * @deprecated Provided for ABI compatibility
-   * @see Runtime(Context)
+   *
+   * @see #Runtime(RuntimeReplFactory)
+   * @see Stetho.DefaultInspectorModulesBuilder#runtimeRepl(RuntimeReplFactory)
    */
   @Deprecated
   public Runtime() {
@@ -70,6 +73,10 @@ public class Runtime implements ChromeDevtoolsDomain {
     });
   }
 
+  /**
+   * @deprecated This was a transitionary API that was replaced by
+   *     {@link com.facebook.stetho.Stetho.DefaultInspectorModulesBuilder#runtimeRepl}
+   */
   public Runtime(Context context) {
     this(new RhinoDetectingRuntimeReplFactory(context));
   }


### PR DESCRIPTION
As the DevTools implementation has matured it has become clear that the
modules are not truly modular or interchangable at all and have heavy
dependencies between the two that make it impossible to provide or
configure them in isolation.  Because of this, we're moving to a more
explicit customization API which is responsible for managing the
dependencies of the implementation directly while still preserving the
level of abstractions already present in the system (such as providing a
custom document model, runtime REPL, etc).