### PR TITLE
Improve hit testing to handle non-view elements

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -9,141 +9,20 @@
 
 package com.facebook.stetho.common.android;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.graphics.PointF;
-import android.os.Build;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewParent;
-
-import com.facebook.stetho.common.Predicate;
-import com.facebook.stetho.common.Util;
 
 import javax.annotation.Nullable;
 
-public final class ViewUtil {
+final class ViewUtil {
   private ViewUtil() {
   }
 
-  private static boolean isHittable(View view) {
-    if (view.getVisibility() != View.VISIBLE) {
-      return false;
-    }
-
-    if (ViewCompat.getInstance().getAlpha(view) < 0.001f) {
-      return false;
-    }
-
-    return true;
-  }
-
   @Nullable
-  public static View hitTest(View view, float x, float y) {
-    return hitTest(view, x, y, null /* viewSelector */);
-  }
-
-  // x,y are in view's local coordinate space (relative to its own top/left)
-  @Nullable
-  public static View hitTest(
-      View view,
-      float x,
-      float y,
-      @Nullable Predicate<View> viewSelector) {
-    View result = hitTestImpl(view, x, y, viewSelector, false);
-    if (result == null) {
-      result = hitTestImpl(view, x, y, viewSelector, true);
-    }
-    return result;
-  }
-
-  private static View hitTestImpl(
-      View view,
-      float x,
-      float y,
-      @Nullable Predicate<View> viewSelector,
-      boolean allowViewGroupResult) {
-    if (!isHittable(view)) {
-      return null;
-    }
-
-    if (!ViewUtil.pointInView(view, x, y)) {
-      return null;
-    }
-
-    if (viewSelector != null && !viewSelector.apply(view)) {
-      return null;
-    }
-
-    if (!(view instanceof ViewGroup)) {
-      return view;
-    }
-
-    final ViewGroup viewGroup = (ViewGroup)view;
-
-    // TODO: get list of Views that are sorted in Z- and draw-order, e.g. buildOrderedChildList()
-    if (viewGroup.getChildCount() > 0) {
-      PointF localPoint = new PointF();
-
-      for (int i = viewGroup.getChildCount() - 1; i >= 0; --i) {
-        final View child = viewGroup.getChildAt(i);
-
-        if (ViewUtil.isTransformedPointInView(viewGroup, child, x, y, localPoint)) {
-          View childResult = hitTestImpl(
-              child,
-              localPoint.x,
-              localPoint.y,
-              viewSelector,
-              allowViewGroupResult);
-
-          if (childResult != null) {
-            return childResult;
-          }
-        }
-      }
-    }
-
-    return allowViewGroupResult ? viewGroup : null;
-  }
-
-  public static boolean pointInView(View view, float localX, float localY) {
-    return localX >= 0 && localX < (view.getRight() - view.getLeft())
-        && localY >= 0 && localY < (view.getBottom() - view.getTop());
-  }
-
-  public static boolean isTransformedPointInView(
-      ViewGroup parent,
-      View child,
-      float x,
-      float y,
-      @Nullable PointF outLocalPoint) {
-    Util.throwIfNull(parent);
-    Util.throwIfNull(child);
-
-    float localX = x + parent.getScrollX() - child.getLeft();
-    float localY = y + parent.getScrollY() - child.getTop();
-
-    // TODO: handle transforms
-    /*Matrix childMatrix = child.getMatrix();
-    if (!childMatrix.isIdentity()) {
-      final float[] localXY = new float[2];
-      localXY[0] = localX;
-      localXY[1] = localY;
-      child.getInverseMatrix
-    }*/
-
-    final boolean isInView = ViewUtil.pointInView(child, localX, localY);
-    if (isInView && outLocalPoint != null) {
-      outLocalPoint.set(localX, localY);
-    }
-
-    return isInView;
-  }
-
-  @Nullable
-  public static Activity tryGetActivity(View view) {
+  static Activity tryGetActivity(View view) {
     if (view == null) {
       return null;
     }
@@ -177,35 +56,5 @@ public final class ViewUtil {
     }
 
     return null;
-  }
-
-  private static class ViewCompat {
-    private static final ViewCompat sInstance;
-    static {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-        sInstance = new ViewCompatHoneycomb();
-      } else {
-        sInstance = new ViewCompat();
-      }
-    }
-
-    public static ViewCompat getInstance() {
-      return sInstance;
-    }
-
-    protected ViewCompat() {
-    }
-
-    public float getAlpha(View view) {
-      return 1.0f;
-    }
-
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    private static class ViewCompatHoneycomb extends ViewCompat {
-      @Override
-      public float getAlpha(View view) {
-        return view.getAlpha();
-      }
-    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -45,16 +45,38 @@ final class ActivityDescriptor
     }
   }
 
-  @Override
   @Nullable
+  @Override
   public View getViewAndBoundsForHighlighting(Activity element, Rect bounds) {
     final Descriptor.Host host = getHost();
+    Window window = null;
+    HighlightableDescriptor descriptor = null;
+
     if (host instanceof AndroidDescriptorHost) {
-      Window window = element.getWindow();
-      return ((AndroidDescriptorHost) host).getHighlightingView(window, bounds);
+      window = element.getWindow();
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(window);
     }
 
-    return null;
+    return descriptor == null
+        ? null
+        : descriptor.getViewAndBoundsForHighlighting(window, bounds);
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(Activity element, int x, int y, Rect bounds) {
+    final Descriptor.Host host = getHost();
+    Window window = null;
+    HighlightableDescriptor descriptor = null;
+
+    if (host instanceof AndroidDescriptorHost) {
+      window = element.getWindow();
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(window);
+    }
+
+    return descriptor == null
+        ? null
+        : descriptor.getElementToHighlightAtPosition(window, x, y, bounds);
   }
 
   private static void getDialogFragments(

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
@@ -9,14 +9,11 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
-import android.view.View;
-import android.graphics.Rect;
-
 import com.facebook.stetho.inspector.elements.Descriptor;
 
 import javax.annotation.Nullable;
 
 interface AndroidDescriptorHost extends Descriptor.Host {
   @Nullable
-  View getHighlightingView(@Nullable Object element, Rect bounds);
+  HighlightableDescriptor getHighlightableDescriptor(@Nullable Object element);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
@@ -33,10 +33,33 @@ final class DialogDescriptor
   @Override
   public View getViewAndBoundsForHighlighting(Dialog element, Rect bounds) {
     final Descriptor.Host host = getHost();
+    Window window = null;
+    HighlightableDescriptor descriptor = null;
+
     if (host instanceof AndroidDescriptorHost) {
-      return ((AndroidDescriptorHost) host).getHighlightingView(element.getWindow(), bounds);
+      window = element.getWindow();
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(window);
     }
 
-    return null;
+    return descriptor == null
+        ? null
+        : descriptor.getViewAndBoundsForHighlighting(window, bounds);
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(Dialog element, int x, int y, Rect bounds) {
+    final Descriptor.Host host = getHost();
+    Window window = null;
+    HighlightableDescriptor descriptor = null;
+
+    if (host instanceof AndroidDescriptorHost) {
+      window = element.getWindow();
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(window);
+    }
+
+    return descriptor == null
+        ? null
+        : descriptor.getElementToHighlightAtPosition(window, x, y, bounds);
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -123,12 +123,34 @@ final class DialogFragmentDescriptor
   @Override
   public View getViewAndBoundsForHighlighting(Object element, Rect bounds) {
     final Descriptor.Host host = getHost();
+    Dialog dialog = null;
+    HighlightableDescriptor descriptor = null;
+
     if (host instanceof AndroidDescriptorHost) {
-      Dialog dialog = mAccessor.getDialog(element);
-      return ((AndroidDescriptorHost) host).getHighlightingView(dialog, bounds);
+      dialog = mAccessor.getDialog(element);
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(dialog);
     }
 
-    return null;
+    return descriptor == null
+        ? null
+        : descriptor.getViewAndBoundsForHighlighting(dialog, bounds);
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(Object element, int x, int y, Rect bounds) {
+    final Descriptor.Host host = getHost();
+    Dialog dialog = null;
+    HighlightableDescriptor descriptor = null;
+
+    if (host instanceof AndroidDescriptorHost) {
+      dialog = mAccessor.getDialog(element);
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(dialog);
+    }
+
+    return descriptor == null
+        ? null
+        : descriptor.getElementToHighlightAtPosition(dialog, x, y, bounds);
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -19,6 +19,7 @@ import com.facebook.stetho.common.android.FragmentCompat;
 import com.facebook.stetho.common.android.ResourcesUtil;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 
 import javax.annotation.Nullable;
@@ -77,5 +78,22 @@ final class FragmentDescriptor
   @Nullable
   public View getViewAndBoundsForHighlighting(Object element, Rect bounds) {
     return mAccessor.getView(element);
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(Object element, int x, int y, Rect bounds) {
+    final Descriptor.Host host = getHost();
+    View view = null;
+    HighlightableDescriptor descriptor = null;
+
+    if (host instanceof AndroidDescriptorHost) {
+      view = mAccessor.getView(element);
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(view);
+    }
+
+    return descriptor == null
+        ? null
+        : descriptor.getElementToHighlightAtPosition(view, x, y, bounds);
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -24,4 +24,16 @@ public interface HighlightableDescriptor<E> {
    */
   @Nullable
   View getViewAndBoundsForHighlighting(E element, Rect bounds);
+
+  /**
+   * Used when activating find by touch feature to figure out which element to focus / highlight.
+   *
+   * @param element the element
+   * @param y coordinate in local coordinate space
+   * @param y coordinate in local coordinate space
+   * @param bounds The bounds of the returned element. Used to offset the coordinates for next call.
+   * @return A child element or self if this coordinate falls within self and not a child.
+   */
+  @Nullable
+  Object getElementToHighlightAtPosition(E element, int x, int y, Rect bounds);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -167,6 +167,13 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
     return element;
   }
 
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(View element, int x, int y, Rect bounds) {
+    bounds.set(0, 0, element.getWidth(), element.getHeight());
+    return element;
+  }
+
   @Override
   protected void onGetStyleRuleNames(View element, StyleRuleNameAccumulator accumulator) {
     accumulator.store(VIEW_STYLE_RULE_NAME, false);

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -9,6 +9,7 @@
 
 package com.facebook.stetho.inspector.elements.android;
 
+import android.graphics.Rect;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -21,7 +22,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup> {
+import javax.annotation.Nullable;
+
+final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup>
+    implements HighlightableDescriptor<ViewGroup> {
 
   /**
    * This is a cache that maps from a View to the Fragment that contains it. If the View isn't
@@ -88,6 +92,33 @@ final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup> {
       return childView;
     } else {
       return ((WeakReference<Object>) value).get();
+    }
+  }
+
+  @Override
+  @Nullable
+  public View getViewAndBoundsForHighlighting(ViewGroup element, Rect bounds) {
+    return element;
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(ViewGroup element, int x, int y, Rect bounds) {
+    View hitChild = null;
+    for (int i = 0, count = element.getChildCount(); i < count; ++i) {
+      final View child = element.getChildAt(i);
+      child.getHitRect(bounds);
+      if (bounds.contains(x, y)) {
+        hitChild = child;
+        break;
+      }
+    }
+
+    if (hitChild != null) {
+      return hitChild;
+    } else {
+      bounds.set(0, 0, element.getWidth(), element.getHeight());
+      return element;
     }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -15,6 +15,7 @@ import android.view.Window;
 
 import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
+import com.facebook.stetho.inspector.elements.Descriptor;
 
 import javax.annotation.Nullable;
 
@@ -32,5 +33,22 @@ final class WindowDescriptor extends AbstractChainedDescriptor<Window>
   @Nullable
   public View getViewAndBoundsForHighlighting(Window element, Rect bounds) {
     return element.peekDecorView();
+  }
+
+  @Nullable
+  @Override
+  public Object getElementToHighlightAtPosition(Window element, int x, int y, Rect bounds) {
+    final Descriptor.Host host = getHost();
+    View view = null;
+    HighlightableDescriptor descriptor = null;
+
+    if (host instanceof AndroidDescriptorHost) {
+      view = element.peekDecorView();
+      descriptor = ((AndroidDescriptorHost) host).getHighlightableDescriptor(view);
+    }
+
+    return descriptor == null
+        ? null
+        : descriptor.getElementToHighlightAtPosition(view, x, y, bounds);
   }
 }


### PR DESCRIPTION
With the ability to implement custom descriptors also came the ability to highlight non-view elements. However this feature was not extended to handle click inspection. This commit resolves that by generalizing some of the hit testing logic and moving it into highlightable descriptors.

In a follow up PR I will try to decouple most of the highlighting from android Views.