### PR TITLE
Remove creation of jars in output

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -99,7 +99,6 @@ afterEvaluate { project ->
     artifacts {
         archives androidJavadocJar
         archives androidSourcesJar
-        archives jarRelease
     }
 
     version = VERSION_NAME


### PR DESCRIPTION
There have been a number of problems lately when it comes to how gradle is assembling the output to maven. Specifically the fact that the default packaging is a jar. This means no proguard files are included (See #419). There was a hack that you can do 
```
debugCompile ('com.facebook.stetho:stetho:1.3.1:@aar') {
  transitive = true
}
```
this allows you to get a proguard file and does not compile the R.java files (See #422). 

In order to test this I ran 
`./gradlew installArchives` then modified the sample app's build.gradle to be 

```
...
dependencies {
    ...
    compile 'com.facebook.stetho:stetho:1.3.2-SNAPSHOT'
    ....
}
repositories {
    maven { url System.getenv('HOME') + "/.m2/repository/" }
}
```

I also modified the sample app to perform proguard minification `minifyEnabled true`, and was able to reproduce https://github.com/facebook/stetho/wiki/FAQ#nothing-is-shown-in-chrome-devtools-and-i-see-many-method-not-implemented-messages-in-logcat

After my fix I verified that you no longer need an app specific proguard file (for stetho related components).

We are still able to create the fatjar by using the command `./gradlew fatjarRelease`