### PR TITLE
Work around Travis memory restrictions with stetho-js-rhino

### DIFF
--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -20,8 +20,8 @@ android {
     dexOptions {
         // This library is huge and causes Travis issues due to
         // https://github.com/facebook/stetho/issues/354
-        javaMaxHeapSize "512M"
-        threadCount 2
+        javaMaxHeapSize "256M"
+        threadCount 1
     }
 }
 

--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -16,6 +16,13 @@ android {
         // Rhino has references to awt and swing
         disable 'InvalidPackage'
     }
+
+    dexOptions {
+        // This library is huge and causes Travis issues due to
+        // https://github.com/facebook/stetho/issues/354
+        javaMaxHeapSize "512M"
+        threadCount 2
+    }
 }
 
 dependencies {


### PR DESCRIPTION
stetho-js-rhino is a huge artifact due to the external dependency on
Mozilla's Rhino package.  This causes extreme memory usage when dexing
the artifact as part of task
:stetho-js-rhino:transformClassesWithDexForDebugAndroidTest.  It is
believed that the cgroup policy applied to our job causes the process to
be killed as a result.

This change attempts to reduce the total resource load of the dx step to
sneak by this limit.

Fixes #354