### PR TITLE
Bundle default proguard rules

### DIFF
--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+        consumerProguardFiles 'proguard-consumer.pro'
     }
 
     lintOptions {

--- a/stetho-js-rhino/proguard-consumer.pro
+++ b/stetho-js-rhino/proguard-consumer.pro
@@ -1,0 +1,22 @@
+-keep class com.facebook.stetho.rhino.** { *; }
+
+# rhino (javascript)
+-dontwarn org.mozilla.javascript.**
+-dontwarn org.mozilla.classfile.**
+-keep class org.mozilla.classfile.** { *; }
+-keep class org.mozilla.javascript.* { *; }
+-keep class org.mozilla.javascript.annotations.** { *; }
+-keep class org.mozilla.javascript.ast.** { *; }
+-keep class org.mozilla.javascript.commonjs.module.** { *; }
+-keep class org.mozilla.javascript.commonjs.module.provider.** { *; }
+-keep class org.mozilla.javascript.debug.** { *; }
+-keep class org.mozilla.javascript.jdk13.** { *; }
+-keep class org.mozilla.javascript.jdk15.** { *; }
+-keep class org.mozilla.javascript.json.** { *; }
+-keep class org.mozilla.javascript.optimizer.** { *; }
+-keep class org.mozilla.javascript.regexp.** { *; }
+-keep class org.mozilla.javascript.serialize.** { *; }
+-keep class org.mozilla.javascript.typedarrays.** { *; }
+-keep class org.mozilla.javascript.v8dtoa.** { *; }
+-keep class org.mozilla.javascript.xml.** { *; }
+-keep class org.mozilla.javascript.xmlimpl.** { *; }

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+        consumerProguardFiles 'proguard-consumer.pro'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 }

--- a/stetho/proguard-consumer.pro
+++ b/stetho/proguard-consumer.pro
@@ -1,0 +1,2 @@
+-keep class com.facebook.stetho.** { *; }
+-dontwarn com.facebook.stetho.**


### PR DESCRIPTION
v0.5.7 of the android gradle build plugin added support for bundling proguard rules in an aar using `consumerProguardFiles`

This adds base proguard rules to the stetho aar and stetho-js-rhino aar. This will allow usage of these modules in a proguarded project without the developer needing to hunt down and configure proguard for stetho.