### PR TITLE
Accessibility

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
@@ -69,6 +69,10 @@ public final class ListUtil {
     return new OneItemImmutableList<>(item);
   }
 
+  public static <T> List<T> newImmutableList(T itemOne, T itemTwo) {
+    return new TwoItemImmutableList<>(itemOne, itemTwo);
+  }
+
   private static interface ImmutableList<E> extends List<E>, RandomAccess {
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -155,4 +155,14 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
 
   protected void onGetStyles(E element, StyleAccumulator accumulator) {
   }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+    mSuper.getAccessibilityStyles(element, accumulator);
+    onGetAccessibilityStyles((E) element, accumulator);
+  }
+
+  protected void onGetAccessibilityStyles(E element, StyleAccumulator accumulator) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -146,6 +146,12 @@ public final class Document extends ThreadBoundProxy {
     nodeDescriptor.getStyles(element, styleAccumulator);
   }
 
+  public void getElementAccessibilityStyles(Object element, StyleAccumulator styleAccumulator) {
+    NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
+
+    nodeDescriptor.getAccessibilityStyles(element, styleAccumulator);
+  }
+
   public DocumentView getDocumentView() {
     verifyThreadAccess();
     return mShadowDocument;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -35,4 +35,6 @@ public interface NodeDescriptor extends ThreadBound {
   void setAttributesAsText(Object element, String text);
 
   void getStyles(Object element, StyleAccumulator accumulator);
+
+  void getAccessibilityStyles(Object element, StyleAccumulator accumulator);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -55,4 +55,8 @@ public final class ObjectDescriptor extends Descriptor {
   @Override
   public void getStyles(Object element, StyleAccumulator accumulator) {
   }
+
+  @Override
+  public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements.android;
+
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.view.View;
+import android.view.ViewParent;
+
+public final class AccessibilityNodeInfoWrapper {
+
+  public AccessibilityNodeInfoWrapper() {
+  }
+
+  public static boolean getIgnored(View view, AccessibilityNodeInfoCompat nodeInfo) {
+    int important = ViewCompat.getImportantForAccessibility(view);
+
+    if (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO ||
+        important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+      return true;
+    }
+
+    // Go all the way up the tree to make sure no parent has hidden its descendants
+    ViewParent parent = view.getParent();
+    while (parent instanceof View) {
+      if (ViewCompat.getImportantForAccessibility((View) parent)
+          == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+        return true;
+      }
+      parent = parent.getParent();
+    }
+
+    // AccessibilityNodeInfo is actionable
+    if (nodeInfo.isClickable() || nodeInfo.isLongClickable() || nodeInfo.isFocusable()) {
+      return false;
+    }
+
+    // AccessibilityNodeInfo has text set (commonly set from TextViews and Switches).
+    CharSequence nodeText = nodeInfo.getText();
+    if (nodeText != null && nodeText.length() > 0) {
+      return false;
+    }
+
+    // AccessibilityNodeInfo has a content description
+    CharSequence contentDescription = nodeInfo.getContentDescription();
+    if (contentDescription != null && contentDescription.length() > 0) {
+      return false;
+    }
+
+    // View has an AccessibilityNodeProvider
+    if (ViewCompat.getAccessibilityNodeProvider(view) != null) {
+      return false;
+    }
+
+    // View has an AccessibilityDelegate
+    if (ViewCompat.hasAccessibilityDelegate(view)){
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -130,4 +130,8 @@ final class DialogFragmentDescriptor
   @Override
   public void getStyles(Object element, StyleAccumulator styles) {
   }
+
+  @Override
+  public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -9,8 +9,10 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewDebug;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
 
 import com.facebook.stetho.common.ExceptionUtil;
 import com.facebook.stetho.common.LogUtil;
@@ -180,6 +182,21 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
         }
       }
     }
+  }
+
+  @Override
+  protected void onGetAccessibilityStyles(View element, StyleAccumulator styles) {
+    AccessibilityNodeInfoCompat nodeInfo = AccessibilityNodeInfoCompat.obtain();
+    ViewCompat.onInitializeAccessibilityNodeInfo(element, nodeInfo);
+
+    getStyleFromValue(
+        element,
+        "ignored",
+        AccessibilityNodeInfoWrapper.getIgnored(element, nodeInfo),
+        null,
+        styles);
+
+    nodeInfo.recycle();
   }
 
   private static boolean canIntBeMappedToString(@Nullable ViewDebug.ExportedProperty annotation) {


### PR DESCRIPTION
Added the basic start for accessibility inspection, and a wrapper class to hold all of the methods for various accessibility properties I plan to add to the inspector.  For now these will appear as a second CSS Selector alongside other view properties.  The only one currently implemented is "ignored", which signifies whether or not a node will be ignored by accessibility services.

I plan to follow the properties of the AXNode type in the Chrome Debugging Protocol (http://chromedevtools.github.io/debugger-protocol-viewer/tot/Accessibility/#type-AXNode).  This will make it easier to transition to the Accessibility Panel if Stetho is upgraded past the 1.1 version of the protocol.

I'm not sure if this is a problem, but by adding the "getStyleFromBoolean" and getStyleFromCharString" methods into ViewDescriptor.java, I have exposed a lot more of the methods/fields of the standard View class.  If that's not desired, I can change the approach here.

Screenshot:
![screen shot 2016-05-31 at 2 33 01 pm](https://cloud.githubusercontent.com/assets/1518064/15691315/cad690b4-273c-11e6-967d-e24128a8072d.png)