### PR TITLE
Fixed SqliteDatabaseDriver with custom DatabaseFilesProvider

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/SqliteDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/SqliteDatabaseDriver.java
@@ -201,12 +201,22 @@ public class SqliteDatabaseDriver extends Database.DatabaseDriver {
 
   private SQLiteDatabase openDatabase(String databaseName) throws SQLiteException {
     Util.throwIfNull(databaseName);
-    File databaseFile = mContext.getDatabasePath(databaseName);
+    File databaseFile = findDatabaseFile(databaseName);
 
     // Execpted to throw if it cannot open the file (for example, if it doesn't exist).
     return SQLiteDatabase.openDatabase(databaseFile.getAbsolutePath(),
         null /* cursorFactory */,
         SQLiteDatabase.OPEN_READWRITE);
+  }
+
+  private File findDatabaseFile(String databaseName) {
+    for (File providedDatabaseFile : mDatabaseFilesProvider.getDatabaseFiles()) {
+      if (providedDatabaseFile.getName().equals(databaseName)) {
+        return providedDatabaseFile;
+      }
+    }
+
+    return mContext.getDatabasePath(databaseName);
   }
 
 }


### PR DESCRIPTION
When opening a table the DatabaseFilesProvider is first checked for the table then if not found there we fall back to the context.getDatabasePath() call.

If a custom DatabaseFilesProvider is used then the context.getDatabasePath() won't find those databases.