### PR TITLE
Improve support for custom SQLite open flags

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseConnectionProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseConnectionProvider.java
@@ -12,11 +12,16 @@ package com.facebook.stetho.inspector.database;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 
+import com.facebook.stetho.inspector.database.SQLiteDatabaseCompat.SQLiteOpenOptions;
+
 import java.io.File;
 
 /**
  * Opens the requested database using
  * {@link SQLiteDatabase#openDatabase(String, SQLiteDatabase.CursorFactory, int)} directly.
+ *
+ * <p>It is intended that this class be subclassed to enable/disable features via
+ * {@link #determineOpenOptions(File)}</p>
  */
 public class DefaultDatabaseConnectionProvider implements DatabaseConnectionProvider {
   public DefaultDatabaseConnectionProvider() {
@@ -24,10 +29,43 @@ public class DefaultDatabaseConnectionProvider implements DatabaseConnectionProv
 
   @Override
   public SQLiteDatabase openDatabase(File databaseFile) throws SQLiteException {
-    // Expected to throw if it cannot open the file (for example, if it doesn't exist).
-    return SQLiteDatabase.openDatabase(
+    return performOpen(
+        databaseFile,
+        determineOpenOptions(databaseFile));
+  }
+
+  /**
+   * Subclassing this function is intended to provide custom open behaviour on a per-file basis.
+   */
+  protected @SQLiteOpenOptions int determineOpenOptions(File databaseFile) {
+    @SQLiteOpenOptions int flags = 0;
+
+    // Try to guess if we should be using write-ahead logging.  If this heuristic fails
+    // developers are expected to subclass this provider and explicitly assert the connection.
+    File walFile = new File(databaseFile.getParent(), databaseFile.getName() + "-wal");
+    if (walFile.exists()) {
+      flags |= SQLiteDatabaseCompat.ENABLE_WRITE_AHEAD_LOGGING;
+    }
+
+    return flags;
+  }
+
+  /**
+   * Perform the open per the options provided in {@link #determineOpenOptions(File)}.
+   * Subclassing is supported however this typically indicates a missing feature of some kind
+   * in {@link SQLiteDatabaseCompat} that should be patched in Stetho itself.
+   */
+  protected SQLiteDatabase performOpen(File databaseFile, @SQLiteOpenOptions int options) {
+    int flags = SQLiteDatabase.OPEN_READWRITE;
+
+    SQLiteDatabaseCompat compatInstance = SQLiteDatabaseCompat.getInstance();
+    flags |= compatInstance.provideOpenFlags(options);
+
+    SQLiteDatabase db = SQLiteDatabase.openDatabase(
         databaseFile.getAbsolutePath(),
         null /* cursorFactory */,
-        SQLiteDatabase.OPEN_READWRITE);
+        flags);
+    compatInstance.enableFeatures(options, db);
+    return db;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/SQLiteDatabaseCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/SQLiteDatabaseCompat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.database;
+
+import android.annotation.TargetApi;
+import android.database.sqlite.SQLiteDatabase;
+import android.os.Build;
+import android.support.annotation.IntDef;
+
+/**
+ * Compatibility layer which supports opening databases with WAL and foreign key support
+ * where supported.
+ *
+ * <p>For simplicity of implementation, all options are <em>ignored</em> prior to Honeycomb.</p>
+ */
+public abstract class SQLiteDatabaseCompat {
+  public static final int ENABLE_WRITE_AHEAD_LOGGING = 0x1;
+  public static final int ENABLE_FOREIGN_KEY_CONSTRAINTS = 0x2;
+  @IntDef(
+      value = { ENABLE_WRITE_AHEAD_LOGGING, ENABLE_FOREIGN_KEY_CONSTRAINTS },
+      flag = true)
+  public @interface SQLiteOpenOptions {}
+
+  private static final SQLiteDatabaseCompat sInstance;
+
+  static {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      sInstance = new JellyBeanAndBeyondImpl();
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+      sInstance = new HoneycombImpl();
+    } else {
+      sInstance = new NoopImpl();
+    }
+  }
+
+  public static SQLiteDatabaseCompat getInstance() {
+    return sInstance;
+  }
+
+  public abstract int provideOpenFlags(@SQLiteOpenOptions int openOptions);
+  public abstract void enableFeatures(@SQLiteOpenOptions int openOptions, SQLiteDatabase db);
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  private static class JellyBeanAndBeyondImpl extends SQLiteDatabaseCompat {
+    @Override
+    public int provideOpenFlags(@SQLiteOpenOptions int openOptions) {
+      int openFlags = 0;
+      if ((openOptions & ENABLE_WRITE_AHEAD_LOGGING) != 0) {
+        openFlags |= SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING;
+      }
+      return openFlags;
+    }
+
+    @Override
+    public void enableFeatures(@SQLiteOpenOptions int openOptions, SQLiteDatabase db) {
+      if ((openOptions & ENABLE_FOREIGN_KEY_CONSTRAINTS) != 0) {
+        db.setForeignKeyConstraintsEnabled(true);
+      }
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+  private static class HoneycombImpl extends SQLiteDatabaseCompat {
+    @Override
+    public int provideOpenFlags(@SQLiteOpenOptions int openOptions) {
+      return 0;
+    }
+
+    @Override
+    public void enableFeatures(@SQLiteOpenOptions int openOptions, SQLiteDatabase db) {
+      if ((openOptions & ENABLE_WRITE_AHEAD_LOGGING) != 0) {
+        db.enableWriteAheadLogging();
+      }
+
+      if ((openOptions & ENABLE_FOREIGN_KEY_CONSTRAINTS) != 0) {
+        db.execSQL("PRAGMA foreign_keys = ON");
+      }
+    }
+  }
+
+  private static class NoopImpl extends SQLiteDatabaseCompat {
+    @Override
+    public int provideOpenFlags(@SQLiteOpenOptions int openOptions) {
+      return 0;
+    }
+
+    @Override
+    public void enableFeatures(@SQLiteOpenOptions int openOptions, SQLiteDatabase db) {
+    }
+  }
+}


### PR DESCRIPTION
This diff adds a WAL-guessing heuristic to support most database users
for the common case as well as expands upon
DefaultDatabaseConnectionProvider to fully support subclassing to
conveniently select custom options on a per database file basis.