### PR TITLE
Add support for editable style properties

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
@@ -29,4 +29,16 @@ public final class StringUtil {
       return string;
     }
   }
+
+  public static String removeAll(String string, char target) {
+    final int length = string.length();
+    final StringBuilder builder = new StringBuilder(length);
+    for (int i = 0; i < length; ++i) {
+      char c = string.charAt(i);
+      if (c != target) {
+        builder.append(c);
+      }
+    }
+    return builder.toString();
+  }
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -140,12 +140,30 @@ public abstract class AbstractChainedDescriptor<E>
   }
 
   @Override
-  public final void getStyles(E element, StyleAccumulator accumulator) {
-    mSuper.getStyles(element, accumulator);
-    onGetStyles(element, accumulator);
+  public final void getStyleRuleNames(E element, StyleRuleNameAccumulator accumulator) {
+    mSuper.getStyleRuleNames(element, accumulator);
+    onGetStyleRuleNames(element, accumulator);
   }
 
-  protected void onGetStyles(E element, StyleAccumulator accumulator) {
+  protected void onGetStyleRuleNames(E element, StyleRuleNameAccumulator accumulator) {
+  }
+
+  @Override
+  public final void getStyles(E element, String ruleName, StyleAccumulator accumulator) {
+    mSuper.getStyles(element, ruleName, accumulator);
+    onGetStyles(element, ruleName, accumulator);
+  }
+
+  protected void onGetStyles(E element, String ruleName, StyleAccumulator accumulator) {
+  }
+
+  @Override
+  public final void setStyle(E element, String ruleName, String name, String value) {
+    mSuper.setStyle(element, ruleName, name, value);
+    onSetStyle(element, ruleName, name, value);
+  }
+
+  protected void onSetStyle(E element, String ruleName, String name, String value) {
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -141,10 +141,22 @@ public final class Document extends ThreadBoundProxy {
     mDocumentProvider.setAttributesAsText(element, text);
   }
 
-  public void getElementStyles(Object element, StyleAccumulator styleAccumulator) {
+  public void getElementStyleRuleNames(Object element, StyleRuleNameAccumulator accumulator) {
     NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
 
-    nodeDescriptor.getStyles(element, styleAccumulator);
+    nodeDescriptor.getStyleRuleNames(element, accumulator);
+  }
+
+  public void getElementStyles(Object element, String ruleName, StyleAccumulator accumulator) {
+    NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
+
+    nodeDescriptor.getStyles(element, ruleName, accumulator);
+  }
+
+  public void setElementStyle(Object element, String ruleName, String name, String value) {
+    NodeDescriptor nodeDescriptor = getNodeDescriptor(element);
+
+    nodeDescriptor.setStyle(element, ruleName, name, value);
   }
 
   public void getElementComputedStyles(Object element, ComputedStyleAccumulator styleAccumulator) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -34,7 +34,11 @@ public interface NodeDescriptor<E> extends ThreadBound {
 
   void setAttributesAsText(E element, String text);
 
-  void getStyles(E element, StyleAccumulator accumulator);
+  void getStyleRuleNames(E element, StyleRuleNameAccumulator accumulator);
+
+  void getStyles(E element, String ruleName, StyleAccumulator accumulator);
+
+  void setStyle(E element, String ruleName, String name, String value);
 
   void getComputedStyles(E element, ComputedStyleAccumulator accumulator);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -53,7 +53,15 @@ public final class ObjectDescriptor extends Descriptor<Object> {
   }
 
   @Override
-  public void getStyles(Object element, StyleAccumulator accumulator) {
+  public void getStyleRuleNames(Object element, StyleRuleNameAccumulator accumulator) {
+  }
+
+  @Override
+  public void getStyles(Object element, String ruleName, StyleAccumulator accumulator) {
+  }
+
+  @Override
+  public void setStyle(Object element, String ruleName, String name, String value) {
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleRuleNameAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleRuleNameAccumulator.java
@@ -9,6 +9,6 @@
 
 package com.facebook.stetho.inspector.elements;
 
-public interface StyleAccumulator {
-  void store(String name, String value, boolean isDefault);
+public interface StyleRuleNameAccumulator {
+  void store(String ruleName, boolean editable);
 }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -26,6 +26,7 @@ import com.facebook.stetho.inspector.elements.Descriptor;
 import com.facebook.stetho.inspector.elements.DescriptorMap;
 import com.facebook.stetho.inspector.elements.NodeType;
 import com.facebook.stetho.inspector.elements.StyleAccumulator;
+import com.facebook.stetho.inspector.elements.StyleRuleNameAccumulator;
 
 import javax.annotation.Nullable;
 
@@ -131,7 +132,15 @@ final class DialogFragmentDescriptor
   }
 
   @Override
-  public void getStyles(Object element, StyleAccumulator styles) {
+  public void getStyleRuleNames(Object element, StyleRuleNameAccumulator accumulator) {
+  }
+
+  @Override
+  public void getStyles(Object element, String ruleName, StyleAccumulator accumulator) {
+  }
+
+  @Override
+  public void setStyle(Object element, String ruleName, String name, String value) {
   }
 
   @Override

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -23,6 +23,7 @@ import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.AttributeAccumulator;
 import com.facebook.stetho.inspector.elements.ComputedStyleAccumulator;
 import com.facebook.stetho.inspector.elements.StyleAccumulator;
+import com.facebook.stetho.inspector.elements.StyleRuleNameAccumulator;
 import com.facebook.stetho.inspector.helper.IntegerFormatter;
 
 import javax.annotation.Nullable;
@@ -44,8 +45,8 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
   private static final String ID_NAME = "id";
   private static final String NONE_VALUE = "(none)";
   private static final String NONE_MAPPING = "<no mapping>";
-  private static final String VIEW_SELECTOR_NAME = "<this_view>";
-  private static final String ACCESSIBILITY_SELECTOR_NAME = "Accessibility Properties";
+  private static final String VIEW_STYLE_RULE_NAME = "<this_view>";
+  private static final String ACCESSIBILITY_STYLE_RULE_NAME = "Accessibility Properties";
 
   private final MethodInvoker mMethodInvoker;
 
@@ -167,93 +168,93 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
   }
 
   @Override
-  protected void onGetStyles(View element, StyleAccumulator styles) {
-    List<ViewCSSProperty> properties = getViewProperties();
-    for (int i = 0, size = properties.size(); i < size; i++) {
-      ViewCSSProperty property = properties.get(i);
-      try {
-        getStyleFromValue(
-            VIEW_SELECTOR_NAME,
-            element,
-            property.getCSSName(),
-            property.getValue(element),
-            property.getAnnotation(),
-            styles);
-      } catch (Exception e) {
-        if (e instanceof IllegalAccessException || e instanceof InvocationTargetException) {
-          LogUtil.e(e, "failed to get style property " + property.getCSSName() +
-                  " of element= " + element.toString());
-        } else {
-          throw ExceptionUtil.propagate(e);
+  protected void onGetStyleRuleNames(View element, StyleRuleNameAccumulator accumulator) {
+    accumulator.store(VIEW_STYLE_RULE_NAME, false);
+    accumulator.store(ACCESSIBILITY_STYLE_RULE_NAME, false);
+  }
+
+  @Override
+  protected void onGetStyles(View element, String ruleName, StyleAccumulator accumulator) {
+    if (VIEW_STYLE_RULE_NAME.equals(ruleName)) {
+      List<ViewCSSProperty> properties = getViewProperties();
+      for (int i = 0, size = properties.size(); i < size; i++) {
+        ViewCSSProperty property = properties.get(i);
+        try {
+          getStyleFromValue(
+              element,
+              property.getCSSName(),
+              property.getValue(element),
+              property.getAnnotation(),
+              accumulator);
+        } catch (Exception e) {
+          if (e instanceof IllegalAccessException || e instanceof InvocationTargetException) {
+            LogUtil.e(e, "failed to get style property " + property.getCSSName() +
+                    " of element= " + element.toString());
+          } else {
+            throw ExceptionUtil.propagate(e);
+          }
         }
       }
+    } else if (ACCESSIBILITY_STYLE_RULE_NAME.equals(ruleName)) {
+      AccessibilityNodeInfoCompat nodeInfo = AccessibilityNodeInfoCompat.obtain();
+      ViewCompat.onInitializeAccessibilityNodeInfo(element, nodeInfo);
+
+      boolean ignored = AccessibilityNodeInfoWrapper.getIgnored(nodeInfo, element);
+      getStyleFromValue(
+          element,
+          "ignored",
+          ignored,
+          null,
+          accumulator);
+
+      if (ignored) {
+        getStyleFromValue(
+            element,
+            "ignored-reasons",
+            AccessibilityNodeInfoWrapper.getIgnoredReasons(nodeInfo, element),
+            null,
+            accumulator);
+      }
+
+      getStyleFromValue(
+          element,
+          "focusable",
+          !ignored,
+          null,
+          accumulator);
+
+      if (!ignored) {
+        getStyleFromValue(
+            element,
+            "focusable-reasons",
+            AccessibilityNodeInfoWrapper.getFocusableReasons(nodeInfo, element),
+            null,
+            accumulator);
+
+        getStyleFromValue(
+            element,
+            "focused",
+            nodeInfo.isAccessibilityFocused(),
+            null,
+            accumulator);
+
+        getStyleFromValue(
+            element,
+            "description",
+            AccessibilityNodeInfoWrapper.getDescription(nodeInfo, element),
+            null,
+            accumulator);
+
+        getStyleFromValue(
+            element,
+            "actions",
+            AccessibilityNodeInfoWrapper.getActions(nodeInfo),
+            null,
+            accumulator);
+      }
+
+      nodeInfo.recycle();
     }
-
-    AccessibilityNodeInfoCompat nodeInfo = AccessibilityNodeInfoCompat.obtain();
-    ViewCompat.onInitializeAccessibilityNodeInfo(element, nodeInfo);
-
-    boolean ignored = AccessibilityNodeInfoWrapper.getIgnored(nodeInfo, element);
-    getStyleFromValue(
-        ACCESSIBILITY_SELECTOR_NAME,
-        element,
-        "ignored",
-        ignored,
-        null,
-        styles);
-
-    if (ignored) {
-      getStyleFromValue(
-          ACCESSIBILITY_SELECTOR_NAME,
-          element,
-          "ignored-reasons",
-          AccessibilityNodeInfoWrapper.getIgnoredReasons(nodeInfo, element),
-          null,
-          styles);
-    }
-
-    getStyleFromValue(
-        ACCESSIBILITY_SELECTOR_NAME,
-        element,
-        "focusable",
-        !ignored,
-        null,
-        styles);
-
-    if (!ignored) {
-      getStyleFromValue(
-          ACCESSIBILITY_SELECTOR_NAME,
-          element,
-          "focusable-reasons",
-          AccessibilityNodeInfoWrapper.getFocusableReasons(nodeInfo, element),
-          null,
-          styles);
-
-      getStyleFromValue(
-          ACCESSIBILITY_SELECTOR_NAME,
-          element,
-          "focused",
-          nodeInfo.isAccessibilityFocused(),
-          null,
-          styles);
-
-      getStyleFromValue(
-          ACCESSIBILITY_SELECTOR_NAME,
-          element,
-          "description",
-          AccessibilityNodeInfoWrapper.getDescription(nodeInfo, element),
-          null,
-          styles);
-
-      getStyleFromValue(
-          ACCESSIBILITY_SELECTOR_NAME,
-          element,
-          "actions",
-          AccessibilityNodeInfoWrapper.getActions(nodeInfo),
-          null,
-          styles);
-    }
-
-    nodeInfo.recycle();
   }
 
   @Override
@@ -350,7 +351,6 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
   }
 
   private void getStyleFromValue(
-      String selector,
       View element,
       String name,
       Object value,
@@ -358,46 +358,44 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
       StyleAccumulator styles) {
 
     if (name.equals(ID_NAME)) {
-      getIdStyle(selector, element, styles);
+      getIdStyle(element, styles);
     } else if (value instanceof Integer) {
-      getStyleFromInteger(selector, name, (Integer) value, annotation, styles);
+      getStyleFromInteger(name, (Integer) value, annotation, styles);
     } else if (value instanceof Float) {
-      styles.store(selector, name, String.valueOf(value), ((Float) value) == 0.0f);
+      styles.store(name, String.valueOf(value), ((Float) value) == 0.0f);
     } else if (value instanceof Boolean) {
-      styles.store(selector, name, String.valueOf(value), false);
+      styles.store(name, String.valueOf(value), false);
     } else if (value instanceof Short) {
-      styles.store(selector, name, String.valueOf(value), ((Short) value) == 0);
+      styles.store(name, String.valueOf(value), ((Short) value) == 0);
     } else if (value instanceof Long) {
-      styles.store(selector, name, String.valueOf(value), ((Long) value) == 0);
+      styles.store(name, String.valueOf(value), ((Long) value) == 0);
     } else if (value instanceof Double) {
-      styles.store(selector, name, String.valueOf(value), ((Double) value) == 0.0d);
+      styles.store(name, String.valueOf(value), ((Double) value) == 0.0d);
     } else if (value instanceof Byte) {
-      styles.store(selector, name, String.valueOf(value), ((Byte) value) == 0);
+      styles.store(name, String.valueOf(value), ((Byte) value) == 0);
     } else if (value instanceof Character) {
-      styles.store(selector, name, String.valueOf(value), ((Character) value) == Character.MIN_VALUE);
+      styles.store(name, String.valueOf(value), ((Character) value) == Character.MIN_VALUE);
     } else if (value instanceof CharSequence) {
-      styles.store(selector, name, String.valueOf(value), ((CharSequence) value).length() == 0);
+      styles.store(name, String.valueOf(value), ((CharSequence) value).length() == 0);
     } else {
-      getStylesFromObject(selector, element, name, value, annotation, styles);
+      getStylesFromObject(element, name, value, annotation, styles);
     }
   }
 
   private void getIdStyle(
-      String selector,
       View element,
       StyleAccumulator styles) {
 
     @Nullable String id = getIdAttribute(element);
 
     if (id == null) {
-      styles.store(selector, ID_NAME, NONE_VALUE, false);
+      styles.store(ID_NAME, NONE_VALUE, false);
     } else {
-      styles.store(selector, ID_NAME, id, false);
+      styles.store(ID_NAME, id, false);
     }
   }
 
   private void getStyleFromInteger(
-      String selector,
       String name,
       Integer value,
       @Nullable ViewDebug.ExportedProperty annotation,
@@ -407,13 +405,11 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
 
     if (canIntBeMappedToString(annotation)) {
       styles.store(
-          selector,
           name,
           intValueStr + " (" + mapIntToStringUsingAnnotation(value, annotation) + ")",
           false);
     } else if (canFlagsBeMappedToString(annotation)) {
       styles.store(
-          selector,
           name,
           intValueStr + " (" + mapFlagsToStringUsingAnnotation(value, annotation) + ")",
           false);
@@ -427,12 +423,11 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
           canIntBeMappedToString(annotation)) {
         defaultValue = false;
       }
-      styles.store(selector, name, intValueStr, defaultValue);
+      styles.store(name, intValueStr, defaultValue);
     }
   }
 
   private void getStylesFromObject(
-      String selector,
       View view,
       String name,
       Object value,
@@ -487,7 +482,6 @@ final class ViewDescriptor extends AbstractChainedDescriptor<View>
           field.getAnnotation(ViewDebug.ExportedProperty.class);
 
       getStyleFromValue(
-          selector,
           view,
           propertyName,
           propertyValue,


### PR DESCRIPTION
This commit adds support for editable style properties based on rule
name (previously called selector). Previously properties had to be
implemented as attributes to be able to be edited.