### PR TITLE
Added ignoredReasons to accessibility inspection

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.common.android;
+
+import android.support.annotation.Nullable;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.text.TextUtils;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.AdapterView;
+import android.widget.HorizontalScrollView;
+import android.widget.ScrollView;
+import android.widget.Spinner;
+
+import java.util.List;
+
+/**
+ * This class provides utility methods for determining certain accessibility properties of
+ * {@link View}s and {@link AccessibilityNodeInfoCompat}s. It is porting some of the checks from
+ * {@link com.googlecode.eyesfree.utils.AccessibilityNodeInfoUtils}, but has stripped many features
+ * which are unnecessary here.
+ */
+public final class AccessibilityUtil {
+  private AccessibilityUtil() {
+  }
+
+  /**
+   * Returns whether the specified node has text or a content description.
+   *
+   * @param node The node to check.
+   * @return {@code true} if the node has text.
+   */
+  public static boolean hasText(@Nullable AccessibilityNodeInfoCompat node) {
+    if (node == null) {
+      return false;
+    }
+
+    return !TextUtils.isEmpty(node.getText()) || !TextUtils.isEmpty(node.getContentDescription());
+  }
+
+  /**
+   * Returns whether the supplied {@link View} and {@link AccessibilityNodeInfoCompat} would
+   * produce spoken feedback if it were accessibility focused.  NOTE: not all speaking nodes are
+   * focusable.
+   *
+   * @param view The {@link View} to evaluate
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if it meets the criterion for producing spoken feedback
+   */
+  public static boolean isSpeakingNode(
+      @Nullable AccessibilityNodeInfoCompat node,
+      @Nullable View view) {
+    if (node == null || view == null) {
+      return false;
+    }
+
+    if (!node.isVisibleToUser()) {
+      return false;
+    }
+
+    int important = ViewCompat.getImportantForAccessibility(view);
+    if (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS ||
+        (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO &&
+            node.getChildCount() <= 0)) {
+      return false;
+    }
+
+    return node.isCheckable() || hasText(node) || hasNonActionableSpeakingDescendants(node, view);
+  }
+
+  /**
+   * Determines if the supplied {@link View} and {@link AccessibilityNodeInfoCompat} has any
+   * children which are not independently accessibility focusable and also have a spoken
+   * description.
+   * <p>
+   * NOTE: Accessibility services will include these children's descriptions in the closest
+   * focusable ancestor.
+   *
+   * @param view The {@link View} to evaluate
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if it has any non-actionable speaking descendants within its subtree
+   */
+  public static boolean hasNonActionableSpeakingDescendants(
+      @Nullable AccessibilityNodeInfoCompat node,
+      @Nullable View view) {
+
+    if (node == null || view == null || !(view instanceof ViewGroup)) {
+      return false;
+    }
+
+    ViewGroup viewGroup = (ViewGroup) view;
+    for (int i = 0, count = viewGroup.getChildCount(); i < count; i++) {
+      View childView = viewGroup.getChildAt(i);
+
+      if (childView == null) {
+        continue;
+      }
+
+      AccessibilityNodeInfoCompat childNode = AccessibilityNodeInfoCompat.obtain();
+      try {
+        ViewCompat.onInitializeAccessibilityNodeInfo(childView, childNode);
+
+        if (isAccessibilityFocusable(childNode, childView)) {
+          continue;
+        }
+
+        if (isSpeakingNode(childNode, childView)) {
+          return true;
+        }
+      } finally {
+        childNode.recycle();
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Determines if the provided {@link View} and {@link AccessibilityNodeInfoCompat} meet the
+   * criteria for gaining accessibility focus.
+   *
+   * @param view The {@link View} to evaluate
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if it is possible to gain accessibility focus
+   */
+  public static boolean isAccessibilityFocusable(
+      @Nullable AccessibilityNodeInfoCompat node,
+      @Nullable View view) {
+    if (node == null || view == null) {
+      return false;
+    }
+
+    // Never focus invisible nodes.
+    if (!node.isVisibleToUser()) {
+      return false;
+    }
+
+    // Always focus "actionable" nodes.
+    if (isActionableForAccessibility(node)) {
+      return true;
+    }
+
+    // only focus top-level list items with non-actionable speaking children.
+    return isTopLevelScrollItem(node, view) && isSpeakingNode(node, view);
+  }
+
+  /**
+   * Determines whether the provided {@link View} and {@link AccessibilityNodeInfoCompat} is a
+   * top-level item in a scrollable container.
+   *
+   * @param view The {@link View} to evaluate
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if it is a top-level item in a scrollable container.
+   */
+  public static boolean isTopLevelScrollItem(
+      @Nullable AccessibilityNodeInfoCompat node,
+      @Nullable View view) {
+    if (node == null || view == null) {
+      return false;
+    }
+
+    View parent = (View) ViewCompat.getParentForAccessibility(view);
+    if (parent == null) {
+      return false;
+    }
+
+    if (node.isScrollable()) {
+      return true;
+    }
+
+    List actionList = node.getActionList();
+    if (actionList.contains(AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) ||
+        actionList.contains(AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD)) {
+      return true;
+    }
+
+    // AdapterView, ScrollView, and HorizontalScrollView are focusable
+    // containers, but Spinner is a special case.
+    if (parent instanceof Spinner) {
+      return false;
+    }
+
+    return
+        parent instanceof AdapterView ||
+            parent instanceof ScrollView ||
+            parent instanceof HorizontalScrollView;
+  }
+
+  /**
+   * Returns whether a node is actionable. That is, the node supports one of
+   * {@link AccessibilityNodeInfoCompat#isClickable()},
+   * {@link AccessibilityNodeInfoCompat#isFocusable()}, or
+   * {@link AccessibilityNodeInfoCompat#isLongClickable()}.
+   *
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if node is actionable.
+   */
+  public static boolean isActionableForAccessibility(@Nullable AccessibilityNodeInfoCompat node) {
+    if (node == null) {
+      return false;
+    }
+
+    if (node.isClickable() || node.isLongClickable() || node.isFocusable()) {
+      return true;
+    }
+
+    List actionList = node.getActionList();
+    return
+        actionList.contains(AccessibilityNodeInfoCompat.ACTION_CLICK) ||
+            actionList.contains(AccessibilityNodeInfoCompat.ACTION_LONG_CLICK) ||
+            actionList.contains(AccessibilityNodeInfoCompat.ACTION_FOCUS);
+  }
+
+  /**
+   * Determines if any of the provided {@link View}'s and {@link AccessibilityNodeInfoCompat}'s
+   * ancestors can receive accessibility focus
+   *
+   * @param view The {@link View} to evaluate
+   * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
+   * @return {@code true} if an ancestor of may receive accessibility focus
+   */
+  public static boolean hasFocusableAncestor(
+      @Nullable AccessibilityNodeInfoCompat node,
+      @Nullable View view) {
+    if (node == null || view == null) {
+      return false;
+    }
+
+    ViewParent parentView = ViewCompat.getParentForAccessibility(view);
+    if (!(parentView instanceof View)) {
+      return false;
+    }
+
+    AccessibilityNodeInfoCompat parentNode = AccessibilityNodeInfoCompat.obtain();
+    try {
+      ViewCompat.onInitializeAccessibilityNodeInfo((View) parentView, parentNode);
+      if (parentNode == null) {
+        return false;
+      }
+
+      if (isAccessibilityFocusable(parentNode, (View) parentView)) {
+        return true;
+      }
+
+      if (hasFocusableAncestor(parentNode, (View) parentView)) {
+        return true;
+      }
+    } finally {
+      parentNode.recycle();
+    }
+    return false;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -14,14 +14,15 @@ import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
 import android.view.View;
 import android.view.ViewParent;
 
+import com.facebook.stetho.common.android.AccessibilityUtil;
+
 public final class AccessibilityNodeInfoWrapper {
 
   public AccessibilityNodeInfoWrapper() {
   }
 
-  public static boolean getIgnored(View view, AccessibilityNodeInfoCompat nodeInfo) {
+  public static boolean getIgnored(AccessibilityNodeInfoCompat node, View view) {
     int important = ViewCompat.getImportantForAccessibility(view);
-
     if (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO ||
         important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
       return true;
@@ -37,33 +38,66 @@ public final class AccessibilityNodeInfoWrapper {
       parent = parent.getParent();
     }
 
-    // AccessibilityNodeInfo is actionable
-    if (nodeInfo.isClickable() || nodeInfo.isLongClickable() || nodeInfo.isFocusable()) {
-      return false;
+    if (!node.isVisibleToUser()) {
+      return true;
     }
 
-    // AccessibilityNodeInfo has text set (commonly set from TextViews and Switches).
-    CharSequence nodeText = nodeInfo.getText();
-    if (nodeText != null && nodeText.length() > 0) {
-      return false;
+    if (AccessibilityUtil.isAccessibilityFocusable(node, view)) {
+      if (node.getChildCount() <= 0) {
+        // Leaves that are accessibility focusable are never ignored, even if they don't have a
+        // speakable description
+        return false;
+      } else if (AccessibilityUtil.isSpeakingNode(node, view)) {
+        // Node is focusable and has something to speak
+        return false;
+      }
+
+      // Node is focusable and has nothing to speak
+      return true;
     }
 
-    // AccessibilityNodeInfo has a content description
-    CharSequence contentDescription = nodeInfo.getContentDescription();
-    if (contentDescription != null && contentDescription.length() > 0) {
-      return false;
-    }
-
-    // View has an AccessibilityNodeProvider
-    if (ViewCompat.getAccessibilityNodeProvider(view) != null) {
-      return false;
-    }
-
-    // View has an AccessibilityDelegate
-    if (ViewCompat.hasAccessibilityDelegate(view)){
+    // If this node has no focusable ancestors, but it still has text,
+    // then it should receive focus from navigation and be read aloud.
+    if (!AccessibilityUtil.hasFocusableAncestor(node, view) && AccessibilityUtil.hasText(node)) {
       return false;
     }
 
     return true;
   }
+
+  public static String getIgnoredReasons(AccessibilityNodeInfoCompat node, View view) {
+    int important = ViewCompat.getImportantForAccessibility(view);
+
+    if (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO) {
+      return "View has importantForAccessibility set to 'NO'.";
+    }
+
+    if (important == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+      return "View has importantForAccessibility set to 'NO_HIDE_DESCENDANTS'.";
+    }
+
+    ViewParent parent = view.getParent();
+    while (parent instanceof View) {
+      if (ViewCompat.getImportantForAccessibility((View) parent)
+              == ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+        return "An ancestor View has importantForAccessibility set to 'NO_HIDE_DESCENDANTS'.";
+      }
+      parent = parent.getParent();
+    }
+
+    if (!node.isVisibleToUser()) {
+      return "View is not visible.";
+    }
+
+    if (AccessibilityUtil.isAccessibilityFocusable(node, view)) {
+      return "View is actionable, but has no description.";
+    }
+
+    if (AccessibilityUtil.hasText(node)) {
+      return "View is not actionable, and an ancestor View has co-opted its description.";
+    }
+
+    return "View is not actionable and has no description.";
+  }
+
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -189,12 +189,22 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
     AccessibilityNodeInfoCompat nodeInfo = AccessibilityNodeInfoCompat.obtain();
     ViewCompat.onInitializeAccessibilityNodeInfo(element, nodeInfo);
 
+    boolean ignored = AccessibilityNodeInfoWrapper.getIgnored(nodeInfo, element);
     getStyleFromValue(
         element,
         "ignored",
-        AccessibilityNodeInfoWrapper.getIgnored(element, nodeInfo),
+        ignored,
         null,
         styles);
+
+    if (ignored) {
+      getStyleFromValue(
+          element,
+          "ignored-reasons",
+          AccessibilityNodeInfoWrapper.getIgnoredReasons(nodeInfo, element),
+          null,
+          styles);
+    }
 
     nodeInfo.recycle();
   }


### PR DESCRIPTION
Added ignored-reasons as a property to the Accessibility Properties panel, which explains in plain language why a node is being ignored by accessibility.

I've also updated the ignored property to be more accurate to what Talkback and other Accessibility Services actually look for to determine whether or not to ignore a view.

![screen shot 2016-08-08 at 12 44 55 pm](https://cloud.githubusercontent.com/assets/1518064/17493622/fa308324-5d65-11e6-8421-cb6b3e78ff10.png)
