### PR TITLE
Fixes rss url; otherwise it gets 302 status code and shows a blank list.

### DIFF
--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
@@ -31,7 +31,8 @@ import java.util.concurrent.CountDownLatch;
 
 public class APODRssFetcher {
   private static final String TAG = "APODRssFetcher";
-  private static final String APOD_RSS_URL = "http://apod.nasa.gov/apod.rss";
+  
+  private static final String APOD_RSS_URL = "https://apod.nasa.gov/apod.rss";
 
   private final ContentResolver mContentResolver;
 


### PR DESCRIPTION
The RssFetcher in the sample app talks to [http://apod.nasa.gov/apod.rss](url). Probably due to a configuration change at server recently, it returns 302 and app shows a blank list (doesn't handle redirection very well). Fix it by pointing to latest url.

<img width="860" alt="screen shot 2017-01-31 at 1 38 16 pm" src="https://cloud.githubusercontent.com/assets/631469/22486411/4178c790-e7be-11e6-882c-6b37cd2f2605.png">

