### PR TITLE
Use empty rect if bounds are null, avoiding NPE

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -62,6 +62,7 @@ abstract class ViewHighlighter {
     // Only assigned on the UI thread
     private View mHighlightedView;
     private final Rect mHighlightedBounds = new Rect();
+    private final Rect mEmptyRect = new Rect();
 
     private AtomicReference<View> mViewToHighlight = new AtomicReference<View>();
     private AtomicReference<Rect> mBoundsToHighlight = new AtomicReference<Rect>();
@@ -98,7 +99,10 @@ abstract class ViewHighlighter {
 
     private void highlightViewOnUiThread() {
       final View viewToHighlight = mViewToHighlight.getAndSet(null);
-      final Rect boundsToHighlight = mBoundsToHighlight.getAndSet(null);
+      Rect boundsToHighlight = mBoundsToHighlight.getAndSet(null);
+      if (boundsToHighlight == null) {
+        boundsToHighlight = mEmptyRect;
+      }
 
       if (viewToHighlight == mHighlightedView && mHighlightedBounds.equals(boundsToHighlight)) {
         return;


### PR DESCRIPTION
The bounds passed to `setHighlightedViewImpl` is `@Nullable` but not the bounds declared in `HighlightOverlays.highlightView`. This commit makes sure `HighlightOverlays.highlightView` is always passed a non-null `Rect`.