### PR TITLE
Show SQLite views as tables

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabasePeerManager.java
@@ -120,8 +120,8 @@ public class DatabasePeerManager extends ChromePeerManager {
       throws SQLiteException {
     SQLiteDatabase database = openDatabase(databaseName);
     try {
-      Cursor cursor = database.rawQuery("SELECT name FROM sqlite_master WHERE type=?",
-          new String[] { "table" });
+      Cursor cursor = database.rawQuery("SELECT name FROM sqlite_master WHERE type IN (?, ?)",
+          new String[] { "table", "view" });
       try {
         List<String> tableNames = new ArrayList<String>();
         while (cursor.moveToNext()) {


### PR DESCRIPTION
Simple change to make views (as with CREATE VIEW ...) show up in the
WebSQL section as a table.  Quick smoke test reveals there's no trouble
treating them as tables in Stetho.

Closes #285