### PR TITLE
Some fixes to recent hit test improvements

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -383,7 +383,7 @@ final class AndroidDocumentProvider extends ThreadBoundProxy
 
                 if (event.getAction() == MotionEvent.ACTION_UP) {
                   if (mListener != null) {
-                    mListener.onInspectRequested(viewToHighlight);
+                    mListener.onInspectRequested(elementToHighlight);
                   }
                 }
               }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -105,12 +105,18 @@ final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup>
   @Override
   public Object getElementToHighlightAtPosition(ViewGroup element, int x, int y, Rect bounds) {
     View hitChild = null;
-    for (int i = 0, count = element.getChildCount(); i < count; ++i) {
-      final View child = element.getChildAt(i);
-      child.getHitRect(bounds);
-      if (bounds.contains(x, y)) {
-        hitChild = child;
-        break;
+    for (int i = element.getChildCount() - 1; i >= 0; --i) {
+      final View childView = element.getChildAt(i);
+      final boolean hasChildren = childView instanceof ViewGroup &&
+          ((ViewGroup) childView).getChildCount() > 0;
+      if (isChildVisible(childView) &&
+          childView.getVisibility() == View.VISIBLE &&
+          (hasChildren || childView.isFocusable())) {
+        childView.getHitRect(bounds);
+        if (bounds.contains(x, y)) {
+          hitChild = childView;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
1. Tell chrome to inspect the clicked element, not the view which is
highlighted.

2. Find child to return back to front to respect z ordering.

3. Disregard hidden views and views which are not focusable.