### PR TITLE
Update build tools and Android plug-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: android
 
+jdk:
+  - oraclejdk8
+
 android:
   components:
     - tools
-    - build-tools-23.0.3
+    - build-tools-24.0.2
     - android-23
     - platform-tools
     - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 9

--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 9

--- a/stetho-okhttp3/build.gradle
+++ b/stetho-okhttp3/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 9

--- a/stetho-sample/build.gradle
+++ b/stetho-sample/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         applicationId "com.facebook.stetho.sample"

--- a/stetho-timber/build.gradle
+++ b/stetho-timber/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 11

--- a/stetho-urlconnection/build.gradle
+++ b/stetho-urlconnection/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 9

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         minSdkVersion 9


### PR DESCRIPTION
This updates the build tools to `24.0.1` and the Android Gradle plug-in to `2.1.3` (latest versions as of Aug 18, 2016)