### PR TITLE
Add details on OkHttp integration

### DIFF
--- a/index.md
+++ b/index.md
@@ -71,20 +71,24 @@ This brings up most of the default configuration but does not enable some additi
 
 ### Enable Network Inspection
 
-If you are using the popular OkHttp library at the 2.2.x+ or 3.x release, you can use the Interceptors system to automatically hook into your existing stack. This is currently the simplest and most straightforward way to enable network inspection: 
+If you are using the popular OkHttp library at the 2.2.x+ or 3.x release, you can use the Interceptors system to automatically hook into your existing stack. This is currently the simplest and most straightforward way to enable network inspection.
+
+#### For OkHttp 2.x
     
 ```java    
 OkHttpClient client = new OkHttpClient();
 client.networkInterceptors().add(new StethoInterceptor());
 ```
 
-or:
+#### For OkHttp 3.x
 
 ```java
 new OkHttpClient.Builder()
     .addNetworkInterceptor(new StethoInterceptor())
     .build();
 ```
+
+As interceptors can modify the request and response, add the Stetho interceptor after all others to get an accurate view of the network traffic.
 
 If you are using `HttpURLConnection`, you can use `StethoURLConnectionManager` to assist with integration though you should be aware that there are some caveats with this approach. In particular, you must explicitly add `Accept-Encoding: gzip` to the request headers and manually handle compressed responses in order for Stetho to report compressed payload sizes.
 


### PR DESCRIPTION
Make it clear that the two code samples relate to different versions of
OkHttp, and add a warning on the order of interceptors (see #423).