### PR TITLE
Display logs with ASSERT level as ERROR messages in Chrome console.

### DIFF
--- a/stetho-timber/src/main/java/com/facebook/stetho/timber/StethoTree.java
+++ b/stetho-timber/src/main/java/com/facebook/stetho/timber/StethoTree.java
@@ -47,6 +47,7 @@ public class StethoTree extends Timber.Tree {
         logLevel = Console.MessageLevel.WARNING;
         break;
       case Log.ERROR:
+      case Log.ASSERT:
         logLevel = Console.MessageLevel.ERROR;
         break;
       default:


### PR DESCRIPTION
`ASSERT` log level often means **never_should_happen** type of errors, so let them look like errors in Chrome console.