### PR TITLE
Fix NPE in ObjectMapper

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
@@ -111,7 +111,9 @@ public class ObjectMapper {
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(
             "Class: " + type.getSimpleName() + " " +
-            "Field: " + field.getName() + " type " + setValue.getClass().getName(),
+            "Field: " + field.getName() + " type " + (setValue != null ?
+                setValue.getClass().getName()
+                : "null"),
             e);
       }
     }


### PR DESCRIPTION
Fix NPE when an IllegalArgumentException is thrown from `field.set`.
fixes #447
