### PR TITLE
Fix the Rhino autodetection feature

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -274,7 +274,7 @@ public class Stetho {
       provideIfDesired(new Network(mContext));
       provideIfDesired(new Page(mContext));
       provideIfDesired(new Profiler());
-      provideIfDesired(new Runtime());
+      provideIfDesired(new Runtime(mContext));
       provideIfDesired(new Worker());
       if (Build.VERSION.SDK_INT >= DatabaseConstants.MIN_API_LEVEL) {
         provideIfDesired(new Database(mContext, new DefaultDatabaseFilesProvider(mContext)));


### PR DESCRIPTION
This was accidentally broken in #245 by not modifying the default
inspector modules provider to use the new Runtime(Context) constructor,
effectively disabling the entire feature.