### PR TITLE
Make NodeDescriptor, Descriptor, and HighlightableDescriptor generic

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -34,11 +34,13 @@ import javax.annotation.Nullable;
  * @param <E> the class that this descriptor will be describing for {@link DocumentProvider},
  * {@link Document}, and ultimately {@link DOM}.
  */
-public abstract class AbstractChainedDescriptor<E> extends Descriptor implements ChainedDescriptor {
+public abstract class AbstractChainedDescriptor<E>
+    extends Descriptor<E> implements ChainedDescriptor<E> {
 
-  private Descriptor mSuper;
+  private Descriptor<? super E> mSuper;
 
-  public void setSuper(Descriptor superDescriptor) {
+  @Override
+  public void setSuper(Descriptor<? super E> superDescriptor) {
     Util.throwIfNull(superDescriptor);
 
     if (superDescriptor != mSuper) {
@@ -49,26 +51,24 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
     }
   }
 
-  final Descriptor getSuper() {
+  final Descriptor<? super E> getSuper() {
     return mSuper;
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void hook(Object element) {
+  public final void hook(E element) {
     verifyThreadAccess();
     mSuper.hook(element);
-    onHook((E) element);
+    onHook(element);
   }
 
   protected void onHook(E element) {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void unhook(Object element) {
+  public final void unhook(E element) {
     verifyThreadAccess();
-    onUnhook((E) element);
+    onUnhook(element);
     mSuper.unhook(element);
   }
 
@@ -76,9 +76,8 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final NodeType getNodeType(Object element) {
-    return onGetNodeType((E) element);
+  public final NodeType getNodeType(E element) {
+    return onGetNodeType(element);
   }
 
   protected NodeType onGetNodeType(E element) {
@@ -86,9 +85,8 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final String getNodeName(Object element) {
-    return onGetNodeName((E) element);
+  public final String getNodeName(E element) {
+    return onGetNodeName(element);
   }
 
   protected String onGetNodeName(E element) {
@@ -96,9 +94,8 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final String getLocalName(Object element) {
-    return onGetLocalName((E) element);
+  public final String getLocalName(E element) {
+    return onGetLocalName(element);
   }
 
   protected String onGetLocalName(E element) {
@@ -106,9 +103,8 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final String getNodeValue(Object element) {
-    return onGetNodeValue((E) element);
+  public final String getNodeValue(E element) {
+    return onGetNodeValue(element);
   }
 
   @Nullable
@@ -117,29 +113,26 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void getChildren(Object element, Accumulator<Object> children) {
+  public final void getChildren(E element, Accumulator<Object> children) {
     mSuper.getChildren(element, children);
-    onGetChildren((E) element, children);
+    onGetChildren(element, children);
   }
 
   protected void onGetChildren(E element, Accumulator<Object> children) {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void getAttributes(Object element, AttributeAccumulator attributes) {
+  public final void getAttributes(E element, AttributeAccumulator attributes) {
     mSuper.getAttributes(element, attributes);
-    onGetAttributes((E) element, attributes);
+    onGetAttributes(element, attributes);
   }
 
   protected void onGetAttributes(E element, AttributeAccumulator attributes) {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void setAttributesAsText(Object element, String text) {
-    onSetAttributesAsText((E) element, text);
+  public final void setAttributesAsText(E element, String text) {
+    onSetAttributesAsText(element, text);
   }
 
   protected void onSetAttributesAsText(E element, String text) {
@@ -147,20 +140,18 @@ public abstract class AbstractChainedDescriptor<E> extends Descriptor implements
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void getStyles(Object element, StyleAccumulator accumulator) {
+  public final void getStyles(E element, StyleAccumulator accumulator) {
     mSuper.getStyles(element, accumulator);
-    onGetStyles((E) element, accumulator);
+    onGetStyles(element, accumulator);
   }
 
   protected void onGetStyles(E element, StyleAccumulator accumulator) {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public final void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  public final void getAccessibilityStyles(E element, StyleAccumulator accumulator) {
     mSuper.getAccessibilityStyles(element, accumulator);
-    onGetAccessibilityStyles((E) element, accumulator);
+    onGetAccessibilityStyles(element, accumulator);
   }
 
   protected void onGetAccessibilityStyles(E element, StyleAccumulator accumulator) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -52,6 +52,6 @@ import com.facebook.stetho.common.Accumulator;
  * The third option is to implement {@link ChainedDescriptor} (e.g. by deriving from
  * {@link AbstractChainedDescriptor}) which solves all of these issues for you.<p/>
  */
-public interface ChainedDescriptor {
-  void setSuper(Descriptor superDescriptor);
+public interface ChainedDescriptor<E> {
+  void setSuper(Descriptor<? super E> superDescriptor);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class Descriptor implements NodeDescriptor {
+public abstract class Descriptor<E> implements NodeDescriptor<E> {
   private Host mHost;
 
   protected Descriptor() {
@@ -104,7 +104,7 @@ public abstract class Descriptor implements NodeDescriptor {
 
   public interface Host extends ThreadBound {
     @Nullable
-    public Descriptor getDescriptor(@Nullable Object element);
+    public Descriptor<?> getDescriptor(@Nullable Object element);
 
     public void onAttributeModified(
         Object element,

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -14,27 +14,27 @@ import com.facebook.stetho.common.ThreadBound;
 
 import javax.annotation.Nullable;
 
-public interface NodeDescriptor extends ThreadBound {
-  void hook(Object element);
+public interface NodeDescriptor<E> extends ThreadBound {
+  void hook(E element);
 
-  void unhook(Object element);
+  void unhook(E element);
 
-  NodeType getNodeType(Object element);
+  NodeType getNodeType(E element);
 
-  String getNodeName(Object element);
+  String getNodeName(E element);
 
-  String getLocalName(Object element);
+  String getLocalName(E element);
 
   @Nullable
-  String getNodeValue(Object element);
+  String getNodeValue(E element);
 
-  void getChildren(Object element, Accumulator<Object> children);
+  void getChildren(E element, Accumulator<Object> children);
 
-  void getAttributes(Object element, AttributeAccumulator attributes);
+  void getAttributes(E element, AttributeAccumulator attributes);
 
-  void setAttributesAsText(Object element, String text);
+  void setAttributesAsText(E element, String text);
 
-  void getStyles(Object element, StyleAccumulator accumulator);
+  void getStyles(E element, StyleAccumulator accumulator);
 
-  void getAccessibilityStyles(Object element, StyleAccumulator accumulator);
+  void getAccessibilityStyles(E element, StyleAccumulator accumulator);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -11,7 +11,7 @@ package com.facebook.stetho.inspector.elements;
 
 import com.facebook.stetho.common.Accumulator;
 
-public final class ObjectDescriptor extends Descriptor {
+public final class ObjectDescriptor extends Descriptor<Object> {
   @Override
   public void hook(Object element) {
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 final class ActivityDescriptor
-    extends AbstractChainedDescriptor<Activity> implements HighlightableDescriptor {
+    extends AbstractChainedDescriptor<Activity> implements HighlightableDescriptor<Activity> {
   @Override
   protected String onGetNodeName(Activity element) {
     String className = element.getClass().getName();
@@ -45,11 +45,11 @@ final class ActivityDescriptor
   }
 
   @Override
-  public View getViewForHighlighting(Object element) {
+  @Nullable
+  public View getViewForHighlighting(Activity element) {
     final Descriptor.Host host = getHost();
     if (host instanceof AndroidDescriptorHost) {
-      Activity activity = (Activity)element;
-      Window window = activity.getWindow();
+      Window window = element.getWindow();
       return ((AndroidDescriptorHost) host).getHighlightingView(window);
     }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
@@ -19,7 +19,7 @@ import com.facebook.stetho.inspector.elements.Descriptor;
 import javax.annotation.Nullable;
 
 final class DialogDescriptor
-    extends AbstractChainedDescriptor<Dialog> implements HighlightableDescriptor {
+    extends AbstractChainedDescriptor<Dialog> implements HighlightableDescriptor<Dialog> {
   @Override
   protected void onGetChildren(Dialog element, Accumulator<Object> children) {
     Window window = element.getWindow();
@@ -30,11 +30,10 @@ final class DialogDescriptor
 
   @Nullable
   @Override
-  public View getViewForHighlighting(Object element) {
+  public View getViewForHighlighting(Dialog element) {
     final Descriptor.Host host = getHost();
     if (host instanceof AndroidDescriptorHost) {
-      final Dialog dialog = (Dialog) element;
-      return ((AndroidDescriptorHost) host).getHighlightingView(dialog.getWindow());
+      return ((AndroidDescriptorHost) host).getHighlightingView(element.getWindow());
     }
 
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -28,9 +28,10 @@ import com.facebook.stetho.inspector.elements.StyleAccumulator;
 import javax.annotation.Nullable;
 
 final class DialogFragmentDescriptor
-    extends Descriptor implements ChainedDescriptor, HighlightableDescriptor {
+    extends Descriptor<Object>
+    implements ChainedDescriptor<Object>, HighlightableDescriptor<Object> {
   private final DialogFragmentAccessor mAccessor;
-  private Descriptor mSuper;
+  private Descriptor<? super Object> mSuper;
 
   public static DescriptorMap register(DescriptorMap map) {
     maybeRegister(map, FragmentCompat.getSupportLibInstance());
@@ -51,7 +52,7 @@ final class DialogFragmentDescriptor
   }
 
   @Override
-  public void setSuper(Descriptor superDescriptor) {
+  public void setSuper(Descriptor<? super Object> superDescriptor) {
     Util.throwIfNull(superDescriptor);
 
     if (superDescriptor != mSuper) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -23,7 +23,7 @@ import com.facebook.stetho.inspector.elements.DescriptorMap;
 import javax.annotation.Nullable;
 
 final class FragmentDescriptor
-    extends AbstractChainedDescriptor<Object> implements HighlightableDescriptor {
+    extends AbstractChainedDescriptor<Object> implements HighlightableDescriptor<Object> {
   private static final String ID_ATTRIBUTE_NAME = "id";
   private static final String TAG_ATTRIBUTE_NAME = "tag";
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -13,7 +13,7 @@ import android.view.View;
 
 import javax.annotation.Nullable;
 
-interface HighlightableDescriptor {
+interface HighlightableDescriptor<E> {
   @Nullable
-  View getViewForHighlighting(Object element);
+  View getViewForHighlighting(E element);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -37,7 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-final class ViewDescriptor extends AbstractChainedDescriptor<View> implements HighlightableDescriptor {
+final class ViewDescriptor extends AbstractChainedDescriptor<View>
+    implements HighlightableDescriptor<View> {
   private static final String ID_NAME = "id";
   private static final String NONE_VALUE = "(none)";
   private static final String NONE_MAPPING = "<no mapping>";
@@ -156,8 +157,8 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View> implements Hi
   }
 
   @Override
-  public View getViewForHighlighting(Object element) {
-    return (View) element;
+  public View getViewForHighlighting(View element) {
+    return element;
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -18,7 +18,7 @@ import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import javax.annotation.Nullable;
 
 final class WindowDescriptor extends AbstractChainedDescriptor<Window>
-    implements HighlightableDescriptor {
+    implements HighlightableDescriptor<Window> {
   @Override
   protected void onGetChildren(Window element, Accumulator<Object> children) {
     View decorView = element.peekDecorView();
@@ -29,8 +29,7 @@ final class WindowDescriptor extends AbstractChainedDescriptor<Window>
 
   @Override
   @Nullable
-  public View getViewForHighlighting(Object element) {
-    Window window = (Window) element;
-    return window.peekDecorView();
+  public View getViewForHighlighting(Window element) {
+    return element.peekDecorView();
   }
 }


### PR DESCRIPTION
Previously only AbstractChainedDescriptor was generic. Anyone extending
directly from Descriptor or implementing HighlightableDescriptor had to
make sure to add casts from Object to their concrete type. This diff
solves that by making all descriptors generic.