### PR TITLE
Add ability to toggle view inspection

### DIFF
--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
@@ -50,6 +50,7 @@ public class SampleDebugApplication extends SampleApplication {
           }
         })
         .enableWebKitInspector(new ExtInspectorModulesProvider(context))
+        .enableViewInspection(true) // Default setting is true
         .build());
   }
 


### PR DESCRIPTION
This is a quick fix to add the option to disable view inspection. It's a great addition, but can cause significant slowdown for applications with deep hierarchies.