### PR TITLE
Add ability to register custom descriptors

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -31,6 +31,7 @@ import com.facebook.stetho.inspector.database.DatabaseFilesProvider;
 import com.facebook.stetho.inspector.database.DefaultDatabaseConnectionProvider;
 import com.facebook.stetho.inspector.database.DefaultDatabaseFilesProvider;
 import com.facebook.stetho.inspector.database.SqliteDatabaseDriver;
+import com.facebook.stetho.inspector.elements.DescriptorProvider;
 import com.facebook.stetho.inspector.elements.Document;
 import com.facebook.stetho.inspector.elements.DocumentProviderFactory;
 import com.facebook.stetho.inspector.elements.android.ActivityTracker;
@@ -63,6 +64,7 @@ import com.facebook.stetho.server.SocketHandlerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -391,7 +393,7 @@ public class Stetho {
         return mDocumentProvider;
       }
       if (Build.VERSION.SDK_INT >= AndroidDocumentConstants.MIN_API_LEVEL) {
-        return new AndroidDocumentProviderFactory(mContext);
+        return new AndroidDocumentProviderFactory(mContext, Collections.<DescriptorProvider>emptyList());
       }
       return null;
     }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-public final class DescriptorMap {
+public final class DescriptorMap implements DescriptorRegistrar {
   private final Map<Class<?>, Descriptor> mMap = new IdentityHashMap<>();
   private boolean mIsInitializing;
   private Descriptor.Host mHost;
@@ -27,7 +27,8 @@ public final class DescriptorMap {
     return this;
   }
 
-  public DescriptorMap register(Class<?> elementClass, Descriptor descriptor) {
+  @Override
+  public DescriptorMap registerDescriptor(Class<?> elementClass, Descriptor descriptor) {
     Util.throwIfNull(elementClass);
     Util.throwIfNull(descriptor);
     Util.throwIf(descriptor.isInitialized());

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+public interface DescriptorProvider {
+  void registerDescriptor(DescriptorRegistrar registrar);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorRegistrar.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorRegistrar.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+public interface DescriptorRegistrar {
+  DescriptorRegistrar registerDescriptor(Class<?> elementClass, Descriptor descriptor);
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -28,6 +28,7 @@ import com.facebook.stetho.common.Util;
 import com.facebook.stetho.common.android.ViewUtil;
 import com.facebook.stetho.inspector.elements.DocumentProvider;
 import com.facebook.stetho.inspector.elements.Descriptor;
+import com.facebook.stetho.inspector.elements.DescriptorProvider;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.DocumentProviderListener;
 import com.facebook.stetho.inspector.elements.NodeDescriptor;
@@ -71,7 +72,10 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
     }
   };
 
-  public AndroidDocumentProvider(Application application, ThreadBound enforcer) {
+  public AndroidDocumentProvider(
+      Application application,
+      List<DescriptorProvider> descriptorProviders,
+      ThreadBound enforcer) {
     super(enforcer);
 
     mApplication = Util.throwIfNull(application);
@@ -79,19 +83,25 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
 
     mDescriptorMap = new DescriptorMap()
         .beginInit()
-        .register(Activity.class, new ActivityDescriptor())
-        .register(AndroidDocumentRoot.class, mDocumentRoot)
-        .register(Application.class, new ApplicationDescriptor())
-        .register(Dialog.class, new DialogDescriptor());
+        .registerDescriptor(Activity.class, new ActivityDescriptor())
+        .registerDescriptor(AndroidDocumentRoot.class, mDocumentRoot)
+        .registerDescriptor(Application.class, new ApplicationDescriptor())
+        .registerDescriptor(Dialog.class, new DialogDescriptor())
+        .registerDescriptor(Object.class, new ObjectDescriptor())
+        .registerDescriptor(TextView.class, new TextViewDescriptor())
+        .registerDescriptor(View.class, new ViewDescriptor())
+        .registerDescriptor(ViewGroup.class, new ViewGroupDescriptor())
+        .registerDescriptor(Window.class, new WindowDescriptor());
+
     DialogFragmentDescriptor.register(mDescriptorMap);
-    FragmentDescriptor.register(mDescriptorMap)
-        .register(Object.class, new ObjectDescriptor())
-        .register(TextView.class, new TextViewDescriptor())
-        .register(View.class, new ViewDescriptor())
-        .register(ViewGroup.class, new ViewGroupDescriptor())
-        .register(Window.class, new WindowDescriptor())
-        .setHost(this)
-        .endInit();
+    FragmentDescriptor.register(mDescriptorMap);
+
+    for (int i = 0, size = descriptorProviders.size(); i < size; ++i) {
+      final DescriptorProvider descriptorProvider = descriptorProviders.get(i);
+      descriptorProvider.registerDescriptor(mDescriptorMap);
+    }
+
+    mDescriptorMap.setHost(this).endInit();
 
     mHighlighter = ViewHighlighter.newInstance();
     mInspectModeHandler = new InspectModeHandler();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
@@ -17,22 +17,29 @@ import com.facebook.stetho.common.ThreadBound;
 import com.facebook.stetho.common.UncheckedCallable;
 import com.facebook.stetho.common.Util;
 import com.facebook.stetho.common.android.HandlerUtil;
+import com.facebook.stetho.inspector.elements.DescriptorProvider;
 import com.facebook.stetho.inspector.elements.DocumentProvider;
 import com.facebook.stetho.inspector.elements.DocumentProviderFactory;
+
+import java.util.List;
 
 public final class AndroidDocumentProviderFactory
     implements DocumentProviderFactory, ThreadBound {
   private final Application mApplication;
+  private final List<DescriptorProvider> mDescriptorProviders;
   private final Handler mHandler;
 
-  public AndroidDocumentProviderFactory(Application application) {
+  public AndroidDocumentProviderFactory(
+      Application application,
+      List<DescriptorProvider> descriptorProviders) {
     mApplication = Util.throwIfNull(application);
+    mDescriptorProviders = Util.throwIfNull(descriptorProviders);
     mHandler = new Handler(Looper.getMainLooper());
   }
 
   @Override
   public DocumentProvider create() {
-    return new AndroidDocumentProvider(mApplication, this);
+    return new AndroidDocumentProvider(mApplication, mDescriptorProviders, this);
   }
 
   // ThreadBound implementation

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -43,7 +43,7 @@ final class DialogFragmentDescriptor
     if (compat != null) {
       Class<?> dialogFragmentClass = compat.getDialogFragmentClass();
       LogUtil.d("Adding support for %s", dialogFragmentClass);
-      map.register(dialogFragmentClass, new DialogFragmentDescriptor(compat));
+      map.registerDescriptor(dialogFragmentClass, new DialogFragmentDescriptor(compat));
     }
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -39,7 +39,7 @@ final class FragmentDescriptor
     if (compat != null) {
       Class<?> fragmentClass = compat.getFragmentClass();
       LogUtil.d("Adding support for %s", fragmentClass.getName());
-      map.register(fragmentClass, new FragmentDescriptor(compat));
+      map.registerDescriptor(fragmentClass, new FragmentDescriptor(compat));
     }
   }
 


### PR DESCRIPTION
This commit introduces the notion of a DescriptorProvider. A
DescriptorProvider is an object which given a DescriptorMap will
register a number of Descriptors. A list of DescriptorProviders can be
passed to the AndroidDocumentProviderFactory to add or override
descriptors for class of your choosing. This functionality enables
applications and libraries to add their own descriptors while relying
on Stetho defaults for all other settings.