### PR TITLE
Unit tests for stetho-js-rhino are now using jUnit4 (ditching Robolectric)

### DIFF
--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     compile 'org.mozilla:rhino:1.7.6'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:2.4'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho-js-rhino/src/test/java/com/facebook/stetho/rhino/JsFormatTest.java
+++ b/stetho-js-rhino/src/test/java/com/facebook/stetho/rhino/JsFormatTest.java
@@ -9,16 +9,13 @@
 
 package com.facebook.stetho.rhino;
 
-import android.os.Build;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.junit.runners.JUnit4;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-@Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
-@RunWith(RobolectricTestRunner.class)
+@RunWith(JUnit4.class)
 public class JsFormatTest {
 
   @Test


### PR DESCRIPTION

Turns out that in the pull request "Js tweaks #286" it was mentioned that
the unit tests where using Robolectric for no reason.

Somehow the patch with the unit tests fix wasn't merged.