### PR TITLE
Fix importClass and importPackage not finding external classes

### DIFF
--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
@@ -189,7 +189,7 @@ public class JsRuntimeReplFactoryBuilder {
     for (Class<?> aClass : mClasses) {
       String className = aClass.getName();
       try {
-        String expression = String.format("importClass(%s)", className);
+        String expression = String.format("importClass(Packages.%s)", className);
         jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
       } catch (Exception e) {
         throw new StethoJsException(e, "Failed to import class: %s", className);
@@ -201,7 +201,7 @@ public class JsRuntimeReplFactoryBuilder {
     // Import the packages that the caller requested
     for (String packageName : mPackages) {
       try {
-        String expression = String.format("importPackage(%s)", packageName);
+        String expression = String.format("importPackage(Packages.%s)", packageName);
         jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
       } catch (Exception e) {
         throw new StethoJsException(e, "Failed to import package: %s", packageName);

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
@@ -189,10 +189,17 @@ public class JsRuntimeReplFactoryBuilder {
     for (Class<?> aClass : mClasses) {
       String className = aClass.getName();
       try {
-        String expression = String.format("importClass(Packages.%s)", className);
+        // import from default classes
+        String expression = String.format("importClass(%s)", className);
         jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
       } catch (Exception e) {
-        throw new StethoJsException(e, "Failed to import class: %s", className);
+        try {
+          // import from application classes
+          String expression = String.format("importClass(Packages.%s)", className);
+          jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
+        } catch (Exception e1) {
+          throw new StethoJsException(e1, "Failed to import class: %s", className);
+        }
       }
     }
   }
@@ -201,10 +208,17 @@ public class JsRuntimeReplFactoryBuilder {
     // Import the packages that the caller requested
     for (String packageName : mPackages) {
       try {
-        String expression = String.format("importPackage(Packages.%s)", packageName);
+        // import from default packages
+        String expression = String.format("importPackage(%s)", packageName);
         jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
       } catch (Exception e) {
-        throw new StethoJsException(e, "Failed to import package: %s", packageName);
+        try {
+          // import from application packages
+          String expression = String.format("importPackage(Packages.%s)", packageName);
+          jsContext.evaluateString(scope, expression, SOURCE_NAME, 1, null);
+        } catch (Exception e1) {
+          throw new StethoJsException(e, "Failed to import package: %s", packageName);
+        }
       }
     }
   }


### PR DESCRIPTION
For external packages, the package name needs to be prefixed with `Packages.` per https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Scripting_Java#External_Packages_and_Classes

Mostly fixes #405 
