### PR TITLE
Handle any runtime exception from a database driver

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -23,6 +23,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.os.Build;
 
+import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.Util;
 import com.facebook.stetho.inspector.helper.ChromePeerManager;
 import com.facebook.stetho.inspector.helper.PeerRegistrationListener;
@@ -163,7 +164,9 @@ public class Database implements ChromeDevtoolsDomain {
           return response;
         }
       });
-    } catch (SQLiteException e) {
+    } catch (RuntimeException e) {
+      LogUtil.e(e, "Exception executing: %s", request.query);
+
       Error error = new Error();
       error.code = 0;
       error.message = e.getMessage();


### PR DESCRIPTION
Since database drivers are such wide ranging third party code it
cannot be assumed that they exclusively throw SQLiteException but
instead could throw any manner of unknown RuntimeException and that
should not tear down the connection with chrome://inspect but, since
we are indeed a debug tool, should report sufficient debugging
information to diagnose the issue.