### PR TITLE
Have DefaultDatabaseProvider return filename

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
@@ -28,8 +28,8 @@ public final class DefaultDatabaseFilesProvider implements DatabaseFilesProvider
   @Override
   public List<File> getDatabaseFiles() {
     List<File> databaseFiles = new ArrayList<File>();
-    for (String filename : mContext.databaseList()) {
-      databaseFiles.add(new File(filename));
+    for (String databaseName : mContext.databaseList()) {
+      databaseFiles.add(mContext.getDatabasePath(databaseName));
     }
     return databaseFiles;
   }


### PR DESCRIPTION
The API for `DatabaseProvider` is to return `List<File>` however the
current implementation of `DefaultDatabaseProvider` returns a `File`
that does not exist. We were able to get around this before due to the
fact that the file was only used to call `File#getName()`.

In #390 this was changed and the actual `File` object was used to open
the database.

This fixes #431