### PR TITLE
Make sure only unfocusable children's descriptions are being co-opted by parents

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -255,7 +255,8 @@ public final class AccessibilityNodeInfoWrapper {
         ViewCompat.onInitializeAccessibilityNodeInfo(child, childNodeInfo);
 
         CharSequence childNodeDescription = null;
-        if (AccessibilityUtil.isSpeakingNode(childNodeInfo, child)) {
+        if (AccessibilityUtil.isSpeakingNode(childNodeInfo, child) &&
+            !AccessibilityUtil.isAccessibilityFocusable(childNodeInfo, child)) {
           childNodeDescription = getDescription(childNodeInfo, child);
         }
 


### PR DESCRIPTION
ViewParents that contain both focusable, and unfocusable children were incorrectly having their description set to the concatenation of all children.  The parent should have only had its description contain the descriptions of the unfocusable children, since the focusable children will retain their own descriptions and focus.
