### PR TITLE
Support for CSS.setPropertyText

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/Ascii.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Ascii.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common;
+
+/** Copyright (C) 2007 The Guava Authors */
+public final class Ascii {
+  /**
+   * If the argument is a {@linkplain #isLowerCase(char) lowercase ASCII character} returns the
+   * uppercase equivalent. Otherwise returns the argument.
+   */
+  public static char toUpperCase(char c) {
+    return isLowerCase(c) ? (char) (c & 0x5f) : c;
+  }
+
+  /**
+   * Indicates whether {@code c} is one of the twenty-six lowercase ASCII alphabetic characters
+   * between {@code 'a'} and {@code 'z'} inclusive. All others (including non-ASCII characters)
+   * return {@code false}.
+   */
+  public static boolean isLowerCase(char c) {
+    // Note: This was benchmarked against the alternate expression "(char)(c - 'a') < 26" (Nov '13)
+    // and found to perform at least as well, or better.
+    return (c >= 'a') && (c <= 'z');
+  }
+
+  /**
+   * Returns a copy of the input string in which all {@linkplain #isUpperCase(char) uppercase ASCII
+   * characters} have been converted to lowercase. All other characters are copied without
+   * modification.
+   */
+  public static String toLowerCase(String string) {
+    int length = string.length();
+    for (int i = 0; i < length; i++) {
+      if (isUpperCase(string.charAt(i))) {
+        char[] chars = string.toCharArray();
+        for (; i < length; i++) {
+          char c = chars[i];
+          if (isUpperCase(c)) {
+            chars[i] = (char) (c ^ 0x20);
+          }
+        }
+        return String.valueOf(chars);
+      }
+    }
+    return string;
+  }
+
+  /**
+   * Indicates whether {@code c} is one of the twenty-six uppercase ASCII alphabetic characters
+   * between {@code 'A'} and {@code 'Z'} inclusive. All others (including non-ASCII characters)
+   * return {@code false}.
+   */
+  public static boolean isUpperCase(char c) {
+    return (c >= 'A') && (c <= 'Z');
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/common/Ascii.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Ascii.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2014-present, Facebook, Inc.
+ * Copyright (c) 2007 The Guava Authors
+ *
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -9,7 +11,6 @@
 
 package com.facebook.stetho.common;
 
-/** Copyright (C) 2007 The Guava Authors */
 public final class Ascii {
   /**
    * If the argument is a {@linkplain #isLowerCase(char) lowercase ASCII character} returns the

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -155,4 +155,14 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
 
   protected void onGetStyles(E element, StyleAccumulator accumulator) {
   }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void setStyle(Object element, String text) {
+    onSetStyle((E) element, text);
+  }
+
+  protected void onSetStyle(E element, String text) {
+    mSuper.setStyle(element, text);
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -9,11 +9,14 @@
 
 package com.facebook.stetho.inspector.elements;
 
+import android.util.Pair;
+import com.facebook.stetho.common.Ascii;
 import com.facebook.stetho.common.ThreadBound;
 import com.facebook.stetho.common.UncheckedCallable;
 import com.facebook.stetho.common.Util;
 
 import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -100,6 +103,39 @@ public abstract class Descriptor implements NodeDescriptor {
       keyValuePairs.put(key, value);
     }
     return keyValuePairs;
+  }
+
+  /**
+   * Parses the text argument text from CSS.setPropertyText()
+   * Text will be in the format "attribute: value;"
+   * @param text the text argument to be parsed
+   * @return a pair of method name corresponding to the attribute and value to be set.
+   */
+  protected static Pair<String, String> parseSetPropertyTextArg(String text) {
+    int spaceIndex = text.indexOf(" ");
+    String key = text.substring(0, spaceIndex - 1);
+    String value = text.substring(spaceIndex + 1, text.length() - 1);
+    return new Pair<>(propertyKeyToSetterMethodName(key), value);
+  }
+
+  /** Converts an attribute name from CSS.setPropertyText() into a setter method name */
+  private static String propertyKeyToSetterMethodName(String text) {
+    boolean uppercaseNextChar = false;
+    StringBuilder buffer = new StringBuilder(text.length());
+    for (int i = 0, N = text.length(); i < N; ++i) {
+      final char c = text.charAt(i);
+      if (c == '-') {
+        uppercaseNextChar = true;
+      } else {
+        buffer.append(!uppercaseNextChar ? c : Ascii.toUpperCase(c));
+        uppercaseNextChar = false;
+      }
+    }
+    return "set" + firstCharToUpper(buffer.toString());
+  }
+
+  private static String firstCharToUpper(String word) {
+    return word.isEmpty() ? word : Ascii.toUpperCase(word.charAt(0)) + word.substring(1);
   }
 
   public interface Host extends ThreadBound {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -142,8 +142,12 @@ public final class Document extends ThreadBoundProxy {
 
   public void getElementStyles(Object element, StyleAccumulator styleAccumulator) {
     NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
-
     nodeDescriptor.getStyles(element, styleAccumulator);
+  }
+
+  public void setElementStyle(Object element, String text) {
+    NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
+    nodeDescriptor.setStyle(element, text);
   }
 
   public DocumentView getDocumentView() {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -35,4 +35,6 @@ public interface NodeDescriptor extends ThreadBound {
   void setAttributesAsText(Object element, String text);
 
   void getStyles(Object element, StyleAccumulator accumulator);
+
+  void setStyle(Object element, String text);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -55,4 +55,8 @@ public final class ObjectDescriptor extends Descriptor {
   @Override
   public void getStyles(Object element, StyleAccumulator accumulator) {
   }
+
+  @Override
+  public void setStyle(Object element, String text) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -130,4 +130,8 @@ final class DialogFragmentDescriptor
   @Override
   public void getStyles(Object element, StyleAccumulator styles) {
   }
+
+  @Override
+  public void setStyle(Object element, String text) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -9,6 +9,7 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewDebug;
 import com.facebook.stetho.common.LogUtil;
@@ -134,6 +135,12 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
     }
   }
 
+  @Override
+  protected void onSetStyle(View element, String text) {
+    Pair<String, String> keyValuePair = parseSetPropertyTextArg(text);
+    mMethodInvoker.invoke(element, keyValuePair.first, keyValuePair.second);
+  }
+
   @Nullable
   private static String getIdAttribute(View element) {
     int id = element.getId();
@@ -150,7 +157,6 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
 
   @Override
   protected void onGetStyles(View element, StyleAccumulator styles) {
-
     List<ViewCSSProperty> properties = getViewProperties();
     for (int i = 0, size = properties.size(); i < size; i++) {
       ViewCSSProperty property = properties.get(i);

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -23,6 +23,7 @@ import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsMethod;
 import com.facebook.stetho.json.ObjectMapper;
 import com.facebook.stetho.json.annotation.JsonProperty;
+
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -91,6 +92,57 @@ public class CSS implements ChromeDevtoolsDomain {
   }
 
   @ChromeDevtoolsMethod
+  public SetPropertyTextResult setPropertyText(JsonRpcPeer peer, JSONObject params) {
+    final SetPropertyTextRequest request =  mObjectMapper.convertValue(
+        params,
+        SetPropertyTextRequest.class);
+
+    final SetPropertyTextResult result = new SetPropertyTextResult();
+    result.style = new CSSStyle();
+    result.style.shorthandEntries = Collections.emptyList();
+    result.style.cssProperties = new ArrayList<>();
+    result.style.styleSheetId = request.styleSheetId;
+
+    mDocument.postAndWait(new Runnable() {
+      @Override
+      public void run() {
+        int nodeId;
+        try {
+          nodeId = Integer.valueOf(request.styleSheetId);
+        } catch (NumberFormatException e) {
+          LogUtil.w("Failed to set style of an element, cannot nodeid=" + request.styleSheetId);
+          return;
+        }
+        Object elementForNodeId = mDocument.getElementForNodeId(nodeId);
+
+        if (elementForNodeId == null) {
+          LogUtil.w("Failed to get style of an element that does not exist, nodeid=" +
+              request.styleSheetId);
+        }
+
+        mDocument.setElementStyle(elementForNodeId, request.text);
+
+        mDocument.getElementStyles(
+            elementForNodeId,
+            new StyleAccumulator() {
+              @Override
+              public void store(String name, String value, boolean isDefault) {
+                if (!isDefault) {
+                  CSSProperty property = new CSSProperty();
+                  property.name = name;
+                  property.value = value;
+
+                  result.style.cssProperties.add(property);
+                }
+              }
+            });
+      }
+    });
+
+    return result;
+  }
+
+  @ChromeDevtoolsMethod
   public JsonRpcResult getMatchedStylesForNode(JsonRpcPeer peer, JSONObject params) {
     final GetMatchedStylesForNodeRequest request = mObjectMapper.convertValue(
         params,
@@ -115,6 +167,7 @@ public class CSS implements ChromeDevtoolsDomain {
     rule.selectorList.selectors = ListUtil.newImmutableList(selector);
 
     rule.style = new CSSStyle();
+    rule.style.styleSheetId = String.valueOf(request.nodeId);
     rule.style.cssProperties = new ArrayList<>();
 
     match.rule = rule;
@@ -324,6 +377,12 @@ public class CSS implements ChromeDevtoolsDomain {
 
   private static class GetMatchedStylesForNodeResult implements JsonRpcResult {
     @JsonProperty
+    public CSSStyle inlineStyle;
+
+    @JsonProperty
+    public CSSStyle attributesStyle;
+
+    @JsonProperty
     public List<RuleMatch> matchedCSSRules;
 
     @JsonProperty
@@ -331,5 +390,18 @@ public class CSS implements ChromeDevtoolsDomain {
 
     @JsonProperty
     public List<InheritedStyleEntry> inherited;
+  }
+
+  private static class SetPropertyTextRequest implements JsonRpcResult {
+    @JsonProperty(required = true)
+    public String styleSheetId;
+
+    @JsonProperty(required = true)
+    public String text;
+  }
+
+  private static class SetPropertyTextResult implements JsonRpcResult {
+    @JsonProperty(required = true)
+    public CSSStyle style;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -110,7 +110,8 @@ public class CSS implements ChromeDevtoolsDomain {
         try {
           nodeId = Integer.valueOf(request.styleSheetId);
         } catch (NumberFormatException e) {
-          LogUtil.w("Failed to set style of an element, cannot nodeid=" + request.styleSheetId);
+          LogUtil.w("Failed to set style of an element, cannot find element with nodeid=" +
+              request.styleSheetId);
           return;
         }
         Object elementForNodeId = mDocument.getElementForNodeId(nodeId);

--- a/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.verify;
 @Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
 @RunWith(RobolectricTestRunner.class)
 public class ViewDescriptorTest {
-
   private final MethodInvoker mMethodInvoker = mock(MethodInvoker.class);
   private final ViewDescriptor mDescriptor = new ViewDescriptor(mMethodInvoker);
   private final Activity mActivity = Robolectric.setupActivity(Activity.class);
@@ -56,5 +55,17 @@ public class ViewDescriptorTest {
   public void testSetAttributeAsTextIgnoreInvalidFormat() {
     mDescriptor.setAttributesAsText(mTextView, "garbage");
     verify(mMethodInvoker, never()).invoke(anyObject(), anyString(), anyString());
+  }
+
+  @Test
+  public void testSetPropertyTextSimple() {
+    mDescriptor.setStyle(mTextView, "y: 46;");
+    verify(mMethodInvoker).invoke(mTextView, "setY", "46");
+  }
+
+  @Test
+  public void testSetPropertyTextDashes() {
+    mDescriptor.setStyle(mTextView, "scale-x: 2;");
+    verify(mMethodInvoker).invoke(mTextView, "setScaleX", "2");
   }
 }


### PR DESCRIPTION
This is an initial stab at adding support for editing View properties via the CSS tab in the Elements tab.
There are a few problems/drawbacks here:
- I'm using Chrome 45 which uses `CSS.setPropertyText`. However, that doesn't seem to be in the [protocol specification](https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/devtools/protocol.json&q=protocol.json&sq=package:chromium&type=cs) anymore. In fact, `setPropertyText` has been migrated to `setStyleText` [in June](https://chromium.googlesource.com/chromium/src/+/43034046ffeeb2316ba26d00fde97b4202cf404e) but apparently hasn't shipped to Chrome Stable yet.
- Right now this is only able to set simple properties (egg.: x, y, scaleX, scaleY) that have a corresponding setter method (setX, setY, setScaleX, setScaleY, etc) using `MethodInvoker`. We probably need to be able to support setting other stuff like padding and margins, however that may require a more customized approach. I see that some similar logic has been implemented for `getStyles()` so @ichub might have ideas on how we could achieve this.
