### PR TITLE
Avoid false positive in LeakCanary

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -16,6 +16,7 @@ import com.facebook.stetho.common.Accumulator;
 import com.facebook.stetho.inspector.elements.AbstractChainedDescriptor;
 import com.facebook.stetho.inspector.elements.NodeType;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -52,10 +53,13 @@ final class ApplicationDescriptor extends AbstractChainedDescriptor<Application>
   @Override
   protected void onGetChildren(Application element, Accumulator<Object> children) {
     ElementContext context = getContext(element);
-    List<Activity> activities = context.getActivitiesList();
+    List<WeakReference<Activity>> activities = context.getActivitiesList();
     // We report these in reverse order so that the newer ones show up on top
     for (int i = activities.size() - 1; i >= 0; --i) {
-      children.store(activities.get(i));
+      Activity activity = activities.get(i).get();
+      if (activity != null) {
+        children.store(activity);
+      }
     }
   }
 
@@ -75,7 +79,7 @@ final class ApplicationDescriptor extends AbstractChainedDescriptor<Application>
       mElement = null;
     }
 
-    public List<Activity> getActivitiesList() {
+    public List<WeakReference<Activity>> getActivitiesList() {
       return mActivityTracker.getActivitiesView();
     }
 


### PR DESCRIPTION
LeakCanary flags Stetho's ActivityTracker as a potential leak because it
does indeed have a path to the GC root that isn't already covered by the
many exclusions present in LeakCanary for legitimate Android use cases.
This is essentially a known flaw in LeakCanary in which unknown path to
GC roots are assumed to be leaks even if they are indeed consistent with
the normal object lifecycle (like in our case the strong reference is
removed when the activity is destroyed).

Working around this issue is trivial however and does indeed have the
effect of making our code look less suspicious of leaks in the first
place.

Closes #319