### PR TITLE
Support for Dialogs without a DialogFragment

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -10,10 +10,13 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Activity;
+import android.app.Dialog;
+import android.util.SparseArray;
 import android.view.View;
 import android.view.Window;
 
 import com.facebook.stetho.common.Accumulator;
+import com.facebook.stetho.common.ReflectionUtil;
 import com.facebook.stetho.common.StringUtil;
 import com.facebook.stetho.common.android.FragmentActivityAccessor;
 import com.facebook.stetho.common.android.FragmentCompat;
@@ -23,6 +26,7 @@ import com.facebook.stetho.inspector.elements.Descriptor;
 
 import javax.annotation.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 final class ActivityDescriptor
@@ -38,9 +42,59 @@ final class ActivityDescriptor
     getDialogFragments(FragmentCompat.getSupportLibInstance(), element, children);
     getDialogFragments(FragmentCompat.getFrameworkInstance(), element, children);
 
+    getDialogs(element, children);
+
     Window window = element.getWindow();
     if (window != null) {
       children.store(window);
+    }
+  }
+
+  private void getDialogs(Activity activity, Accumulator<Object> children) {
+    // TODO: optimize reflection use
+
+    // We don't need to worry about double-emitting any Dialogs that are hosted by DialogFragments
+    // because they are not included in Activity.mManagedDialogs.
+
+    Field fieldMManagedDialogs = ReflectionUtil.tryGetDeclaredField(
+        Activity.class,
+        "mManagedDialogs");
+    if (fieldMManagedDialogs == null) {
+      return;
+    }
+    fieldMManagedDialogs.setAccessible(true);
+
+    SparseArray managedDialogs;
+    try {
+      managedDialogs = (SparseArray) fieldMManagedDialogs.get(activity);
+    } catch (IllegalAccessException | IllegalArgumentException ex) {
+      return;
+    }
+
+    if (managedDialogs == null) {
+      return;
+    }
+
+    Field fieldMDialog = null;
+    for (int i = 0, size = managedDialogs.size(); i < size; ++i) {
+      Object managedDialog = managedDialogs.valueAt(i);
+
+      if (fieldMDialog == null) {
+        fieldMDialog = ReflectionUtil.tryGetDeclaredField(managedDialog.getClass(), "mDialog");
+      }
+      if (fieldMDialog == null) {
+        return;
+      }
+      fieldMDialog.setAccessible(true);
+
+      Dialog dialog;
+      try {
+        dialog = (Dialog) fieldMDialog.get(managedDialog);
+      } catch (IllegalAccessException | IllegalArgumentException ex) {
+        return;
+      }
+
+      children.store(dialog);
     }
   }
 


### PR DESCRIPTION
This is preliminary support for `Dialogs` that are not hosted by a `DialogFragment`.

I haven't had really had time to test this yet, but it should work.

Closes #295 