### PR TITLE
Finish renaming DOM to Document where appropriate

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -40,7 +40,7 @@ import com.facebook.stetho.inspector.ChromeDiscoveryHandler;
 import com.facebook.stetho.inspector.elements.Document;
 import com.facebook.stetho.inspector.elements.DocumentProviderFactory;
 import com.facebook.stetho.inspector.elements.android.ActivityTracker;
-import com.facebook.stetho.inspector.elements.android.AndroidDOMConstants;
+import com.facebook.stetho.inspector.elements.android.AndroidDocumentConstants;
 import com.facebook.stetho.inspector.elements.android.AndroidDocumentProviderFactory;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.module.CSS;
@@ -362,7 +362,7 @@ public class Stetho {
       if (mDocumentProvider != null) {
         return mDocumentProvider;
       }
-      if (Build.VERSION.SDK_INT >= AndroidDOMConstants.MIN_API_LEVEL) {
+      if (Build.VERSION.SDK_INT >= AndroidDocumentConstants.MIN_API_LEVEL) {
         return new AndroidDocumentProviderFactory(mContext);
       }
       return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -12,6 +12,7 @@ package com.facebook.stetho.inspector.elements;
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.common.ThreadBound;
 import com.facebook.stetho.common.Util;
+import com.facebook.stetho.inspector.protocol.module.DOM;
 
 import javax.annotation.Nullable;
 
@@ -30,8 +31,8 @@ import javax.annotation.Nullable;
  * {@link #verifyThreadAccess()} in a few important methods such as {@link #hook(Object)} and
  * {@link #unhook(Object)} (anything that writes or is potentially really dangerous if misused).<p/>
  *
- * @param <E> the class that this descriptor will be describing for {@link DocumentProvider} and
- * {@link com.facebook.stetho.inspector.protocol.module.DOM}
+ * @param <E> the class that this descriptor will be describing for {@link DocumentProvider},
+ * {@link Document}, and ultimately {@link DOM}.
  */
 public abstract class AbstractChainedDescriptor<E> extends Descriptor implements ChainedDescriptor {
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -46,7 +46,7 @@ public final class Document extends ThreadBoundProxy {
     super(factory);
 
     mFactory = factory;
-    mObjectIdMapper = new DOMObjectIdMapper();
+    mObjectIdMapper = new DocumentObjectIdMapper();
     mReferenceCounter = 0;
     mUpdateListeners = new UpdateListenerCollection();
     mCachedUpdateQueue = new ArrayDeque<>();
@@ -73,7 +73,7 @@ public final class Document extends ThreadBoundProxy {
       @Override
       public void run() {
         mShadowDocument = new ShadowDocument(mDocumentProvider.getRootElement());
-        createShadowDOMUpdate().commit();
+        createShadowDocumentUpdate().commit();
         mDocumentProvider.setListener(new ProviderListener());
       }
     });
@@ -263,7 +263,7 @@ public final class Document extends ThreadBoundProxy {
     }
   }
 
-  private ShadowDocument.Update createShadowDOMUpdate() {
+  private ShadowDocument.Update createShadowDocumentUpdate() {
     verifyThreadAccess();
 
     if (mDocumentProvider.getRootElement() != mShadowDocument.getRootElement()) {
@@ -313,22 +313,22 @@ public final class Document extends ThreadBoundProxy {
   private void updateTree() {
     long startTimeMs = SystemClock.elapsedRealtime();
 
-    ShadowDocument.Update domUpdate = createShadowDOMUpdate();
-    boolean isEmpty = domUpdate.isEmpty();
+    ShadowDocument.Update docUpdate = createShadowDocumentUpdate();
+    boolean isEmpty = docUpdate.isEmpty();
     if (isEmpty) {
-      domUpdate.abandon();
+      docUpdate.abandon();
     } else {
-      applyDOMUpdate(domUpdate);
+      applyDocumentUpdate(docUpdate);
     }
 
     long deltaMs = SystemClock.elapsedRealtime() - startTimeMs;
     LogUtil.d(
-        "DOM.updateTree() completed in %s ms%s",
+        "Document.updateTree() completed in %s ms%s",
         Long.toString(deltaMs),
         isEmpty ? " (no changes)" : "");
   }
   
-  private void applyDOMUpdate(final ShadowDocument.Update domUpdate) {
+  private void applyDocumentUpdate(final ShadowDocument.Update docUpdate) {
     // TODO: it'd be nice if we could delegate our calls into mPeerManager.sendNotificationToPeers()
     //       to a background thread so as to offload the UI from JSON serialization stuff
 
@@ -336,17 +336,17 @@ public final class Document extends ThreadBoundProxy {
     // sub-trees which have not been reconnected to the tree, should be garbage collected.
     // We do this first so that we can tag nodes as garbage by removing them from mObjectIdMapper
     // (which also unhooks them). We rely on this marking later.
-    domUpdate.getGarbageElements(new Accumulator<Object>() {
+    docUpdate.getGarbageElements(new Accumulator<Object>() {
       @Override
       public void store(Object element) {
         if (!mObjectIdMapper.containsObject(element)) {
           throw new IllegalStateException();
         }
 
-        ElementInfo newElementInfo = domUpdate.getElementInfo(element);
+        ElementInfo newElementInfo = docUpdate.getElementInfo(element);
 
-        // Only send over DOM.childNodeRemoved for the root of a disconnected tree. The remainder
-        // of the sub-tree is included automatically, so we don't need to send events for those.
+        // Only raise onChildNodeRemoved for the root of a disconnected tree. The remainder of the
+        // sub-tree is included automatically, so we don't need to send events for those.
         if (newElementInfo.parentElement == null) {
           ElementInfo oldElementInfo = mShadowDocument.getElementInfo(element);
           int parentNodeId = mObjectIdMapper.getIdForObject(oldElementInfo.parentElement);
@@ -359,18 +359,18 @@ public final class Document extends ThreadBoundProxy {
       }
     });
 
-    // Transmit other DOM changes over to Chrome
-    domUpdate.getChangedElements(new Accumulator<Object>() {
-      private final HashSet<Object> domInsertedElements = new HashSet<>();
+    // Transmit other Document changes to our listener
+    docUpdate.getChangedElements(new Accumulator<Object>() {
+      private final HashSet<Object> listenerInsertedElements = new HashSet<>();
 
       private Accumulator<Object> insertedElements = new Accumulator<Object>() {
         @Override
         public void store(Object element) {
-          if (domUpdate.isElementChanged(element)) {
+          if (docUpdate.isElementChanged(element)) {
             // We only need to track changed elements because unchanged elements will never be
             // encountered by the code below, in store(), which uses this Set to skip elements that
             // don't need to be processed.
-            domInsertedElements.add(element);
+            listenerInsertedElements.add(element);
           }
         }
       };
@@ -382,14 +382,14 @@ public final class Document extends ThreadBoundProxy {
           return;
         }
 
-        if (domInsertedElements.contains(element)) {
-          // This element was already transmitted in its entirety by a DOM.childNodeInserted event.
+        if (listenerInsertedElements.contains(element)) {
+          // This element was already transmitted in its entirety by an onChildNodeInserted event.
           // Trying to send any further updates about it is both unnecessary and incorrect (we'd
           // end up with duplicated elements and really bad performance).
           return;
         }
 
-        final ElementInfo newElementInfo = domUpdate.getElementInfo(element);
+        final ElementInfo newElementInfo = docUpdate.getElementInfo(element);
         final ElementInfo oldElementInfo = mShadowDocument.getElementInfo(element);
 
         final List<Object> oldChildren = (oldElementInfo != null)
@@ -398,78 +398,79 @@ public final class Document extends ThreadBoundProxy {
 
         final List<Object> newChildren = newElementInfo.children;
 
-        // This list is representative of Chrome's view of the DOM.
-        // We need to sync up Chrome with newChildren.
-        ChildEventingList domChildren = acquireChildEventingList(element, domUpdate);
+        // This list is representative of our listener's view of the Document (ultimately, this
+        // means Chrome DevTools). We need to sync it up with newChildren.
+        ChildEventingList listenerChildren = acquireChildEventingList(element, docUpdate);
         for (int i = 0, N = oldChildren.size(); i < N; ++i) {
           final Object childElement = oldChildren.get(i);
           if (mObjectIdMapper.containsObject(childElement)) {
-            domChildren.add(childElement);
+            listenerChildren.add(childElement);
           }
         }
-        updateDOMChildren(domChildren, newChildren, insertedElements);
-        releaseChildEventingList(domChildren);
+        updateListenerChildren(listenerChildren, newChildren, insertedElements);
+        releaseChildEventingList(listenerChildren);
       }
     });
 
-    domUpdate.commit();
+    docUpdate.commit();
   }
 
-  private static void updateDOMChildren(
-      ChildEventingList domChildren,
+  private static void updateListenerChildren(
+      ChildEventingList listenerChildren,
       List<Object> newChildren,
       Accumulator<Object> insertedElements) {
     int index = 0;
-    while (index <= domChildren.size()) {
+    while (index <= listenerChildren.size()) {
       // Insert new items that were added to the end of the list
-      if (index == domChildren.size()) {
+      if (index == listenerChildren.size()) {
         if (index == newChildren.size()) {
           break;
         }
 
         final Object newElement = newChildren.get(index);
-        domChildren.addWithEvent(index, newElement, insertedElements);
+        listenerChildren.addWithEvent(index, newElement, insertedElements);
         ++index;
         continue;
       }
 
       // Remove old items that were removed from the end of the list
       if (index == newChildren.size()) {
-        domChildren.removeWithEvent(index);
+        listenerChildren.removeWithEvent(index);
         continue;
       }
 
-      final Object domElement = domChildren.get(index);
+      final Object listenerElement = listenerChildren.get(index);
       final Object newElement = newChildren.get(index);
 
       // This slot has exactly what we need to have here.
-      if (domElement == newElement) {
+      if (listenerElement == newElement) {
         ++index;
         continue;
       }
 
-      int newElementDomIndex = domChildren.indexOf(newElement);
-      if (newElementDomIndex == -1) {
-        domChildren.addWithEvent(index, newElement, insertedElements);
+      int newElementListenerIndex = listenerChildren.indexOf(newElement);
+      if (newElementListenerIndex == -1) {
+        listenerChildren.addWithEvent(index, newElement, insertedElements);
         ++index;
         continue;
       }
 
       // TODO: use longest common substring to decide whether to
-      //       1) remove(newElementDomIndex)-then-add(index), or
+      //       1) remove(newElementListenerIndex)-then-add(index), or
       //       2) remove(index) and let a subsequent loop iteration do add() (that is, when index
-      //          catches up the current value of newElementDomIndex)
+      //          catches up the current value of newElementListenerIndex)
       //       Neither one of these is the best strategy -- it depends on context.
 
-      domChildren.removeWithEvent(newElementDomIndex);
-      domChildren.addWithEvent(index, newElement, insertedElements);
+      listenerChildren.removeWithEvent(newElementListenerIndex);
+      listenerChildren.addWithEvent(index, newElement, insertedElements);
 
       ++index;
     }
   }
 
   /**
-   * A private implementation of {@link List} that transmits DOM changes to Chrome.
+   * A private implementation of {@link List} that transmits our changes to our listener (and,
+   * ultimately, to the DevTools client).
    */
   private final class ChildEventingList extends ArrayList<Object> {
     private Object mParentElement = null;
@@ -616,7 +617,7 @@ public final class Document extends ThreadBoundProxy {
         Accumulator<Object> insertedItems);
   }
 
-  private final class DOMObjectIdMapper extends ObjectIdMapper {
+  private final class DocumentObjectIdMapper extends ObjectIdMapper {
     @Override
     protected void onMapped(Object object, int id) {
       verifyThreadAccess();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
@@ -282,7 +282,7 @@ public final class ShadowDocument implements DocumentView {
 
     public ElementInfo getElementInfo(Object element) {
       // Return ElementInfo for the new (albeit uncommitted and pre-garbage collected) view of the
-      // DOM. If element is garbage then you'll still get its info (feature, not a bug :)).
+      // Document. If element is garbage then you'll still get its info (feature, not a bug :)).
       ElementInfo elementInfo = mElementToInfoChangesMap.get(element);
       if (elementInfo != null) {
         return elementInfo;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentConstants.java
@@ -9,11 +9,13 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
-import android.content.Context;
-import android.view.View;
+import android.os.Build;
 
-class DOMHiddenView extends View {
-  public DOMHiddenView(Context context) {
-    super(context);
-  }
+public interface AndroidDocumentConstants {
+  /**
+   * Minimum API version required to make effective use of AndroidDocumentProvider. This can be
+   * moved back significantly through manual APIs to discover {@link android.app.Activity}
+   * instances.
+   */
+  int MIN_API_LEVEL = Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -53,8 +53,9 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
 
   // We don't yet have an an implementation for reliably detecting fine-grained changes in the
   // View tree. So, for now at least, we have a timer that runs every so often and just reports
-  // that we changed. Our listener will then read the entire DOM from us and transmit the changes to
-  // Chrome. Detecting, reporting, and traversing fine-grained changes is a future work item.
+  // that we changed. Our listener will then read the entire Document from us and transmit the
+  // changes to Chrome. Detecting, reporting, and traversing fine-grained changes is a future work
+  // item (see Issue #210).
   private static final long REPORT_CHANGED_INTERVAL_MS = 1000;
   private boolean mIsReportChangesTimerPosted = false;
   private final Runnable mReportChangesTimer = new Runnable() {
@@ -247,7 +248,7 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
     private final Predicate<View> mViewSelector = new Predicate<View>() {
       @Override
       public boolean apply(View view) {
-        return !(view instanceof DOMHiddenView);
+        return !(view instanceof DocumentHiddenView);
       }
     };
 
@@ -299,7 +300,7 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
       mOverlays = null;
     }
 
-    private final class OverlayView extends DOMHiddenView {
+    private final class OverlayView extends DocumentHiddenView {
       public OverlayView(Context context) {
         super(context);
       }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DocumentHiddenView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DocumentHiddenView.java
@@ -9,12 +9,11 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
-import android.os.Build;
+import android.content.Context;
+import android.view.View;
 
-public interface AndroidDOMConstants {
-  /**
-   * Minimum API version required to make effective use of the DOM module.  This can be moved
-   * back significantly through manual APIs to discover {@link android.app.Activity} instances.
-   */
-  int MIN_API_LEVEL = Build.VERSION_CODES.ICE_CREAM_SANDWICH;
+class DocumentHiddenView extends View {
+  public DocumentHiddenView(Context context) {
+    super(context);
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -45,7 +45,7 @@ final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup> {
   }
 
   private boolean isChildVisible(View child) {
-    return !(child instanceof DOMHiddenView);
+    return !(child instanceof DocumentHiddenView);
   }
 
   private Object getElementForView(ViewGroup parentView, View childView) {


### PR DESCRIPTION
We renamed `DOMProvider` to `DocumentProvider` while doing the refactor to extract `Document` out of `DOM`. There were a few places we missed. We also need to use some different terminology within `Document`: instead of saying things like "transmit to the DOM" we need to say "transmit to our listener." In some places it's fine to refer to DOM because it's a reference to the realities of the concrete protocol we're using.

Closes #273 