### PR TITLE
Fix javadoc errors on Java 8

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -74,6 +74,9 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
+        if (JavaVersion.current().isJava8Compatible()) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {


### PR DESCRIPTION
Java 8 became much more strict about enforcement of HTML syntax and
rules which breaks the norms we were previously adhering too.