### PR TITLE
Added various other properties to the accessibility inspection

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -9,12 +9,20 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
+import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.EditText;
 
 import com.facebook.stetho.common.android.AccessibilityUtil;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public final class AccessibilityNodeInfoWrapper {
 
@@ -100,4 +108,169 @@ public final class AccessibilityNodeInfoWrapper {
     return "View is not actionable and has no description.";
   }
 
+  @Nullable
+  public static String getFocusableReasons(AccessibilityNodeInfoCompat node, View view) {
+    boolean hasText = AccessibilityUtil.hasText(node);
+    boolean isCheckable = node.isCheckable();
+    boolean hasNonActionableSpeakingDescendants =
+        AccessibilityUtil.hasNonActionableSpeakingDescendants(node, view);
+
+    if (AccessibilityUtil.isActionableForAccessibility(node)) {
+      if (node.getChildCount() <= 0) {
+        return "View is actionable and has no children.";
+      } else if (hasText) {
+        return "View is actionable and has a description.";
+      } else if (isCheckable) {
+        return "View is actionable and checkable.";
+      } else if (hasNonActionableSpeakingDescendants) {
+        return "View is actionable and has non-actionable descendants with descriptions.";
+      }
+    }
+
+    if (AccessibilityUtil.isTopLevelScrollItem(node, view)) {
+      if (hasText) {
+        return "View is a direct child of a scrollable container and has a description.";
+      } else if (isCheckable) {
+        return "View is a direct child of a scrollable container and is checkable.";
+      } else if (hasNonActionableSpeakingDescendants) {
+        return
+            "View is a direct child of a scrollable container and has non-actionable " +
+            "descendants with descriptions.";
+      }
+    }
+
+    if (hasText) {
+      return "View has a description and is not actionable, but has no actionable ancestor.";
+    }
+
+    return null;
+  }
+
+  @Nullable
+  public static String getActions(AccessibilityNodeInfoCompat node) {
+    final StringBuilder actionLabels = new StringBuilder();
+    final String separator = ", ";
+
+    for (AccessibilityActionCompat action : node.getActionList()) {
+      if (actionLabels.length() > 0) {
+        actionLabels.append(separator);
+      }
+      switch (action.getId()) {
+        case AccessibilityNodeInfoCompat.ACTION_FOCUS:
+          actionLabels.append("focus");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_CLEAR_FOCUS:
+          actionLabels.append("clear-focus");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_SELECT:
+          actionLabels.append("select");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_CLEAR_SELECTION:
+          actionLabels.append("clear-selection");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_CLICK:
+          actionLabels.append("click");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_LONG_CLICK:
+          actionLabels.append("long-click");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS:
+          actionLabels.append("accessibility-focus");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_CLEAR_ACCESSIBILITY_FOCUS:
+          actionLabels.append("clear-accessibility-focus");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_NEXT_AT_MOVEMENT_GRANULARITY:
+          actionLabels.append("next-at-movement-granularity");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY:
+          actionLabels.append("previous-at-movement-granularity");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_NEXT_HTML_ELEMENT:
+          actionLabels.append("next-html-element");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_PREVIOUS_HTML_ELEMENT:
+          actionLabels.append("previous-html-element");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD:
+          actionLabels.append("scroll-forward");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD:
+          actionLabels.append("scroll-backward");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_CUT:
+          actionLabels.append("cut");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_COPY:
+          actionLabels.append("copy");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_PASTE:
+          actionLabels.append("paste");
+          break;
+        case AccessibilityNodeInfoCompat.ACTION_SET_SELECTION:
+          actionLabels.append("set-selection");
+          break;
+        default:
+          CharSequence label = action.getLabel();
+          if (label != null) {
+            actionLabels.append(label);
+          } else {
+            actionLabels.append("unknown");
+          }
+          break;
+      }
+    }
+
+    return actionLabels.length() > 0 ? actionLabels.toString() : null;
+  }
+
+  @Nullable
+  public static CharSequence getDescription(AccessibilityNodeInfoCompat node, View view) {
+    CharSequence contentDescription = node.getContentDescription();
+    CharSequence nodeText = node.getText();
+
+    boolean hasNodeText = !TextUtils.isEmpty(nodeText);
+    boolean isEditText = view instanceof EditText;
+
+    // EditText's prioritize their own text content over a contentDescription
+    if (!TextUtils.isEmpty(contentDescription) && (!isEditText || !hasNodeText)) {
+      return contentDescription;
+    }
+
+    if (hasNodeText) {
+      return nodeText;
+    }
+
+    // If there are child views and no contentDescription the text of all non-focusable children,
+    // comma separated, becomes the description.
+    if (view instanceof ViewGroup) {
+      final StringBuilder concatChildDescription = new StringBuilder();
+      final String separator = ", ";
+      ViewGroup viewGroup = (ViewGroup) view;
+
+      for (int i = 0, count = viewGroup.getChildCount(); i < count; i++) {
+        final View child = viewGroup.getChildAt(i);
+
+        AccessibilityNodeInfoCompat childNodeInfo = AccessibilityNodeInfoCompat.obtain();
+        ViewCompat.onInitializeAccessibilityNodeInfo(child, childNodeInfo);
+
+        CharSequence childNodeDescription = null;
+        if (AccessibilityUtil.isSpeakingNode(childNodeInfo, child)) {
+          childNodeDescription = getDescription(childNodeInfo, child);
+        }
+
+        if (!TextUtils.isEmpty(childNodeDescription)) {
+          if (concatChildDescription.length() > 0) {
+            concatChildDescription.append(separator);
+          }
+          concatChildDescription.append(childNodeDescription);
+        }
+        childNodeInfo.recycle();
+      }
+
+      return concatChildDescription.length() > 0 ? concatChildDescription.toString() : null;
+    }
+
+    return null;
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -206,6 +206,43 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
           styles);
     }
 
