### PR TITLE
Fix database id mapping to remove guesswork hacks

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -44,7 +44,6 @@ import com.facebook.stetho.inspector.protocol.module.DOM;
 import com.facebook.stetho.inspector.protocol.module.DOMStorage;
 import com.facebook.stetho.inspector.protocol.module.Database;
 import com.facebook.stetho.inspector.protocol.module.DatabaseConstants;
-import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
 import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
 import com.facebook.stetho.inspector.protocol.module.Debugger;
 import com.facebook.stetho.inspector.protocol.module.HeapProfiler;
@@ -301,7 +300,7 @@ public class Stetho {
      * @deprecated Convert your custom database driver to {@link DatabaseDriver2}.
      */
     @Deprecated
-    public DefaultInspectorModulesBuilder provideDatabaseDriver(DatabaseDriver databaseDriver) {
+    public DefaultInspectorModulesBuilder provideDatabaseDriver(Database.DatabaseDriver databaseDriver) {
       provideDatabaseDriver(new DatabaseDriver2Adapter(databaseDriver));
       return this;
     }

--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -12,7 +12,6 @@ package com.facebook.stetho;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.Util;
@@ -26,7 +25,8 @@ import com.facebook.stetho.dumpapp.plugins.HprofDumperPlugin;
 import com.facebook.stetho.dumpapp.plugins.SharedPreferencesDumperPlugin;
 import com.facebook.stetho.inspector.DevtoolsSocketHandler;
 import com.facebook.stetho.inspector.console.RuntimeReplFactory;
-import com.facebook.stetho.inspector.database.DatabaseConnectionProvider;
+import com.facebook.stetho.inspector.database.ContentProviderDatabaseDriver;
+import com.facebook.stetho.inspector.database.DatabaseDriver2Adapter;
 import com.facebook.stetho.inspector.database.DatabaseFilesProvider;
 import com.facebook.stetho.inspector.database.DefaultDatabaseConnectionProvider;
 import com.facebook.stetho.inspector.database.DefaultDatabaseFilesProvider;
@@ -44,6 +44,8 @@ import com.facebook.stetho.inspector.protocol.module.DOM;
 import com.facebook.stetho.inspector.protocol.module.DOMStorage;
 import com.facebook.stetho.inspector.protocol.module.Database;
 import com.facebook.stetho.inspector.protocol.module.DatabaseConstants;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
 import com.facebook.stetho.inspector.protocol.module.Debugger;
 import com.facebook.stetho.inspector.protocol.module.HeapProfiler;
 import com.facebook.stetho.inspector.protocol.module.Inspector;
@@ -241,7 +243,8 @@ public class Stetho {
     @Nullable private DocumentProviderFactory mDocumentProvider;
     @Nullable private RuntimeReplFactory mRuntimeRepl;
     @Nullable private DatabaseFilesProvider mDatabaseFilesProvider;
-    @Nullable private List<Database.DatabaseDriver> mDatabaseDrivers;
+    @Nullable private List<DatabaseDriver2> mDatabaseDrivers;
+    private boolean mExcludeSqliteDatabaseDriver;
 
     public DefaultInspectorModulesBuilder(Context context) {
       mContext = (Application)context.getApplicationContext();
@@ -285,7 +288,8 @@ public class Stetho {
      *       new DefaultDatabaseConnectionProvider(...)))
      * </pre>
      *
-     * @deprecated See example alternative above.
+     * @deprecated Use {@link #provideDatabaseDriver(DatabaseDriver2)} with
+     *     {@link SqliteDatabaseDriver} explicitly.
      */
     @Deprecated
     public DefaultInspectorModulesBuilder databaseFiles(DatabaseFilesProvider provider) {
@@ -294,16 +298,42 @@ public class Stetho {
     }
 
     /**
-     * Extend and provide additional database drivers. Currently two database drivers are supported
-     * in this lib: <br>
-     *   1. <code>SqliteDatabaseDriver</code> - Presents sqlite databases and all tables of the app.<br>
-     *   2. <code>ContentProviderDatabaseDriver</code> - Configure and present content providers data.
+     * @deprecated Convert your custom database driver to {@link DatabaseDriver2}.
      */
-    public DefaultInspectorModulesBuilder provideDatabaseDriver(Database.DatabaseDriver databaseDriver) {
+    @Deprecated
+    public DefaultInspectorModulesBuilder provideDatabaseDriver(DatabaseDriver databaseDriver) {
+      provideDatabaseDriver(new DatabaseDriver2Adapter(databaseDriver));
+      return this;
+    }
+
+    /**
+     * Extend and provide additional database drivers.  Stetho provides two database
+     * drivers by default, with the option for developers to provide their own:
+     * <ol>
+     *   <li>{@link SqliteDatabaseDriver} - Presents SQLite databases.</li>
+     *   <li>{@link ContentProviderDatabaseDriver} - Configure and present content provider
+     *   data.</li>
+     * </ol>
+     *
+     * <p>Stetho assumes the {@link SqliteDatabaseDriver} should be installed if
+     * no driver of that type is provided and {@link #excludeSqliteDatabaseDriver} is not
+     * used.</p>
+     */
+    public DefaultInspectorModulesBuilder provideDatabaseDriver(DatabaseDriver2 databaseDriver) {
       if (mDatabaseDrivers == null) {
         mDatabaseDrivers = new ArrayList<>();
       }
       mDatabaseDrivers.add(databaseDriver);
+      return this;
+    }
+
+    /**
+     * Do not automatically provide the {@link SqliteDatabaseDriver} instance.  The instance
+     * is provided by default for backwards compatibility purposes and simplicity of API, with
+     * this API provided to disable that functionality if desired.
+     */
+    public DefaultInspectorModulesBuilder excludeSqliteDatabaseDriver(boolean exclude) {
+      mExcludeSqliteDatabaseDriver = exclude;
       return this;
     }
 
@@ -363,18 +393,14 @@ public class Stetho {
         Database database = new Database();
         boolean hasSqliteDatabaseDriver = false;
         if (mDatabaseDrivers != null) {
-          for (Database.DatabaseDriver databaseDriver : mDatabaseDrivers) {
+          for (DatabaseDriver2 databaseDriver : mDatabaseDrivers) {
             database.add(databaseDriver);
             if (databaseDriver instanceof SqliteDatabaseDriver) {
               hasSqliteDatabaseDriver = true;
             }
           }
         }
-        if (!hasSqliteDatabaseDriver) {
-          // Add the SqliteDatabaseDriver by default for convenience.  If this isn't desired,
-          // the caller must install a dummy version of the driver (with an empty files provider).
-          // Not ideal, but given the current API and the need for backwards compatability we
-          // don't have much of a choice here...
+        if (!hasSqliteDatabaseDriver && !mExcludeSqliteDatabaseDriver) {
           database.add(
               new SqliteDatabaseDriver(mContext,
                   mDatabaseFilesProvider != null ?

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
@@ -16,7 +16,6 @@ import android.database.sqlite.SQLiteException;
 
 import com.facebook.stetho.inspector.protocol.module.Database;
 import com.facebook.stetho.inspector.protocol.module.DatabaseDescriptor;
-import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
 import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
 
 import java.util.ArrayList;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
@@ -13,38 +13,41 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
+
 import com.facebook.stetho.inspector.protocol.module.Database;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDescriptor;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @ThreadSafe
-public class ContentProviderDatabaseDriver extends Database.DatabaseDriver {
+public class ContentProviderDatabaseDriver
+    extends DatabaseDriver2<ContentProviderDatabaseDriver.ContentProviderDatabaseDescriptor> {
 
   private final static String sDatabaseName = "content-providers";
 
   private final ContentProviderSchema[] mContentProviderSchemas;
-  private List<String> mDatabaseNames;
   private List<String> mTableNames;
 
-  public ContentProviderDatabaseDriver(Context context, ContentProviderSchema... contentProviderSchemas) {
+  public ContentProviderDatabaseDriver(
+      Context context,
+      ContentProviderSchema... contentProviderSchemas) {
     super(context);
     mContentProviderSchemas = contentProviderSchemas;
   }
 
   @Override
-  public List<String> getDatabaseNames() {
-    if (mDatabaseNames == null && mContentProviderSchemas != null) {
-      mDatabaseNames = new ArrayList<>();
-      mDatabaseNames.add(sDatabaseName);
-    }
-    return mDatabaseNames;
+  public List<ContentProviderDatabaseDescriptor> getDatabaseNames() {
+    return Collections.singletonList(new ContentProviderDatabaseDescriptor());
   }
 
   @Override
-  public List<String> getTableNames(String databaseId) {
+  public List<String> getTableNames(ContentProviderDatabaseDescriptor databaseDesc) {
     if (mTableNames == null) {
       mTableNames = new ArrayList<>();
       for (ContentProviderSchema schema : mContentProviderSchemas) {
@@ -55,7 +58,10 @@ public class ContentProviderDatabaseDriver extends Database.DatabaseDriver {
   }
 
   @Override
-  public Database.ExecuteSQLResponse executeSQL(String databaseName, String query, ExecuteResultHandler<Database.ExecuteSQLResponse> handler) throws SQLiteException {
+  public Database.ExecuteSQLResponse executeSQL(
+      ContentProviderDatabaseDescriptor databaseDesc,
+      String query,
+      ExecuteResultHandler<Database.ExecuteSQLResponse> handler) throws SQLiteException {
 
     // resolve table name from query
     String tableName = fetchTableName(query);
@@ -91,4 +97,15 @@ public class ContentProviderDatabaseDriver extends Database.DatabaseDriver {
     return "";
   }
 
+  static class ContentProviderDatabaseDescriptor implements DatabaseDescriptor {
+    public ContentProviderDatabaseDescriptor() {
+    }
+
+    @Override
+    public String name() {
+      // Hmm, this probably should be each unique URI or authority instead of treating all
+      // content provider instances as one.
+      return sDatabaseName;
+    }
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
@@ -4,7 +4,6 @@ import android.database.sqlite.SQLiteException;
 
 import com.facebook.stetho.inspector.protocol.module.Database;
 import com.facebook.stetho.inspector.protocol.module.DatabaseDescriptor;
-import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
 import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
 
 import java.util.ArrayList;
@@ -17,9 +16,9 @@ import java.util.List;
 @Deprecated
 public class DatabaseDriver2Adapter
     extends DatabaseDriver2<DatabaseDriver2Adapter.StringDatabaseDescriptor> {
-  private final DatabaseDriver mLegacy;
+  private final Database.DatabaseDriver mLegacy;
 
-  public DatabaseDriver2Adapter(DatabaseDriver legacy) {
+  public DatabaseDriver2Adapter(Database.DatabaseDriver legacy) {
     super(legacy.getContext());
     mLegacy = legacy;
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
@@ -1,0 +1,62 @@
+package com.facebook.stetho.inspector.database;
+
+import android.database.sqlite.SQLiteException;
+
+import com.facebook.stetho.inspector.protocol.module.Database;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDescriptor;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver;
+import com.facebook.stetho.inspector.protocol.module.DatabaseDriver2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @deprecated Use {@link DatabaseDriver2} directly.  This is provided only for legacy
+ * drivers to be adapted internally within Stetho.
+ */
+@Deprecated
+public class DatabaseDriver2Adapter
+    extends DatabaseDriver2<DatabaseDriver2Adapter.StringDatabaseDescriptor> {
+  private final DatabaseDriver mLegacy;
+
+  public DatabaseDriver2Adapter(DatabaseDriver legacy) {
+    super(legacy.getContext());
+    mLegacy = legacy;
+  }
+
+  @Override
+  public List<StringDatabaseDescriptor> getDatabaseNames() {
+    List<?> names = mLegacy.getDatabaseNames();
+    List<StringDatabaseDescriptor> descriptors = new ArrayList<>(names.size());
+    for (Object name : names) {
+      descriptors.add(new StringDatabaseDescriptor(name.toString()));
+    }
+    return descriptors;
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<String> getTableNames(StringDatabaseDescriptor database) {
+    return mLegacy.getTableNames(database.name);
+  }
+
+  @SuppressWarnings("unchecked")
+  public Database.ExecuteSQLResponse executeSQL(
+      StringDatabaseDescriptor database,
+      String query,
+      ExecuteResultHandler handler) throws SQLiteException {
+    return mLegacy.executeSQL(database.name, query, handler);
+  }
+
+  static class StringDatabaseDescriptor implements DatabaseDescriptor {
+    public final String name;
+
+    public StringDatabaseDescriptor(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/BaseDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/BaseDatabaseDriver.java
@@ -16,15 +16,14 @@ import android.database.sqlite.SQLiteException;
 import java.util.List;
 
 /**
- * @deprecated Use {@link DatabaseDriver2} instead which enforces generics of
- * {@link DatabaseDescriptor}.
+ * Extend {@link DatabaseDriver2} directly.  This class is provided only as a common API compatible
+ * base layer for the legacy {@link Database.DatabaseDriver}.
  */
-@Deprecated
-public abstract class DatabaseDriver<DESC> {
+public abstract class BaseDatabaseDriver<DESC> {
 
   protected Context mContext;
 
-  public DatabaseDriver(Context context) {
+  public BaseDatabaseDriver(Context context) {
     mContext = context;
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.os.Build;
@@ -365,4 +366,15 @@ public class Database implements ChromeDevtoolsDomain {
     public int code;
   }
 
+  /**
+   * @deprecated Use {@link DatabaseDriver2} which allows for structured identifiers of database
+   *     objects (such as a file path instead of just a string name) which also serves as a
+   *     namespacing separation of multiple drivers.
+   */
+  @Deprecated
+  public static abstract class DatabaseDriver extends BaseDatabaseDriver<String> {
+    public DatabaseDriver(Context context) {
+      super(context);
+    }
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDescriptor.java
@@ -1,0 +1,8 @@
+package com.facebook.stetho.inspector.protocol.module;
+
+public interface DatabaseDescriptor {
+  /**
+   * The user visible name for this database.
+   */
+  String name();
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.protocol.module;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteException;
+
+import java.util.List;
+
+/**
+ * @deprecated Use {@link DatabaseDriver2} instead which enforces generics of
+ * {@link DatabaseDescriptor}.
+ */
+@Deprecated
+public abstract class DatabaseDriver<DESC> {
+
+  protected Context mContext;
+
+  public DatabaseDriver(Context context) {
+    mContext = context;
+  }
+
+  public Context getContext() {
+    return mContext;
+  }
+
+  /**
+   * Access a stable list of objects that describe the databases made available by this driver.
+   * The list of returned objects must not change on each invocation as this will cause
+   * a memory leak when assigning unique identifiers for the objects to remote peers.
+   */
+  public abstract List<DESC> getDatabaseNames();
+
+  /**
+   * Get or create a list of table names given a previously returned database descriptor instance
+   * from {@link #getDatabaseNames()}.
+   */
+  public abstract List<String> getTableNames(DESC database);
+
+  public abstract Database.ExecuteSQLResponse executeSQL(
+      DESC database,
+      String query,
+      ExecuteResultHandler<Database.ExecuteSQLResponse> handler)
+      throws SQLiteException;
+
+  public interface ExecuteResultHandler<RESULT> {
+    RESULT handleRawQuery() throws SQLiteException;
+
+    RESULT handleSelect(Cursor result) throws SQLiteException;
+
+    RESULT handleInsert(long insertedId) throws SQLiteException;
+
+    RESULT handleUpdateDelete(int count) throws SQLiteException;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.protocol.module;
+
+import android.content.Context;
+
+/**
+ * Replaces {@link DatabaseDriver} to enforce that the generic type must
+ * extend {@link DatabaseDescriptor}.
+ */
+public abstract class DatabaseDriver2<DESC extends DatabaseDescriptor>
+    extends DatabaseDriver<DESC> {
+  public DatabaseDriver2(Context context) {
+    super(context);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
@@ -12,11 +12,11 @@ package com.facebook.stetho.inspector.protocol.module;
 import android.content.Context;
 
 /**
- * Replaces {@link DatabaseDriver} to enforce that the generic type must
+ * Replaces {@link Database.DatabaseDriver} to enforce that the generic type must
  * extend {@link DatabaseDescriptor}.
  */
 public abstract class DatabaseDriver2<DESC extends DatabaseDescriptor>
-    extends DatabaseDriver<DESC> {
+    extends BaseDatabaseDriver<DESC> {
   public DatabaseDriver2(Context context) {
     super(context);
   }


### PR DESCRIPTION
The SqliteDatabaseDriver had to resort to counter intuitive hacks
to manually locate a database by its file name and didn't
properly handle deduplicating multiple databases with the same name.  As
we expanded flexibility we failed to address the possibility (nay,
likelihood) that this will occur and it would create very confusing
results for users.

This diff doesn't address the confusion in the UI (two database entries
of the same name can still occur) but it internally makes it possible to
treat them as separate databases and track their filenames separately.
It also makes it relatively straightforward to fix the uniqueness of the
user visible naming by introducing a "context" parameter to
DatabaseDescriptor which would be used in the case of name ambiguity.

This diff addresses concerns raised in #366 and #367.
