### PR TITLE
Fixed a couple of memory leaks.

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -103,10 +103,10 @@ abstract class ViewHighlighter {
       }
 
       if (viewToHighlight != null) {
-
         mHighlightOverlays.highlightView(viewToHighlight, mContentColor.get());
-        mHighlightedView = viewToHighlight;
       }
+
+      mHighlightedView = viewToHighlight;
     }
   }
 }


### PR DESCRIPTION
1. The map in ViewGroupDescriptor now stores WeakReference<Object> as a value instead of Object directly. Since views were stored there directly that could cause activities to be leaked through the context of the view.
2. The highlight view field is now nulled out when the highlighting is cleared.