+    getStyleFromValue(
+        element,
+        "focusable",
+        !ignored,
+        null,
+        styles);
+
+    if (!ignored) {
+      getStyleFromValue(
+          element,
+          "focusable-reasons",
+          AccessibilityNodeInfoWrapper.getFocusableReasons(nodeInfo, element),
+          null,
+          styles);
+
+      getStyleFromValue(
+          element,
+          "focused",
+          nodeInfo.isAccessibilityFocused(),
+          null,
+          styles);
+
+      getStyleFromValue(
+          element,
+          "description",
+          AccessibilityNodeInfoWrapper.getDescription(nodeInfo, element),
+          null,
+          styles);
+
+      getStyleFromValue(
+          element,
+          "actions",
+          AccessibilityNodeInfoWrapper.getActions(nodeInfo),
+          null,
+          styles);
+    }
+
     nodeInfo.recycle();
   }
 


### PR DESCRIPTION
This adds "focusable", "focusable-reasons", "focused", "description", and "actions" to the Accessibility Properties.  I'll detail below what each of these mean:

**Focusable**
This is the inverse of "ignored", and simply states whether or not a view will be able to be focused by an `AccessibilityService`.

**Focusable Reasons**
Similar to ignored-reasons, this states precisely _why_ a view is focusable.  This will help people to understand how to make a view that they don't want to be focusable, not get focus.

**Focused**
This will be true for the currently accessibility-focused view, and false for all others.  This will help determine precisely which view is receiving focus at any given time, which can often be difficult to determine when you have a deep view hierarchy.

**Description**
This is the computed description that `AccessibilityService`s will receive.  If a view has a specific description set via the `contentDescription` attribute, this will likely be it, but actionable views that do not have their own description will create one from their children that are not actionable but have descriptions.  

NOTE:  This does not include extraneous information added by`AccessibilityService`s, such as states (editable, selected, checked, etc.) or gesture hints (double-tap, double-tap and hold, etc.).

**Actions**
A list of all `AccessibilityAction`s that can be performed on the view, including custom actions if there are any defined.

![screen shot 2016-08-11 at 5 32 19 pm](https://cloud.githubusercontent.com/assets/1518064/17609632/b87c0ca4-5feb-11e6-8012-3e14b84ca664.png)
