### PR TITLE
Add ability for descriptors to customize element IDs

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
@@ -34,10 +34,10 @@ public final class AccessibilityUtil {
   }
 
   /**
-   * Returns whether the specified node has text or a content description.
+   * Returns whether the specified nodeID has text or a content description.
    *
-   * @param node The node to check.
-   * @return {@code true} if the node has text.
+   * @param node The nodeID to check.
+   * @return {@code true} if the nodeID has text.
    */
   public static boolean hasText(@Nullable AccessibilityNodeInfoCompat node) {
     if (node == null) {
@@ -79,10 +79,10 @@ public final class AccessibilityUtil {
 
   /**
    * Determines if the supplied {@link View} and {@link AccessibilityNodeInfoCompat} has any
-   * children which are not independently accessibility focusable and also have a spoken
+   * childrenIDs which are not independently accessibility focusable and also have a spoken
    * description.
    * <p>
-   * NOTE: Accessibility services will include these children's descriptions in the closest
+   * NOTE: Accessibility services will include these childrenIDs's descriptions in the closest
    * focusable ancestor.
    *
    * @param view The {@link View} to evaluate
@@ -149,7 +149,7 @@ public final class AccessibilityUtil {
       return true;
     }
 
-    // only focus top-level list items with non-actionable speaking children.
+    // only focus top-level list items with non-actionable speaking childrenIDs.
     return isTopLevelScrollItem(node, view) && isSpeakingNode(node, view);
   }
 
@@ -196,13 +196,13 @@ public final class AccessibilityUtil {
   }
 
   /**
-   * Returns whether a node is actionable. That is, the node supports one of
+   * Returns whether a nodeID is actionable. That is, the nodeID supports one of
    * {@link AccessibilityNodeInfoCompat#isClickable()},
    * {@link AccessibilityNodeInfoCompat#isFocusable()}, or
    * {@link AccessibilityNodeInfoCompat#isLongClickable()}.
    *
    * @param node The {@link AccessibilityNodeInfoCompat} to evaluate
-   * @return {@code true} if node is actionable.
+   * @return {@code true} if nodeID is actionable.
    */
   public static boolean isActionableForAccessibility(@Nullable AccessibilityNodeInfoCompat node) {
     if (node == null) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -156,4 +156,13 @@ public abstract class AbstractChainedDescriptor<E>
 
   protected void onGetAccessibilityStyles(E element, StyleAccumulator accumulator) {
   }
+
+  @Override
+  public final NodeID getNodeID(E element) {
+    return onGetNodeID(element);
+  }
+
+  protected NodeID onGetNodeID(E element) {
+    return mSuper.getNodeID(element);
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentView.java
@@ -10,7 +10,7 @@
 package com.facebook.stetho.inspector.elements;
 
 public interface DocumentView {
-  Object getRootElement();
+  NodeID getRootID();
 
-  ElementInfo getElementInfo(Object element);
+  NodeInfo getNodeInfo(NodeID nodeID);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -37,4 +37,6 @@ public interface NodeDescriptor<E> extends ThreadBound {
   void getStyles(E element, StyleAccumulator accumulator);
 
   void getAccessibilityStyles(E element, StyleAccumulator accumulator);
+
+  NodeID getNodeID(E element);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeID.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeID.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.stetho.inspector.elements;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NodeID implements Comparable<NodeID> {
+  private static AtomicInteger sNextValue = new AtomicInteger(0);
+  public final int value;
+
+  NodeID(int value) {
+    this.value = value;
+  }
+
+  public NodeID() {
+    this(sNextValue.getAndIncrement());
+  }
+
+  @Override
+  public int hashCode() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (o instanceof NodeID) {
+      NodeID other = (NodeID) o;
+      return this.value == other.value;
+    }
+
+    return false;
+  }
+
+  @Override
+  public int compareTo(NodeID o) {
+    return Integer.compare(this.value, o.value);
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeInfo.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeInfo.java
@@ -18,18 +18,18 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 
 @Immutable
-public final class ElementInfo {
-  public final Object element;
-  public @Nullable final Object parentElement;
-  public final List<Object> children;
+public final class NodeInfo {
+  public final NodeID nodeID;
+  public @Nullable final NodeID parentID;
+  public final List<NodeID> childrenIDs;
 
-  ElementInfo(
-      Object element,
-      @Nullable Object parentElement,
-      List<Object> children) {
-    this.element = Util.throwIfNull(element);
-    this.parentElement = parentElement;
-    this.children = ListUtil.copyToImmutableList(children);
+  NodeInfo(
+      NodeID nodeID,
+      @Nullable NodeID parentID,
+      List<NodeID> childrenIDs) {
+    this.nodeID = Util.throwIfNull(nodeID);
+    this.parentID = parentID;
+    this.childrenIDs = ListUtil.copyToImmutableList(childrenIDs);
   }
 
   @Override
@@ -38,11 +38,11 @@ public final class ElementInfo {
       return true;
     }
 
-    if (o instanceof ElementInfo) {
-      ElementInfo other = (ElementInfo) o;
-      return this.element == other.element
-          && this.parentElement == other.parentElement
-          && ListUtil.identityEquals(this.children, other.children);
+    if (o instanceof NodeInfo) {
+      NodeInfo other = (NodeInfo) o;
+      return this.nodeID.value == other.nodeID.value
+          && this.parentID.value == other.parentID.value
+          && this.childrenIDs.equals(other.childrenIDs);
     }
 
     return false;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -11,13 +11,19 @@ package com.facebook.stetho.inspector.elements;
 
 import com.facebook.stetho.common.Accumulator;
 
+import java.util.Map;
+import java.util.HashMap;
+
 public final class ObjectDescriptor extends Descriptor<Object> {
+  private static Map<Integer, NodeID> sElementToIdMap = new HashMap<>();
+
   @Override
   public void hook(Object element) {
   }
 
   @Override
   public void unhook(Object element) {
+    sElementToIdMap.remove(System.identityHashCode(element));
   }
 
   @Override
@@ -58,5 +64,16 @@ public final class ObjectDescriptor extends Descriptor<Object> {
 
   @Override
   public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  }
+
+  @Override
+  public NodeID getNodeID(Object element) {
+    final int key = System.identityHashCode(element);
+    NodeID nodeID = sElementToIdMap.get(key);
+    if (nodeID == null) {
+      nodeID = new NodeID();
+      sElementToIdMap.put(key, nodeID);
+    }
+    return nodeID;
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
@@ -11,7 +11,6 @@ package com.facebook.stetho.inspector.elements;
 
 import android.app.Activity;
 import com.facebook.stetho.common.Accumulator;
-import com.facebook.stetho.common.ListUtil;
 import com.facebook.stetho.common.Util;
 
 import java.util.ArrayDeque;
@@ -25,22 +24,22 @@ import java.util.Queue;
 import java.util.Set;
 
 public final class ShadowDocument implements DocumentView {
-  private final Object mRootElement;
-  private final IdentityHashMap<Object, ElementInfo> mElementToInfoMap = new IdentityHashMap<>();
+  private final NodeID mRootNodeID;
+  private final IdentityHashMap<NodeID, NodeInfo> mNodeIDToInfoMap = new IdentityHashMap<>();
   private boolean mIsUpdating;
 
-  public ShadowDocument(Object rootElement) {
-    mRootElement = Util.throwIfNull(rootElement);
+  public ShadowDocument(NodeID rootID) {
+    mRootNodeID = Util.throwIfNull(rootID);
   }
 
   @Override
-  public Object getRootElement() {
-    return mRootElement;
+  public NodeID getRootID() {
+    return mRootNodeID;
   }
 
   @Override
-  public ElementInfo getElementInfo(Object element) {
-    return mElementToInfoMap.get(element);
+  public NodeInfo getNodeInfo(NodeID id) {
+    return mNodeIDToInfoMap.get(id);
   }
 
   public UpdateBuilder beginUpdate() {
@@ -56,26 +55,26 @@ public final class ShadowDocument implements DocumentView {
   public final class UpdateBuilder {
     /**
      * We use a {@link LinkedHashMap} to preserve ordering between
-     * {@link UpdateBuilder#setElementChildren(Object, List)} and
-     * {@link Update#getChangedElements(Accumulator)}. This isn't needed for correctness but it
+     * {@link UpdateBuilder#setNodeChildren(NodeID, List)} and
+     * {@link Update#getChangedNodeIDs(Accumulator)}. This isn't needed for correctness but it
      * significantly improves performance.<p/>
      *
      * Transmitting DOM updates to Chrome works best if we can do it in top-down order because it
-     * allows us to skip processing (and, more importantly, transmission) of an element that was
+     * allows us to skip processing (and, more importantly, transmission) of an nodeID that was
      * already transmitted in a previous DOM.childNodeInserted event (i.o.w. we can skip
-     * transmission of E2 if it was already bundled up in E1's event, where E2 is any element in
-     * E1's sub-tree). DOM.childNodeInserted transmits the node being inserted by-value, so it takes
-     * time and space proportional to the size of that node's sub-tree. This means the difference
+     * transmission of E2 if it was already bundled up in E1's event, where E2 is any nodeID in
+     * E1's sub-tree). DOM.childNodeInserted transmits the nodeID being inserted by-value, so it takes
+     * time and space proportional to the size of that nodeID's sub-tree. This means the difference
      * between O(n^2) and O(n) time for transmitting updates to Chrome.<p/>
      *
      * We currently only have one implementation of {@link DocumentProvider},
      * {@link com.facebook.stetho.inspector.elements.android.AndroidDocumentProvider}, and it
-     * already supplies element changes in top-down order. Because of this, we can just use
+     * already supplies nodeID changes in top-down order. Because of this, we can just use
      * {@link LinkedHashMap} instead of adding some kind of post-process sorting of the elements to
      * put them in that order. If we reach a point where we can't or shouldn't rely on elements
      * being forwarded to us in top-down order, then we should change this field to an
      * {@link IdentityHashMap} and sort them before relaying them via
-     * {@link Update#getChangedElements(Accumulator)}.<p/>
+     * {@link Update#getChangedNodeIDs(Accumulator)}.<p/>
      *
      * When a large sub-tree is added (e.g. starting a new {@link Activity}), the use of
      * {@link LinkedHashMap} instead of {@link IdentityHashMap} can mean the difference between an
@@ -86,164 +85,164 @@ public final class ShadowDocument implements DocumentView {
      * Given the difference in performance, however, the risk of potential protocol abuse seems
      * reasonable.<p/>
      */
-    private final Map<Object, ElementInfo> mElementToInfoChangesMap = new LinkedHashMap<>();
+    private final Map<NodeID, NodeInfo> mNodeIDToInfoChangesMap = new LinkedHashMap<>();
 
     /**
-     * This contains every element in {@link #mElementToInfoChangesMap} whose
-     * {@link ElementInfo#parentElement} is null. {@link ShadowDocument} provides access to a tree, which
-     * means it has a single root (only one element with a null parent). During an update, however,
+     * This contains every nodeID in {@link #mNodeIDToInfoChangesMap} whose
+     * {@link NodeInfo#parentID} is null. {@link ShadowDocument} provides access to a tree, which
+     * means it has a single root (only one nodeID with a null parent). During an update, however,
      * the DOM can be conceptually thought of as being a forest. The true root is identified by
-     * {@link #mRootElement}, and all other roots identify disconnected trees full of elements that
+     * {@link #mRootNodeID}, and all other roots identify disconnected trees full of elements that
      * must be garbage collected.
      */
-    private final HashSet<Object> mRootElementChanges = new HashSet<>();
+    private final HashSet<NodeID> mRootNodeIDChanges = new HashSet<>();
 
     /**
-     * This is used during {@link #setElementChildren}. We allocate 1 on-demand and reuse it.
+     * This is used during {@link #setNodeChildren}. We allocate 1 on-demand and reuse it.
      */
-    private HashSet<Object> mCachedNotNewChildrenSet;
+    private HashSet<NodeID> mCachedNotNewChildrenSet;
 
-    public void setElementChildren(Object element, List<Object> children) {
+    public void setNodeChildren(NodeID nodeID, List<NodeID> childrenIDs) {
       // If we receive redundant information, then nothing needs to be done.
-      ElementInfo changesElementInfo = mElementToInfoChangesMap.get(element);
-      if (changesElementInfo != null &&
-          ListUtil.identityEquals(children, changesElementInfo.children)) {
+      NodeInfo changesNodeInfo = mNodeIDToInfoChangesMap.get(nodeID);
+      if (changesNodeInfo != null &&
+          childrenIDs.equals(changesNodeInfo.childrenIDs)) {
         return;
       }
 
-      ElementInfo oldElementInfo = mElementToInfoMap.get(element);
-      if (changesElementInfo == null &&
-          oldElementInfo != null &&
-          ListUtil.identityEquals(children, oldElementInfo.children)) {
+      NodeInfo oldNodeInfo = mNodeIDToInfoMap.get(nodeID);
+      if (changesNodeInfo == null &&
+          oldNodeInfo != null &&
+          childrenIDs.equals(oldNodeInfo.childrenIDs)) {
         return;
       }
 
-      ElementInfo newElementInfo;
-      if (changesElementInfo != null &&
-          oldElementInfo != null &&
-          oldElementInfo.parentElement == changesElementInfo.parentElement &&
-          ListUtil.identityEquals(children, oldElementInfo.children)) {
-        // setElementChildren() was already called for element with changes during this
-        // transaction, but now we're being told that the children should match the old view.
+      NodeInfo newNodeInfo;
+      if (changesNodeInfo != null &&
+          oldNodeInfo != null &&
+          oldNodeInfo.parentID.equals(changesNodeInfo.parentID) &&
+          childrenIDs.equals(oldNodeInfo.childrenIDs)) {
+        // setNodeChildren() was already called for nodeID with changes during this
+        // transaction, but now we're being told that the childrenIDs should match the old view.
         // So we should actually remove the change entry.
-        newElementInfo = mElementToInfoMap.get(element);
-        mElementToInfoChangesMap.remove(element);
+        newNodeInfo = mNodeIDToInfoMap.get(nodeID);
+        mNodeIDToInfoChangesMap.remove(nodeID);
       } else {
-        Object parentElement = (changesElementInfo != null)
-            ? changesElementInfo.parentElement
-            : (oldElementInfo != null)
-            ? oldElementInfo.parentElement
+        NodeID parentID = (changesNodeInfo != null)
+            ? changesNodeInfo.parentID
+            : (oldNodeInfo != null)
+            ? oldNodeInfo.parentID
             : null;
 
-        newElementInfo = new ElementInfo(element, parentElement, children);
+        newNodeInfo = new NodeInfo(nodeID, parentID, childrenIDs);
 
-        mElementToInfoChangesMap.put(element, newElementInfo);
+        mNodeIDToInfoChangesMap.put(nodeID, newNodeInfo);
       }
 
-      // At this point, newElementInfo is either equal to oldElementInfo because we've reverted
+      // At this point, newNodeInfo is either equal to oldNodeInfo because we've reverted
       // back to the same data that's in the old view of the tree, or it's a brand new object with
-      // brand new changes (it's different than both of oldElementInfo and changesElementInfo).
+      // brand new changes (it's different than both of oldNodeInfo and changesNodeInfo).
 
-      // Next, set the parentElement to null for child elements that have been removed from
-      // element's children. We must be careful not to set a parentElement to null if that child has
-      // already been moved to be the child of a different element. e.g.,
-      //     setElementChildren(E, { A, B, C})
+      // Next, set the parentID to null for child ids that have been removed from
+      // nodeID's childrenIDs. We must be careful not to set a parentID to null if that child has
+      // already been moved to be the child of a different nodeID. e.g.,
+      //     setNodeChildren(E, { A, B, C})
       //     ...
-      //     setElementChildren(F, { A })
-      //     setElementChildren(E, { B, C })    (don't mark A's parent as null in this case)
+      //     setNodeChildren(F, { A })
+      //     setNodeChildren(E, { B, C })    (don't mark A's parent as null in this case)
 
       // notNewChildrenSet = (oldChildren + changesChildren) - newChildren
-      HashSet<Object> notNewChildrenSet = acquireNotNewChildrenHashSet();
+      HashSet<NodeID> notNewChildrenSet = acquireNotNewChildrenHashSet();
 
-      if (oldElementInfo != null &&
-          oldElementInfo.children != newElementInfo.children) {
-        for (int i = 0, N = oldElementInfo.children.size(); i < N; ++i) {
-          final Object childElement = oldElementInfo.children.get(i);
-          notNewChildrenSet.add(childElement);
+      if (oldNodeInfo != null &&
+          !oldNodeInfo.childrenIDs.equals(newNodeInfo.childrenIDs)) {
+        for (int i = 0, N = oldNodeInfo.childrenIDs.size(); i < N; ++i) {
+          final NodeID childID = oldNodeInfo.childrenIDs.get(i);
+          notNewChildrenSet.add(childID);
         }
       }
 
-      if (changesElementInfo != null &&
-          changesElementInfo.children != newElementInfo.children) {
-        for (int i = 0, N = changesElementInfo.children.size(); i < N; ++i) {
-          final Object childElement = changesElementInfo.children.get(i);
-          notNewChildrenSet.add(childElement);
+      if (changesNodeInfo != null &&
+          !changesNodeInfo.childrenIDs.equals(newNodeInfo.childrenIDs)) {
+        for (int i = 0, N = changesNodeInfo.childrenIDs.size(); i < N; ++i) {
+          final NodeID childID = changesNodeInfo.childrenIDs.get(i);
+          notNewChildrenSet.add(childID);
         }
       }
 
-      for (int i = 0, N = newElementInfo.children.size(); i < N; ++i) {
-        final Object childElement = newElementInfo.children.get(i);
-        setElementParent(childElement, element);
-        notNewChildrenSet.remove(childElement);
+      for (int i = 0, N = newNodeInfo.childrenIDs.size(); i < N; ++i) {
+        final NodeID childID = newNodeInfo.childrenIDs.get(i);
+        setNodeParent(childID, nodeID);
+        notNewChildrenSet.remove(childID);
       }
 
-      for (Object childElement : notNewChildrenSet) {
-        final ElementInfo childChangesElementInfo = mElementToInfoChangesMap.get(childElement);
-        if (childChangesElementInfo != null &&
-            childChangesElementInfo.parentElement != element) {
-          // do nothing. this childElement was moved to be the child of another element.
+      for (NodeID childID : notNewChildrenSet) {
+        final NodeInfo childChangesNodeInfo = mNodeIDToInfoChangesMap.get(childID);
+        if (childChangesNodeInfo != null &&
+            !childChangesNodeInfo.parentID.equals(nodeID)) {
+          // do nothing. this childID was moved to be the child of another nodeID.
           continue;
         }
 
-        final ElementInfo oldChangesElementInfo = mElementToInfoMap.get(childElement);
-        if (oldChangesElementInfo != null &&
-            oldChangesElementInfo.parentElement == element) {
-          setElementParent(childElement, null);
+        final NodeInfo oldChangesNodeInfo = mNodeIDToInfoMap.get(childID);
+        if (oldChangesNodeInfo != null &&
+            oldChangesNodeInfo.parentID.equals(nodeID)) {
+          setNodeParent(childID, null);
         }
       }
 
       releaseNotNewChildrenHashSet(notNewChildrenSet);
     }
 
-    private void setElementParent(Object element, Object parentElement) {
-      ElementInfo changesElementInfo = mElementToInfoChangesMap.get(element);
-      if (changesElementInfo != null &&
-          parentElement == changesElementInfo.parentElement) {
+    private void setNodeParent(NodeID nodeID, NodeID parentID) {
+      NodeInfo changesNodeInfo = mNodeIDToInfoChangesMap.get(nodeID);
+      if (changesNodeInfo != null &&
+          parentID.equals(changesNodeInfo.parentID)) {
         return;
       }
 
-      ElementInfo oldElementInfo = mElementToInfoMap.get(element);
-      if (changesElementInfo == null &&
-          oldElementInfo != null &&
-          parentElement == oldElementInfo.parentElement) {
+      NodeInfo oldNodeInfo = mNodeIDToInfoMap.get(nodeID);
+      if (changesNodeInfo == null &&
+          oldNodeInfo != null &&
+          parentID.equals(oldNodeInfo.parentID)) {
         return;
       }
 
-      if (changesElementInfo != null &&
-          oldElementInfo != null &&
-          parentElement == oldElementInfo.parentElement &&
-          ListUtil.identityEquals(oldElementInfo.children, changesElementInfo.children)) {
-        mElementToInfoChangesMap.remove(element);
+      if (changesNodeInfo != null &&
+          oldNodeInfo != null &&
+          parentID.equals(oldNodeInfo.parentID) &&
+          oldNodeInfo.childrenIDs.equals(changesNodeInfo.childrenIDs)) {
+        mNodeIDToInfoChangesMap.remove(nodeID);
 
-        if (parentElement == null) {
-          mRootElementChanges.remove(element);
+        if (parentID == null) {
+          mRootNodeIDChanges.remove(nodeID);
         }
 
         return;
       }
 
-      List<Object> children = (changesElementInfo != null)
-          ? changesElementInfo.children
-          : (oldElementInfo != null)
-          ? oldElementInfo.children
-          : Collections.emptyList();
+      List<NodeID> children = (changesNodeInfo != null)
+          ? changesNodeInfo.childrenIDs
+          : (oldNodeInfo != null)
+          ? oldNodeInfo.childrenIDs
+          : Collections.<NodeID>emptyList();
 
-      ElementInfo newElementInfo = new ElementInfo(element, parentElement, children);
-      mElementToInfoChangesMap.put(element, newElementInfo);
+      NodeInfo newNodeInfo = new NodeInfo(nodeID, parentID, children);
+      mNodeIDToInfoChangesMap.put(nodeID, newNodeInfo);
 
-      if (parentElement == null) {
-        mRootElementChanges.add(element);
+      if (parentID == null) {
+        mRootNodeIDChanges.add(nodeID);
       } else {
-        mRootElementChanges.remove(element);
+        mRootNodeIDChanges.remove(nodeID);
       }
     }
 
     public Update build() {
-      return new Update(mElementToInfoChangesMap, mRootElementChanges);
+      return new Update(mNodeIDToInfoChangesMap, mRootNodeIDChanges);
     }
 
-    private HashSet<Object> acquireNotNewChildrenHashSet() {
-      HashSet<Object> notNewChildrenHashSet = mCachedNotNewChildrenSet;
+    private HashSet<NodeID> acquireNotNewChildrenHashSet() {
+      HashSet<NodeID> notNewChildrenHashSet = mCachedNotNewChildrenSet;
       if (notNewChildrenHashSet == null) {
         notNewChildrenHashSet = new HashSet<>();
       }
@@ -251,7 +250,7 @@ public final class ShadowDocument implements DocumentView {
       return notNewChildrenHashSet;
     }
 
-    private void releaseNotNewChildrenHashSet(HashSet<Object> notNewChildrenHashSet) {
+    private void releaseNotNewChildrenHashSet(HashSet<NodeID> notNewChildrenHashSet) {
       notNewChildrenHashSet.clear();
       if (mCachedNotNewChildrenSet == null) {
         mCachedNotNewChildrenSet = notNewChildrenHashSet;
@@ -260,78 +259,78 @@ public final class ShadowDocument implements DocumentView {
   }
 
   public final class Update implements DocumentView {
-    private final Map<Object, ElementInfo> mElementToInfoChangesMap;
-    private final Set<Object> mRootElementChangesSet;
+    private final Map<NodeID, NodeInfo> mNodeIDToInfoChangesMap;
+    private final Set<NodeID> mRootNodeIDChangesSet;
 
     public Update(
-        Map<Object, ElementInfo> elementToInfoChangesMap,
-        Set<Object> rootElementChangesSet) {
-      mElementToInfoChangesMap = elementToInfoChangesMap;
-      mRootElementChangesSet = rootElementChangesSet;
+        Map<NodeID, NodeInfo> nodeIDToInfoChangesMap,
+        Set<NodeID> rootNodeIDChangesSet) {
+      mNodeIDToInfoChangesMap = nodeIDToInfoChangesMap;
+      mRootNodeIDChangesSet = rootNodeIDChangesSet;
     }
 
     public boolean isEmpty() {
-      return mElementToInfoChangesMap.isEmpty();
+      return mNodeIDToInfoChangesMap.isEmpty();
     }
 
-    public boolean isElementChanged(Object element) {
-      return mElementToInfoChangesMap.containsKey(element);
+    public boolean isNodeIDChanged(NodeID id) {
+      return mNodeIDToInfoChangesMap.containsKey(id);
     }
 
-    public Object getRootElement() {
-      return ShadowDocument.this.getRootElement();
+    public NodeID getRootID() {
+      return ShadowDocument.this.getRootID();
     }
 
-    public ElementInfo getElementInfo(Object element) {
-      // Return ElementInfo for the new (albeit uncommitted and pre-garbage collected) view of the
-      // Document. If element is garbage then you'll still get its info (feature, not a bug :)).
-      ElementInfo elementInfo = mElementToInfoChangesMap.get(element);
-      if (elementInfo != null) {
-        return elementInfo;
+    public NodeInfo getNodeInfo(NodeID id) {
+      // Return NodeInfo for the new (albeit uncommitted and pre-garbage collected) view of the
+      // Document. If nodeID is garbage then you'll still get its info (feature, not a bug :)).
+      NodeInfo nodeInfo = mNodeIDToInfoChangesMap.get(id);
+      if (nodeInfo != null) {
+        return nodeInfo;
       }
-      return mElementToInfoMap.get(element);
+      return mNodeIDToInfoMap.get(id);
     }
 
-    public void getChangedElements(Accumulator<Object> accumulator) {
-      for (Object element : mElementToInfoChangesMap.keySet()) {
-        accumulator.store(element);
+    public void getChangedNodeIDs(Accumulator<NodeID> accumulator) {
+      for (NodeID id : mNodeIDToInfoChangesMap.keySet()) {
+        accumulator.store(id);
       }
     }
 
-    public void getGarbageElements(Accumulator<Object> accumulator) {
-      // This queue stores pairs of elements, [element, expectedParent]
-      // When we dequeue, we look at element's parentElement in the new view to see if it matches
+    public void getGarbageNodeIDs(Accumulator<NodeID> accumulator) {
+      // This queue stores pairs of elements, [nodeID, expectedParent]
+      // When we dequeue, we look at nodeID's parentID in the new view to see if it matches
       // expectedParent. If it does, then it's garbage. For enqueueing roots, whose parents are
-      // null, since we can't enqueue null we instead enqueue the element twice.
-      Queue<Object> queue = new ArrayDeque<>();
+      // null, since we can't enqueue null we instead enqueue the nodeID twice.
+      Queue<NodeID> queue = new ArrayDeque<>();
 
-      // Initialize the queue with all disconnected tree roots (parentElement == null) which
+      // Initialize the queue with all disconnected tree roots (parentID == null) which
       // aren't the DOM root.
-      for (Object element : mRootElementChangesSet) {
-        ElementInfo newElementInfo = getElementInfo(element);
-        if (element != mRootElement && newElementInfo.parentElement == null) {
-          queue.add(element);
-          queue.add(element);
+      for (NodeID id : mRootNodeIDChangesSet) {
+        NodeInfo newNodeInfo = getNodeInfo(id);
+        if (!id.equals(mRootNodeID) && newNodeInfo.parentID == null) {
+          queue.add(id);
+          queue.add(id);
         }
       }
 
-      // BFS traversal from those elements in the old view of the tree and test each element
+      // BFS traversal from those elements in the old view of the tree and test each nodeID
       // to see if it's still within a disconnected sub-tree. We can tell if it's garbage if its
-      // parent element in the new view of the tree hasn't changed.
+      // parent nodeID in the new view of the tree hasn't changed.
       while (!queue.isEmpty()) {
-        final Object element = queue.remove();
-        final Object expectedParent0 = queue.remove();
-        final Object expectedParent = (element == expectedParent0) ? null : expectedParent0;
-        final ElementInfo newElementInfo = getElementInfo(element);
+        final NodeID id = queue.remove();
+        final NodeID expectedParent0 = queue.remove();
+        final NodeID expectedParent = id.equals(expectedParent0) ? null : expectedParent0;
+        final NodeInfo newNodeInfo = getNodeInfo(id);
 
-        if (newElementInfo.parentElement == expectedParent) {
-          accumulator.store(element);
+        if (newNodeInfo.parentID.equals(expectedParent)) {
+          accumulator.store(id);
 
-          ElementInfo oldElementInfo = ShadowDocument.this.getElementInfo(element);
-          if (oldElementInfo != null) {
-            for (int i = 0, N = oldElementInfo.children.size(); i < N; ++i) {
-              queue.add(oldElementInfo.children.get(i));
-              queue.add(element);
+          NodeInfo oldNodeInfo = ShadowDocument.this.getNodeInfo(id);
+          if (oldNodeInfo != null) {
+            for (int i = 0, N = oldNodeInfo.childrenIDs.size(); i < N; ++i) {
+              queue.add(oldNodeInfo.childrenIDs.get(i));
+              queue.add(id);
             }
           }
         }
@@ -352,99 +351,99 @@ public final class ShadowDocument implements DocumentView {
       }
 
       // Apply the changes to the tree
-      mElementToInfoMap.putAll(mElementToInfoChangesMap);
+      mNodeIDToInfoMap.putAll(mNodeIDToInfoChangesMap);
 
-      // Remove garbage elements: those that have a null parent (other than mRootElement), and
+      // Remove garbage elements: those that have a null parent (other than mRootNodeID), and
       // their entire sub-trees, but excluding reparented elements.
-      for (Object element : mRootElementChangesSet) {
-        removeGarbageSubTree(mElementToInfoMap, element);
+      for (NodeID id : mRootNodeIDChangesSet) {
+        removeGarbageSubTree(mNodeIDToInfoMap, id);
       }
 
       mIsUpdating = false;
 
       // Not usually enabled because it's expensive. Very useful for debugging.
-      //validateTree(mElementToInfoMap);
+      //validateTree(mNodeIDToInfoMap);
     }
 
     private void removeGarbageSubTree(
-        Map<Object, ElementInfo> elementToInfoMap,
-        Object element) {
-      final ElementInfo elementInfo = elementToInfoMap.get(element);
+        Map<NodeID, NodeInfo> nodeIDToInfoMap,
+        NodeID nodeID) {
+      final NodeInfo nodeInfo = nodeIDToInfoMap.get(nodeID);
 
-      // If this element has a parent (it's not a root), and that parent is still in the tree after
+      // If this nodeID has a parent (it's not a root), and that parent is still in the tree after
       // changes have been applied and after our caller (removeGarbageSubTree) removed another
-      // element that claims this element as its child, then that means this element should not be
+      // nodeID that claims this nodeID as its child, then that means this nodeID should not be
       // removed. It has been reparented, and recursion stops here.
-      if (elementInfo.parentElement != null &&
-          elementToInfoMap.containsKey(elementInfo.parentElement)) {
+      if (nodeInfo.parentID != null &&
+          nodeIDToInfoMap.containsKey(nodeInfo.parentID)) {
         return;
       }
 
-      elementToInfoMap.remove(element);
+      nodeIDToInfoMap.remove(nodeID);
 
-      for (int i = 0, N = elementInfo.children.size(); i < N; ++i) {
-        removeGarbageSubTree(elementToInfoMap, elementInfo.children.get(i));
+      for (int i = 0, N = nodeInfo.childrenIDs.size(); i < N; ++i) {
+        removeGarbageSubTree(nodeIDToInfoMap, nodeInfo.childrenIDs.get(i));
       }
     }
 
     // This method is intended for use during debugging. Put a breakpoint on each throw statement in
     // order to catch structural problems in the tree. This method should only be called at the very
     // end of commit().
-    private void validateTree(Map<Object, ElementInfo> elementToInfoMap) {
+    private void validateTree(Map<NodeID, NodeInfo> nodeIDToInfoMap) {
       // We need a tree, not a forest.
-      HashSet<Object> rootElements = new HashSet<>();
+      HashSet<NodeID> rootIDs = new HashSet<>();
 
-      for (Map.Entry<Object, ElementInfo> entry : elementToInfoMap.entrySet()) {
-        final Object element = entry.getKey();
-        final ElementInfo elementInfo = entry.getValue();
+      for (Map.Entry<NodeID, NodeInfo> entry : nodeIDToInfoMap.entrySet()) {
+        final NodeID nodeI = entry.getKey();
+        final NodeInfo nodeInfo = entry.getValue();
 
-        if (element != elementInfo.element) {
+        if (!nodeI.equals(nodeInfo.nodeID)) {
           // should not be possible
-          throw new IllegalStateException("element != elementInfo.element");
+          throw new IllegalStateException("nodeID != nodeInfo.nodeID");
         }
 
-        // Verify children
-        for (int i = 0, N = elementInfo.children.size(); i < N; ++i) {
-          final Object childElement = elementInfo.children.get(i);
-          final ElementInfo childElementInfo = elementToInfoMap.get(childElement);
+        // Verify childrenIDs
+        for (int i = 0, N = nodeInfo.childrenIDs.size(); i < N; ++i) {
+          final NodeID childID = nodeInfo.childrenIDs.get(i);
+          final NodeInfo childNodeInfo = nodeIDToInfoMap.get(childID);
 
-          if (childElementInfo == null) {
+          if (childNodeInfo == null) {
             throw new IllegalStateException(String.format(
-                "elementInfo.get(elementInfo.children.get(%s)) == null",
+                "nodeInfo.get(nodeInfo.childrenIDs.get(%s)) == null",
                 i));
           }
 
-          if (childElementInfo.parentElement != element) {
-            throw new IllegalStateException("childElementInfo.parentElement != element");
+          if (!childNodeInfo.parentID.equals(nodeI)) {
+            throw new IllegalStateException("childNodeInfo.parentID != nodeID");
           }
         }
 
         // Verify parent
-        if (elementInfo.parentElement == null) {
-          rootElements.add(element);
+        if (nodeInfo.parentID == null) {
+          rootIDs.add(nodeI);
         } else {
-          final ElementInfo parentElementInfo = elementToInfoMap.get(elementInfo.parentElement);
-          if (parentElementInfo == null) {
+          final NodeInfo parentNodeInfo = nodeIDToInfoMap.get(nodeInfo.parentID);
+          if (parentNodeInfo == null) {
             throw new IllegalStateException(
-                "elementToInfoMap.get(elementInfo.parentElementInfo) == NULL");
+                "nodeIDToInfoMap.get(nodeInfo.parentNodeInfo) == NULL");
           }
 
-          if (elementInfo.parentElement != parentElementInfo.element) {
+          if (!nodeInfo.parentID.equals(parentNodeInfo.nodeID)) {
             // should not be possible
             throw new IllegalStateException(
-                "elementInfo.parentElementInfo != parentElementInfo.parent");
+                "nodeInfo.parentNodeInfo != parentNodeInfo.parent");
           }
 
-          if (!parentElementInfo.children.contains(element)) {
+          if (!parentNodeInfo.childrenIDs.contains(nodeI)) {
             throw new IllegalStateException(
-                "parentElementInfo.children.contains(element) == FALSE");
+                "parentNodeInfo.childrenIDs.contains(nodeID) == FALSE");
           }
         }
       }
 
-      if (rootElements.size() != 1) {
+      if (rootIDs.size() != 1) {
         throw new IllegalStateException(
-            "elementToInfoMap is a forest, not a tree. rootElements.size() != 1");
+            "nodeIDToInfoMap is a forest, not a tree. rootrootIDs.size() != 1");
       }
     }
   }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -64,7 +64,7 @@ public final class AccessibilityNodeInfoWrapper {
       return true;
     }
 
-    // If this node has no focusable ancestors, but it still has text,
+    // If this nodeID has no focusable ancestors, but it still has text,
     // then it should receive focus from navigation and be read aloud.
     if (!AccessibilityUtil.hasFocusableAncestor(node, view) && AccessibilityUtil.hasText(node)) {
       return false;
@@ -117,7 +117,7 @@ public final class AccessibilityNodeInfoWrapper {
 
     if (AccessibilityUtil.isActionableForAccessibility(node)) {
       if (node.getChildCount() <= 0) {
-        return "View is actionable and has no children.";
+        return "View is actionable and has no childrenIDs.";
       } else if (hasText) {
         return "View is actionable and has a description.";
       } else if (isCheckable) {
@@ -187,10 +187,10 @@ public final class AccessibilityNodeInfoWrapper {
           actionLabels.append("previous-at-movement-granularity");
           break;
         case AccessibilityNodeInfoCompat.ACTION_NEXT_HTML_ELEMENT:
-          actionLabels.append("next-html-element");
+          actionLabels.append("next-html-nodeID");
           break;
         case AccessibilityNodeInfoCompat.ACTION_PREVIOUS_HTML_ELEMENT:
-          actionLabels.append("previous-html-element");
+          actionLabels.append("previous-html-nodeID");
           break;
         case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD:
           actionLabels.append("scroll-forward");
@@ -241,7 +241,7 @@ public final class AccessibilityNodeInfoWrapper {
       return nodeText;
     }
 
-    // If there are child views and no contentDescription the text of all non-focusable children,
+    // If there are child views and no contentDescription the text of all non-focusable childrenIDs,
     // comma separated, becomes the description.
     if (view instanceof ViewGroup) {
       final StringBuilder concatChildDescription = new StringBuilder();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -228,10 +228,10 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
         @Override
         public void store(Object element) {
           if (element instanceof Window) {
-            // Store the Window and do not recurse into its children.
+            // Store the Window and do not recurse into its childrenIDs.
             accumulator.store((Window) element);
           } else {
-            // Recursively scan this element's children in search of more Windows.
+            // Recursively scan this nodeID's childrenIDs in search of more Windows.
             Descriptor elementDescriptor = getDescriptor(element);
             if (elementDescriptor != null) {
               elementDescriptor.getChildren(element, this);

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentRoot.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentRoot.java
@@ -16,7 +16,7 @@ import com.facebook.stetho.common.Util;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.NodeType;
 
-// For the root, we use 1 object for both element and descriptor.
+// For the root, we use 1 object for both nodeID and descriptor.
 
 final class AndroidDocumentRoot extends AbstractChainedDescriptor<AndroidDocumentRoot> {
   private final Application mApplication;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -22,6 +22,7 @@ import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
+import com.facebook.stetho.inspector.elements.NodeID;
 import com.facebook.stetho.inspector.elements.NodeType;
 import com.facebook.stetho.inspector.elements.StyleAccumulator;
 
@@ -97,7 +98,7 @@ final class DialogFragmentDescriptor
   @Override
   public void getChildren(Object element, Accumulator<Object> children) {
     /**
-     * We do NOT want the children from our super-{@link Descriptor}, which is probably
+     * We do NOT want the childrenIDs from our super-{@link Descriptor}, which is probably
      * {@link FragmentDescriptor}. We only want to emit the {@link Dialog}, not the {@link View}.
      * Therefore, we don't call mSuper.getChildren(), and this is the reason why we don't derive
      * from {@link AbstractChainedDescriptor} (it doesn't allow a non-chained implementation of
@@ -134,5 +135,10 @@ final class DialogFragmentDescriptor
 
   @Override
   public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  }
+
+  @Override
+  public NodeID getNodeID(Object element) {
+    return mSuper.getNodeID(element);
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -177,7 +177,7 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
       } catch (Exception e) {
         if (e instanceof IllegalAccessException || e instanceof InvocationTargetException) {
           LogUtil.e(e, "failed to get style property " + property.getCSSName() +
-                  " of element= " + element.toString());
+                  " of nodeID= " + element.toString());
         } else {
           throw ExceptionUtil.propagate(e);
         }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -64,7 +64,7 @@ public class CSS implements ChromeDevtoolsDomain {
         Object element = mDocument.getElementForNodeId(request.nodeId);
 
         if (element == null) {
-          LogUtil.e("Tried to get the style of an element that does not exist, using nodeid=" +
+          LogUtil.e("Tried to get the style of an nodeID that does not exist, using nodeid=" +
               request.nodeId);
 
           return;
@@ -127,7 +127,7 @@ public class CSS implements ChromeDevtoolsDomain {
         Object elementForNodeId = mDocument.getElementForNodeId(request.nodeId);
 
         if (elementForNodeId == null) {
-          LogUtil.w("Failed to get style of an element that does not exist, nodeid=" +
+          LogUtil.w("Failed to get style of an nodeID that does not exist, nodeid=" +
               request.nodeId);
           return;
         }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -567,7 +567,7 @@ public class Runtime implements ChromeDevtoolsDomain {
   public static enum ObjectSubType {
     ARRAY("array"),
     NULL("null"),
-    NODE("node"),
+    NODE("nodeID"),
     REGEXP("regexp"),
     DATE("date"),
     MAP("map"),


### PR DESCRIPTION
Currently a node id is directly connected to the instance of an object.
This has worked well up to this point. However we are implementing
custom descriptors which describe elements which are pooled under the
hood. When the UI changes we make no guarantees that a logical UI node
is represented by the same java object as before.

The problem with the current implementation in stetho is that this
causes the chrome element inspector to collapse/move nodes unexpectedly
when updating. This commit solve this by allows descriptors to
implement custom stable ids for nodes.