### PR TITLE
Add ability to highlight sub-bounds of view

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Activity;
+import android.graphics.Rect;
 import android.view.View;
 import android.view.Window;
 
@@ -46,11 +47,11 @@ final class ActivityDescriptor
 
   @Override
   @Nullable
-  public View getViewForHighlighting(Activity element) {
+  public View getViewAndBoundsForHighlighting(Activity element, Rect bounds) {
     final Descriptor.Host host = getHost();
     if (host instanceof AndroidDescriptorHost) {
       Window window = element.getWindow();
-      return ((AndroidDescriptorHost) host).getHighlightingView(window);
+      return ((AndroidDescriptorHost) host).getHighlightingView(window, bounds);
     }
 
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.view.View;
+import android.graphics.Rect;
 
 import com.facebook.stetho.inspector.elements.Descriptor;
 
@@ -17,5 +18,5 @@ import javax.annotation.Nullable;
 
 interface AndroidDescriptorHost extends Descriptor.Host {
   @Nullable
-  View getHighlightingView(@Nullable Object element);
+  View getHighlightingView(@Nullable Object element, Rect bounds);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Dialog;
+import android.graphics.Rect;
 import android.view.View;
 import android.view.Window;
 import com.facebook.stetho.common.Accumulator;
@@ -30,10 +31,10 @@ final class DialogDescriptor
 
   @Nullable
   @Override
-  public View getViewForHighlighting(Dialog element) {
+  public View getViewAndBoundsForHighlighting(Dialog element, Rect bounds) {
     final Descriptor.Host host = getHost();
     if (host instanceof AndroidDescriptorHost) {
-      return ((AndroidDescriptorHost) host).getHighlightingView(element.getWindow());
+      return ((AndroidDescriptorHost) host).getHighlightingView(element.getWindow(), bounds);
     }
 
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Dialog;
+import android.graphics.Rect;
 import android.view.View;
 
 import com.facebook.stetho.common.Accumulator;
@@ -118,11 +119,11 @@ final class DialogFragmentDescriptor
 
   @Nullable
   @Override
-  public View getViewForHighlighting(Object element) {
+  public View getViewAndBoundsForHighlighting(Object element, Rect bounds) {
     final Descriptor.Host host = getHost();
     if (host instanceof AndroidDescriptorHost) {
       Dialog dialog = mAccessor.getDialog(element);
-      return ((AndroidDescriptorHost) host).getHighlightingView(dialog);
+      return ((AndroidDescriptorHost) host).getHighlightingView(dialog, bounds);
     }
 
     return null;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -9,6 +9,7 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.graphics.Rect;
 import android.view.View;
 
 import com.facebook.stetho.common.Accumulator;
@@ -73,7 +74,8 @@ final class FragmentDescriptor
   }
 
   @Override
-  public View getViewForHighlighting(Object element) {
+  @Nullable
+  public View getViewAndBoundsForHighlighting(Object element, Rect bounds) {
     return mAccessor.getView(element);
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -9,11 +9,19 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.graphics.Rect;
 import android.view.View;
 
 import javax.annotation.Nullable;
 
 interface HighlightableDescriptor<E> {
+
+  /**
+   * Return the {@link View} to highlight or null if this element cannot be highlighted.
+   * If the element does not span the full bounds of the returned {@link View} you can set
+   * the bounds of the passed in Rect. By default the passed in bounds are empty which means
+   * highlight the full bounds of the {@link View}.
+   */
   @Nullable
-  View getViewForHighlighting(E element);
+  View getViewAndBoundsForHighlighting(E element, Rect bounds);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -10,6 +10,7 @@
 package com.facebook.stetho.inspector.elements.android;
 
 import android.support.v4.view.ViewCompat;
+import android.graphics.Rect;
 import android.view.View;
 import android.view.ViewDebug;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
@@ -157,7 +158,8 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
   }
 
   @Override
-  public View getViewForHighlighting(View element) {
+  @Nullable
+  public View getViewAndBoundsForHighlighting(View element, Rect bounds) {
     return element;
   }
 

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
@@ -21,7 +21,7 @@ import android.view.ViewGroup.MarginLayoutParams;
 
 abstract class ViewHighlightOverlays {
 
-  abstract void highlightView(View view, int mainColor);
+  abstract void highlightView(View view, Rect bounds, int mainColor);
 
   abstract void removeHighlight(View view);
 
@@ -37,7 +37,7 @@ abstract class ViewHighlightOverlays {
   private static class NoOpViewHighlightOverlays extends ViewHighlightOverlays {
 
     @Override
-    void highlightView(View view, int mainColor) {
+    void highlightView(View view, Rect bounds, int mainColor) {
     }
 
     @Override
@@ -66,8 +66,14 @@ abstract class ViewHighlightOverlays {
     }
 
     @Override
-    void highlightView(View view, int mainColor) {
+    void highlightView(View view, Rect bounds, int mainColor) {
       mMainHighlightDrawable.setColor(mainColor);
+
+      if (bounds.isEmpty()) {
+        mMainHighlightDrawable.setBounds(0, 0, view.getWidth(), view.getHeight());
+      } else {
+        mMainHighlightDrawable.setBounds(bounds);
+      }
 
       int total = mHighlightDrawables.length;
       for (int i = 0; i < total; i++) {
@@ -122,7 +128,6 @@ abstract class ViewHighlightOverlays {
       @Override
       void highlightView(View view) {
         super.highlightView(view);
-        setBounds(0, 0, view.getWidth(), view.getHeight());
       }
 
       @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -9,6 +9,7 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.graphics.Rect;
 import android.view.View;
 import android.view.Window;
 
@@ -29,7 +30,7 @@ final class WindowDescriptor extends AbstractChainedDescriptor<Window>
 
   @Override
   @Nullable
-  public View getViewForHighlighting(Window element) {
+  public View getViewAndBoundsForHighlighting(Window element, Rect bounds) {
     return element.peekDecorView();
   }
 }


### PR DESCRIPTION
A descriptor may not map directly to a View. For example if a
Descriptor was created for a Drawable it may occupy only a partial
space in the View. This diff solves this problem for descriptor
highlighting by extending HighlightableDescriptor with a method for
returning the bounds to highlight. Returning null will highlight the
full bounds of the View.