### PR TITLE
Fix for duplicates in Element tree, and fix JSON unit test

### DIFF
--- a/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
@@ -29,6 +29,7 @@ import java.util.ListIterator;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link ObjectMapper}
@@ -69,14 +70,23 @@ public class ObjectMapperTest {
     njp.child1.testString = "testString";
     njp.child2.i = 4;
 
-    String expected = "{\"child1\":{\"testString\":\"testString\"},\"child2\":{\"i\":4}}";
-    NestedJsonProperty parsed = mObjectMapper.convertValue(
-        new JSONObject(expected),
+    // The ordering of serialization changes depending on Java 7 vs Java 8.
+    String expected7 = "{\"child1\":{\"testString\":\"testString\"},\"child2\":{\"i\":4}}";
+    String expected8 = "{\"child2\":{\"i\":4},\"child1\":{\"testString\":\"testString\"}}";
+
+    NestedJsonProperty parsed7 = mObjectMapper.convertValue(
+        new JSONObject(expected7),
         NestedJsonProperty.class);
-    assertEquals(njp, parsed);
+    assertEquals(njp, parsed7);
+
+    NestedJsonProperty parsed8 = mObjectMapper.convertValue(
+        new JSONObject(expected8),
+        NestedJsonProperty.class);
+    assertEquals(njp, parsed8);
 
     JSONObject jsonObject = mObjectMapper.convertValue(njp, JSONObject.class);
-    assertEquals(expected, jsonObject.toString());
+
+    assertTrue(expected7.equals(jsonObject.toString()) || expected8.equals(jsonObject.toString()));
   }
 
   @Test


### PR DESCRIPTION
Looks like this actually broke back in #237. We missed 1 tiny detail in the middle of a very large refactoring job.

When we transmit DOM changes to Chrome, we need to keep track of all the elements for each transmission so we don't send over duplicates. When we send over `DOM.childNodeInserted(E)`, which includes E and its whole sub-tree "by value", we must not send a subsequent `DOM.childNodeInserted(*)` for any elements within E's sub-tree, otherwise they'll show up as duplicates in the DevTools UI.

This was managed with a `HashSet` indirectly populated by `DOM.createNodeForElement()` and checked by `ShadowDocument.applyDocumentUpdate()`. The code is still there in the latter, but it got lost in the former. It was only storing the root node of any transmitted sub-tree into the `HashSet` (indirectly via the `Accumulator` interface).

Also, the ObjectMapperTest has been failing due to Java 8 changing the order of things. That commit is also part of thie PR.

Closes #339 
Closes #347