### PR TITLE
Made URLConnectionInspectorHeaders case insensitive

### DIFF
--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
@@ -40,7 +40,7 @@ class URLConnectionInspectorHeaders implements NetworkEventReporter.InspectorHea
   public String firstHeaderValue(String name) {
     int N = headerCount();
     for (int i = 0; i < N; i++) {
-      if (name.equals(headerName(i))) {
+      if (name.equalsIgnoreCase(headerName(i))) {
         return headerValue(i);
       }
     }


### PR DESCRIPTION
URLConnection back by earlier versions of OkHttp (1.5.x) has all lowercased header names, this PR fixed empty Content-Type issue.