### PR TITLE
Update Okhttp3 to 3.4.2

### DIFF
--- a/stetho-okhttp3/build.gradle
+++ b/stetho-okhttp3/build.gradle
@@ -23,7 +23,7 @@ android {
 dependencies {
     compile project(':stetho')
     compile 'com.google.code.findbugs:jsr305:2.0.1'
-    compile 'com.squareup.okhttp3:okhttp:3.0.1'
+    compile 'com.squareup.okhttp3:okhttp:3.4.2'
 
     testCompile 'junit:junit:4.12'
     testCompile('org.robolectric:robolectric:2.4') {
@@ -37,7 +37,7 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4-rule:1.6.1'
     testCompile 'org.powermock:powermock-classloading-xstream:1.6.1'
 
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.0.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.2'
 }
 
 apply from: rootProject.file('release.gradle')


### PR DESCRIPTION
We are using Stetho for debugging applications. It's very useful! We thank for this community.

Sometimes, we are suffering conflicts of dependencies by the Okhttp's version that included by Stetho.

We hope that Stetho uses latest version of Okhttp. Thank you.