### PR TITLE
Move selector naming to the descriptor

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -149,11 +149,11 @@ public abstract class AbstractChainedDescriptor<E>
   }
 
   @Override
-  public final void getAccessibilityStyles(E element, StyleAccumulator accumulator) {
-    mSuper.getAccessibilityStyles(element, accumulator);
-    onGetAccessibilityStyles(element, accumulator);
+  public void getComputedStyles(E element, ComputedStyleAccumulator accumulator) {
+    mSuper.getComputedStyles(element, accumulator);
+    onGetComputedStyles(element, accumulator);
   }
 
-  protected void onGetAccessibilityStyles(E element, StyleAccumulator accumulator) {
+  protected void onGetComputedStyles(E element, ComputedStyleAccumulator accumulator) {
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ComputedStyleAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ComputedStyleAccumulator.java
@@ -9,6 +9,6 @@
 
 package com.facebook.stetho.inspector.elements;
 
-public interface StyleAccumulator {
-  void store(String selector, String name, String value, boolean isDefault);
+public interface ComputedStyleAccumulator {
+  void store(String name, String value);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -147,10 +147,10 @@ public final class Document extends ThreadBoundProxy {
     nodeDescriptor.getStyles(element, styleAccumulator);
   }
 
-  public void getElementAccessibilityStyles(Object element, StyleAccumulator styleAccumulator) {
+  public void getElementComputedStyles(Object element, ComputedStyleAccumulator styleAccumulator) {
     NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
 
-    nodeDescriptor.getAccessibilityStyles(element, styleAccumulator);
+    nodeDescriptor.getComputedStyles(element, styleAccumulator);
   }
 
   public DocumentView getDocumentView() {
@@ -340,7 +340,7 @@ public final class Document extends ThreadBoundProxy {
         Long.toString(deltaMs),
         isEmpty ? " (no changes)" : "");
   }
-  
+
   private void applyDocumentUpdate(final ShadowDocument.Update docUpdate) {
     // TODO: it'd be nice if we could delegate our calls into mPeerManager.sendNotificationToPeers()
     //       to a background thread so as to offload the UI from JSON serialization stuff

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -36,5 +36,5 @@ public interface NodeDescriptor<E> extends ThreadBound {
 
   void getStyles(E element, StyleAccumulator accumulator);
 
-  void getAccessibilityStyles(E element, StyleAccumulator accumulator);
+  void getComputedStyles(E element, ComputedStyleAccumulator accumulator);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -57,6 +57,6 @@ public final class ObjectDescriptor extends Descriptor<Object> {
   }
 
   @Override
-  public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  public void getComputedStyles(Object element, ComputedStyleAccumulator accumulator) {
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -20,6 +20,7 @@ import com.facebook.stetho.common.android.FragmentCompat;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ChainedDescriptor;
+import com.facebook.stetho.inspector.elements.ComputedStyleAccumulator;
 import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.NodeType;
@@ -133,6 +134,6 @@ final class DialogFragmentDescriptor
   }
 
   @Override
-  public void getAccessibilityStyles(Object element, StyleAccumulator accumulator) {
+  public void getComputedStyles(Object element, ComputedStyleAccumulator styles) {
   }
 }


### PR DESCRIPTION
Currently two selector names are hard-coded in DOM.java.
"<this_element>" and "Accessibility Properties". With this commit
descriptors are able to themselves choose what the selector name should
be and how their various properties should be distributed among the
selectors.

This enables an element to have styles such as:

```
layout {
  width: 100px;
  height: 100px;
}

props {
  text: "Hello World";
}
```

Due to this requiring an added property in StyleAccumulator I chose to
also take this commit to split up styles from computed styles which are
two separate concepts but up until now have been handled the same. A
style may be `width: 100%` while a computed style would be `width:
320px`.