### PR TITLE
Json serialization fixes

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
@@ -101,7 +101,7 @@ public class ObjectMapper {
       Object value = jsonObject.opt(field.getName());
       Object setValue = getValueForField(field, value);
       try {
-        field.set(instance, getValueForField(field, value));
+        field.set(instance, setValue);
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(
             "Class: " + type.getSimpleName() + " " +

--- a/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
@@ -272,6 +272,18 @@ public class ObjectMapper {
     if (!canDirectlySerializeClass(clazz)) {
       return convertValue(value, JSONObject.class);
     }
+    // JSON has no support for NaN, Infinity or -Infinity, so we serialize
+    // then as strings. Google Chrome's inspector will accept them just fine.
+    if (clazz.equals(Double.class) || clazz.equals(Float.class)) {
+      double doubleValue = ((Number) value).doubleValue();
+      if (Double.isNaN(doubleValue)) {
+        return "NaN";
+      } else if (doubleValue == Double.POSITIVE_INFINITY) {
+        return "Infinity";
+      } else if (doubleValue == Double.NEGATIVE_INFINITY) {
+        return "-Infinity";
+      }
+    }
     // hmm we should be able to directly serialize here...
     return value;
   }


### PR DESCRIPTION
This branch fixes serialization issues that cause stetho to die when we try to send back NaN, Infinity or -Infinity. These values are not part of the JSON specification. What this patch does is to serialize them as String since JavaScript will accept them back as Doubles.