### PR TITLE
stetho_open.py should respect ANDROID_ADB_SERVER_PORT

### DIFF
--- a/scripts/dumpapp
+++ b/scripts/dumpapp
@@ -26,8 +26,14 @@ def main():
   # transport.
   device = os.environ.get('ANDROID_SERIAL')
 
+  # Connect on the overridden port
+  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT', '')
+  port = 5037
+  if portStr.isdigit():
+      port = int(portStr)
+
   try:
-    sock = stetho_open(device, process)
+    sock = stetho_open(device, process, port)
 
     # Send dumpapp hello (DUMP + version=1)
     sock.send(b'DUMP' + struct.pack('!L', 1))

--- a/scripts/dumpapp
+++ b/scripts/dumpapp
@@ -26,11 +26,8 @@ def main():
   # transport.
   device = os.environ.get('ANDROID_SERIAL')
 
-  # Connect on the overridden port
-  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT', '')
-  port = 5037
-  if portStr.isdigit():
-      port = int(portStr)
+  # Connect on the overridden port if specified
+  port = get_adb_server_port()
 
   try:
     sock = stetho_open(device, process, port)

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -13,11 +13,27 @@
 ##
 ###############################################################################
 
+import os
 import socket
 import struct
 import re
 
-def stetho_open(device=None, process=None, port=5037):
+def get_adb_server_port():
+  defaultPort = 5037
+  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT')
+  if portStr is None:
+    return defaultPort
+  elif portStr.isdigit():
+    return int(portStr)
+  else:
+    raise HumanReadableError(
+      'Invalid integer \'%s\' specified in ANDROID_ADB_SERVER_PORT.' % (
+        portStr))
+
+def stetho_open(device=None, process=None, port=None):
+  if port is None:
+    port = get_adb_server_port()
+
   adb = _connect_to_device(device, port)
 
   socket_name = None
@@ -78,7 +94,7 @@ def _find_only_stetho_socket(device, port):
   finally:
     adb.sock.close()
 
-def _connect_to_device(device=None, port=5037):
+def _connect_to_device(device=None, port=None):
   adb = AdbSmartSocketClient()
   adb.connect(port)
 

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -13,17 +13,16 @@
 ##
 ###############################################################################
 
-import os
 import socket
 import struct
 import re
 
-def stetho_open(device=None, process=None):
-  adb = _connect_to_device(device)
+def stetho_open(device=None, process=None, port=5037):
+  adb = _connect_to_device(device, port)
 
   socket_name = None
   if process is None:
-    socket_name = _find_only_stetho_socket(device)
+    socket_name = _find_only_stetho_socket(device, port)
   else:
     socket_name = _format_process_as_stetho_socket(process)
 
@@ -47,8 +46,8 @@ def read_input(sock, n, tag):
     raise IOError('Unexpected end of stream while reading %s.' % tag)
   return data
 
-def _find_only_stetho_socket(device):
-  adb = _connect_to_device(device)
+def _find_only_stetho_socket(device, port):
+  adb = _connect_to_device(device, port)
   try:
     adb.select_service('shell:cat /proc/net/unix')
     last_stetho_socket_name = None
@@ -79,10 +78,11 @@ def _find_only_stetho_socket(device):
   finally:
     adb.sock.close()
 
-def _connect_to_device(device=None):
+def _connect_to_device(device=None, port=5037):
   adb = AdbSmartSocketClient()
-  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT', '')
-  if portStr.isdigit():
+  if port != None:
+      adb.connect(port)
+  elif portStr.isdigit():
       adb.connect(int(portStr))
   else:
       adb.connect()

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -13,6 +13,7 @@
 ##
 ###############################################################################
 
+import os
 import socket
 import struct
 import re
@@ -35,7 +36,7 @@ def stetho_open(device=None, process=None):
 
   return adb.sock
 
-def read_input(sock, n, tag):  
+def read_input(sock, n, tag):
   data = b'';
   while len(data) < n:
     incoming_data = sock.recv(n - len(data))
@@ -45,7 +46,7 @@ def read_input(sock, n, tag):
   if len(data) != n:
     raise IOError('Unexpected end of stream while reading %s.' % tag)
   return data
-  
+
 def _find_only_stetho_socket(device):
   adb = _connect_to_device(device)
   try:
@@ -80,7 +81,11 @@ def _find_only_stetho_socket(device):
 
 def _connect_to_device(device=None):
   adb = AdbSmartSocketClient()
-  adb.connect()
+  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT', '')
+  if portStr.isdigit():
+      adb.connect(int(portStr))
+  else:
+      adb.connect()
 
   try:
     if device is None:

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -80,12 +80,7 @@ def _find_only_stetho_socket(device, port):
 
 def _connect_to_device(device=None, port=5037):
   adb = AdbSmartSocketClient()
-  if port != None:
-      adb.connect(port)
-  elif portStr.isdigit():
-      adb.connect(int(portStr))
-  else:
-      adb.connect()
+  adb.connect(port)
 
   try:
     if device is None:

--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -95,6 +95,9 @@ def _find_only_stetho_socket(device, port):
     adb.sock.close()
 
 def _connect_to_device(device=None, port=None):
+  if port is None:
+    raise HumanReadableError('Must specify a port when calling _connect_to_device')
+
   adb = AdbSmartSocketClient()
   adb.connect(port)
 


### PR DESCRIPTION
This change now uses ANDROID_ADB_SERVER_PORT when connecting to adb, if
a numeric value is specified. Otherwise the default port (5037) is used.