### PR TITLE
Add support for STETHO_PROCESS environment variable to dumpapp

### DIFF
--- a/scripts/dumpapp
+++ b/scripts/dumpapp
@@ -11,7 +11,11 @@ from stetho_open import *
 def main():
   # Manually parse out -p <process>, all other option handling occurs inside
   # the hosting process.
-  process = None
+
+  # Connect to the process passed in via -p. If that is not supplied fallback
+  # the process defined in STETHO_PROCESS. If neither are defined throw.
+  process = os.environ.get('STETHO_PROCESS')
+
   args = sys.argv[1:]
   if len(args) > 0 and (args[0] == '-p' or args[0] == '--process'):
     if len(args) < 2:
@@ -23,6 +27,7 @@ def main():
   # Connect to ANDROID_SERIAL if supplied, otherwise fallback to any
   # transport.
   device = os.environ.get('ANDROID_SERIAL')
+
   try:
     conn = HTTPConnectionOverADB(device, process)
     query_params = ['argv=' + urllib.parse.quote(arg) for arg in args]

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -58,7 +58,8 @@ def _find_only_stetho_socket(device):
       raise HumanReadableError(
           'Multiple stetho-enabled processes available:%s\n' % (
               '\n\t'.join([''] + process_names)) +
-          'Use -p <process> to select one')
+          'Use -p <process> or the environment variable STETHO_PROCESS to ' +
+          'select one')
     elif last_stetho_socket_name == None:
       raise HumanReadableError('No stetho-enabled processes running')
     else:


### PR DESCRIPTION
We want to be able to support passing the process via environment
variable. This gets around having to create arbitrary wrapper scripts
that just pass `-p myprocess $@` to dumpapp.

Closes #291 

https://gist.github.com/anonymous/b20a4e34cf774b4abdb6