### PR TITLE
Add full websocket support to NetworkEventReporter

### DIFF
--- a/stetho-sample/src/main/AndroidManifest.xml
+++ b/stetho-sample/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
         android:label="@string/apod_title"
         android:name=".APODActivity" />
 
+    <activity
+        android:label="@string/irc_connect_title"
+        android:name=".IRCConnectActivity" />
+
+    <activity
+        android:label="@string/irc_chat_title"
+        android:name=".IRCChatActivity" />
+
     <provider
         android:name=".APODContentProvider"
         android:authorities="com.facebook.stetho.sample.apod"

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCChatActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCChatActivity.java
@@ -1,0 +1,294 @@
+package com.facebook.stetho.sample;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.Nullable;
+
+public class IRCChatActivity extends Activity {
+  private static final int DEFAULT_PORT = 6667;
+
+  private static final String EXTRA_HOST_AND_MAYBE_PORT = "host";
+  private static final String EXTRA_NICKNAME = "nickname";
+
+  private SimpleIRCConnectionManager mSimpleIRCConnectionManager;
+
+  private ExecutorService mConnectionExecutor;
+  private boolean mIsTearingDown;
+
+  private ListView mConsoleDisplay;
+  private IRCConsoleRowAdapter mConsoleRowAdapter;
+  private TextView mConsoleInput;
+
+  public static void showForResult(
+      Activity context,
+      int requestCode,
+      String hostAndMaybePort,
+      String nickname) {
+    Intent intent = new Intent(context, IRCChatActivity.class);
+    intent.putExtra(EXTRA_HOST_AND_MAYBE_PORT, hostAndMaybePort);
+    intent.putExtra(EXTRA_NICKNAME, nickname);
+    context.startActivityForResult(intent, requestCode);
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.irc_chat_activity);
+
+    mConsoleDisplay = (ListView) findViewById(R.id.console_display);
+    mConsoleRowAdapter = new IRCConsoleRowAdapter(this);
+    mConsoleDisplay.setAdapter(mConsoleRowAdapter);
+
+    mConsoleInput = (TextView) findViewById(R.id.console_input);
+    mConsoleInput.setOnEditorActionListener(mOnConsoleInputEditorAction);
+    findViewById(R.id.console_send).setOnClickListener(mConsoleSendClicked);
+
+    // Will re-enable once we connect...
+    mConsoleInput.setEnabled(false);
+
+    mSimpleIRCConnectionManager = new SimpleIRCConnectionManager(
+        getIntent().getStringExtra(EXTRA_HOST_AND_MAYBE_PORT),
+        getIntent().getStringExtra(EXTRA_NICKNAME));
+    mConnectionExecutor = Executors.newCachedThreadPool();
+    mConnectionExecutor.execute(new Runnable() {
+      @Override
+      public void run() {
+        mSimpleIRCConnectionManager.runConnectLoop();
+      }
+    });
+  }
+
+  @Override
+  protected void onDestroy() {
+    mSimpleIRCConnectionManager.shutdown();
+    mConnectionExecutor.shutdown();
+    mIsTearingDown = true;
+    super.onDestroy();
+  }
+
+  private void onConnected() {
+    mConsoleInput.setEnabled(true);
+  }
+
+  private void onIncomingMessage(String message) {
+    if (mIsTearingDown) {
+      return;
+    }
+    mConsoleRowAdapter.add(message);
+  }
+
+  private void onDisconnectOrConnectFailed(@Nullable IOException exception) {
+    if (mIsTearingDown) {
+      return;
+    }
+
+    mIsTearingDown = true;
+
+    final String error;
+    if (exception != null) {
+      Toast.makeText(
+          this,
+          "Error: " + exception.getMessage(),
+          Toast.LENGTH_LONG)
+          .show();
+      error = exception.getMessage();
+    } else {
+      error = null;
+    }
+    new IRCChatActivityResult(error).setResult(this);
+    finish();
+  }
+
+  private final TextView.OnEditorActionListener mOnConsoleInputEditorAction =
+      new TextView.OnEditorActionListener() {
+    @Override
+    public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+      switch (actionId) {
+        case EditorInfo.IME_ACTION_SEND:
+          doSendMessage();
+          return true;
+        default:
+          return false;
+      }
+    }
+  };
+
+  private final View.OnClickListener mConsoleSendClicked = new View.OnClickListener() {
+    @Override
+    public void onClick(View v) {
+      doSendMessage();
+    }
+  };
+
+  private void doSendMessage() {
+    final String message = mConsoleInput.getText().toString();
+    mConsoleInput.setText("");
+    if (!TextUtils.isEmpty(message)) {
+      mConnectionExecutor.execute(new Runnable() {
+        @Override
+        public void run() {
+          mSimpleIRCConnectionManager.send(message);
+        }
+      });
+    }
+  }
+
+  private class SimpleIRCConnectionManager {
+    @Nullable private volatile IRCClientConnection mConnection;
+    private volatile boolean mShutdownRequested;
+
+    private final String mHost;
+    private final int mPort;
+    private final String mNickname;
+
+    public SimpleIRCConnectionManager(String hostAndPort, String nickname) {
+      String[] hostAndPortParts = hostAndPort.split(":", 2);
+      if (hostAndPortParts.length == 2) {
+        mHost = hostAndPortParts[0];
+        mPort = Integer.parseInt(hostAndPortParts[1]);
+      } else {
+        mHost = hostAndPort;
+        mPort = DEFAULT_PORT;
+      }
+      mNickname = nickname;
+    }
+
+    public void runConnectLoop() {
+      boolean graceful = false;
+      try {
+        final IRCClientConnection conn = IRCClientConnection.connect(mHost, mPort);
+        try {
+          mConnection = conn;
+          doConnectLoop(conn);
+        } finally {
+          mConnection = null;
+          conn.close();
+        }
+        graceful = true;
+      } catch (IOException e) {
+        invokeOnDisconnectOrConnectFailed(e);
+      } finally {
+        if (graceful) {
+          invokeOnDisconnectOrConnectFailed(null /* exception */);
+        }
+      }
+    }
+
+    private void doConnectLoop(IRCClientConnection conn) throws IOException {
+      if (mShutdownRequested) {
+        return;
+      }
+
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          onConnected();
+        }
+      });
+
+      conn.send(String.format(Locale.US, "NICK %s", mNickname));
+      conn.send(String.format(Locale.US, "USER %s %s blablabla :%s", mNickname, mHost, mNickname));
+      while (!mShutdownRequested) {
+        final String message = conn.read();
+        if (message == null) {
+          break;
+        }
+        runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            onIncomingMessage(message);
+          }
+        });
+      }
+    }
+
+    public void send(String message) {
+      IRCClientConnection conn = mConnection;
+      if (conn != null) {
+        try {
+          conn.send(message);
+        } catch (IOException e) {
+          invokeOnDisconnectOrConnectFailed(e);
+        }
+      }
+    }
+
+    public void shutdown() {
+      mShutdownRequested = true;
+
+      // Force a socket closure to cause an immediate effect in Stetho.
+      IRCClientConnection conn = mConnection;
+      if (conn != null) {
+        try {
+          conn.close();
+        } catch (IOException e) {
+          invokeOnDisconnectOrConnectFailed(e);
+        }
+      }
+    }
+
+    private void invokeOnDisconnectOrConnectFailed(@Nullable final IOException e) {
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          onDisconnectOrConnectFailed(e);
+        }
+      });
+    }
+  }
+
+  private static class IRCConsoleRowAdapter extends ArrayAdapter<String> {
+    public IRCConsoleRowAdapter(Context context) {
+      super(context, R.layout.irc_console_row);
+    }
+  }
+
+  public static class IRCChatActivityResult {
+    private static final String EXTRA_RESULT_CONNECT_ERROR = "error";
+
+    @Nullable public final String connectError;
+
+    public static IRCChatActivityResult fromResult(int resultCode, Intent data) {
+      if (resultCode == RESULT_CANCELED) {
+        return new IRCChatActivityResult(null /* connectError */);
+      } else {
+        return new IRCChatActivityResult(data.getStringExtra(EXTRA_RESULT_CONNECT_ERROR));
+      }
+    }
+
+    public IRCChatActivityResult(@Nullable String connectError) {
+      this.connectError = connectError;
+    }
+
+    public boolean wasUserDisconnect() {
+      return connectError == null;
+    }
+
+    private void setResult(Activity activity) {
+      if (wasUserDisconnect()) {
+        activity.setResult(RESULT_CANCELED);
+      } else {
+        activity.setResult(
+            RESULT_OK,
+            new Intent(activity, IRCChatActivity.class)
+                .putExtra(EXTRA_RESULT_CONNECT_ERROR, connectError));
+      }
+    }
+  }
+}

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCClientConnection.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCClientConnection.java
@@ -1,0 +1,148 @@
+package com.facebook.stetho.sample;
+
+import com.facebook.stetho.inspector.network.NetworkEventReporter;
+import com.facebook.stetho.inspector.network.NetworkEventReporterImpl;
+import com.facebook.stetho.inspector.network.SimpleTextInspectorWebSocketFrame;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import javax.annotation.Nullable;
+
+/**
+ * Simple IRC client connection system to demonstrate Stetho's "websocket" (any arbitrary
+ * socket will work too) support.
+ */
+public class IRCClientConnection implements Closeable {
+  private final StethoReporter mReporter;
+
+  private final Socket mSocket;
+  private final BufferedReader mInput;
+  private final BufferedWriter mOutput;
+
+  public static IRCClientConnection connect(String host, int port) throws IOException {
+    StethoReporter reporter = new StethoReporter();
+    Socket socket = new Socket();
+    reporter.onPreConnect(host, port);
+    try {
+      socket.connect(new InetSocketAddress(host, port));
+      reporter.onPostConnect();
+    } catch (IOException e) {
+      reporter.onError(e);
+      try {
+        socket.close();
+        throw e;
+      } finally {
+        reporter.onClosed();
+      }
+    }
+    return new IRCClientConnection(reporter, socket, "UTF-8");
+  }
+
+  private IRCClientConnection(
+      StethoReporter reporter,
+      Socket socket,
+      String charset)
+      throws IOException {
+    mReporter = reporter;
+    mSocket = socket;
+    mInput = new BufferedReader(new InputStreamReader(socket.getInputStream(), charset));
+    mOutput = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
+  }
+
+  @Nullable
+  public String read() throws IOException {
+    try {
+      String message = mInput.readLine();
+      if (message != null) {
+        mReporter.onReceive(message);
+        maybeHandleIncomingMessage(message);
+      }
+      return message;
+    } catch (IOException e) {
+      mReporter.onError(e);
+      throw e;
+    }
+  }
+
+  public void send(String message) throws IOException {
+    mReporter.onSend(message);
+    try {
+      mOutput.write(message + "\r\n");
+      mOutput.flush();
+    } catch (IOException e) {
+      mReporter.onError(e);
+      throw e;
+    }
+  }
+
+  private boolean maybeHandleIncomingMessage(String message) throws IOException {
+    if (message.startsWith("PING ")) {
+      send("PONG " + message.substring("PING ".length()));
+      return true;
+    }
+    return false;
+  }
+
+  public void close() throws IOException {
+    try {
+      try {
+        mOutput.close();
+      } catch (IOException e) {
+        mReporter.onError(e);
+        throw e;
+      }
+    } finally {
+      try {
+        mSocket.close();
+      } catch (IOException e) {
+        mReporter.onError(e);
+
+        // Technically this should use addSuppressed but it's KITKAT only and this is a demo...
+        throw e;
+      } finally {
+        mReporter.onClosed();
+      }
+    }
+  }
+
+  private static class StethoReporter {
+    private final NetworkEventReporter mReporter;
+    private final String mRequestId;
+
+    public StethoReporter() {
+      mReporter = NetworkEventReporterImpl.get();
+      mRequestId = mReporter.nextRequestId();
+    }
+
+    public void onPreConnect(String host, int port) {
+      mReporter.webSocketCreated(mRequestId, "irc://" + host + ":" + port);
+    }
+
+    public void onPostConnect() {
+      // Sadly, nothing to report...
+    }
+
+    public void onError(IOException e) {
+      mReporter.webSocketFrameError(mRequestId, e.getMessage());
+    }
+
+    public void onClosed() {
+      mReporter.webSocketClosed(mRequestId);
+    }
+
+    public void onSend(String message) {
+      mReporter.webSocketFrameSent(new SimpleTextInspectorWebSocketFrame(mRequestId, message));
+    }
+
+    public void onReceive(String message) {
+      mReporter.webSocketFrameReceived(new SimpleTextInspectorWebSocketFrame(mRequestId, message));
+    }
+  }
+}

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
@@ -1,0 +1,77 @@
+package com.facebook.stetho.sample;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import com.facebook.stetho.sample.IRCChatActivity.IRCChatActivityResult;
+
+import java.util.Random;
+
+public class IRCConnectActivity extends Activity {
+  private static final String DEFAULT_HOST = "irc.freenode.net";
+
+  private static final int REQUEST_CODE_CHAT = 1;
+
+  private TextView mIRCPriorError;
+  private EditText mIRCServer;
+  private EditText mIRCNickname;
+
+  public static void show(Context context) {
+    Intent intent = new Intent(context, IRCConnectActivity.class);
+    context.startActivity(intent);
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.irc_connect_activity);
+
+    mIRCPriorError = (TextView) findViewById(R.id.irc_prior_error);
+    mIRCServer = (EditText) findViewById(R.id.irc_server);
+    if (TextUtils.isEmpty(mIRCServer.getText())) {
+      mIRCServer.setText(DEFAULT_HOST);
+    }
+    mIRCNickname = (EditText) findViewById(R.id.irc_nickname);
+    if (TextUtils.isEmpty(mIRCNickname.getText())) {
+      mIRCNickname.setText("Guest" + (new Random().nextInt(9999) + 1));
+    }
+
+    findViewById(R.id.irc_connect).setOnClickListener(mConnectClicked);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    switch (requestCode) {
+      case REQUEST_CODE_CHAT:
+        IRCChatActivityResult parsedResult =
+            IRCChatActivityResult.fromResult(resultCode, data);
+        if (parsedResult.wasUserDisconnect()) {
+          mIRCPriorError.setText("");
+          mIRCPriorError.setVisibility(View.GONE);
+        } else {
+          mIRCPriorError.setText("ERROR: " + parsedResult.connectError);
+          mIRCPriorError.setVisibility(View.VISIBLE);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown requestCode=" + requestCode);
+    }
+  }
+
+  private final View.OnClickListener mConnectClicked = new View.OnClickListener() {
+    @Override
+    public void onClick(View v) {
+      IRCChatActivity.showForResult(
+          IRCConnectActivity.this,
+          REQUEST_CODE_CHAT,
+          mIRCServer.getText().toString(),
+          mIRCNickname.getText().toString());
+    }
+  };
+}

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
@@ -39,7 +39,7 @@ public class IRCConnectActivity extends Activity {
     }
     mIRCNickname = (EditText) findViewById(R.id.irc_nickname);
     if (TextUtils.isEmpty(mIRCNickname.getText())) {
-      mIRCNickname.setText("Guest" + (new Random().nextInt(9999) + 1));
+      mIRCNickname.setText("stetho" + (new Random().nextInt(9999) + 1));
     }
 
     findViewById(R.id.irc_connect).setOnClickListener(mConnectClicked);

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
@@ -33,6 +33,7 @@ public class MainActivity extends Activity {
 
     findViewById(R.id.settings_btn).setOnClickListener(mMainButtonClicked);
     findViewById(R.id.apod_btn).setOnClickListener(mMainButtonClicked);
+    findViewById(R.id.irc_btn).setOnClickListener(mMainButtonClicked);
   }
 
   private static boolean isStethoPresent() {
@@ -68,6 +69,8 @@ public class MainActivity extends Activity {
         SettingsActivity.show(MainActivity.this);
       } else if (id == R.id.apod_btn) {
         APODActivity.show(MainActivity.this);
+      } else if (id == R.id.irc_btn) {
+        IRCConnectActivity.show(MainActivity.this);
       }
     }
   };

--- a/stetho-sample/src/main/res/layout/irc_chat_activity.xml
+++ b/stetho-sample/src/main/res/layout/irc_chat_activity.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="15dp">
+
+  <ListView
+      android:id="@+id/console_display"
+      android:layout_width="match_parent"
+      android:layout_height="0px"
+      android:layout_weight="1"
+      android:layout_marginBottom="10dp"
+      android:transcriptMode="normal"
+      />
+
+  <LinearLayout
+      android:orientation="horizontal"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+    <EditText
+        android:id="@+id/console_input"
+        android:layout_width="0px"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:typeface="monospace"
+        android:inputType="textAutoCorrect"
+        android:imeOptions="actionSend"
+        android:maxLines="1">
+
+      <requestFocus />
+
+    </EditText>
+
+    <Button
+        android:id="@+id/console_send"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/send"
+        />
+
+  </LinearLayout>
+
+</LinearLayout>

--- a/stetho-sample/src/main/res/layout/irc_connect_activity.xml
+++ b/stetho-sample/src/main/res/layout/irc_connect_activity.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="15dp"
+    android:gravity="center_vertical">
+
+  <TextView
+      android:id="@+id/irc_prior_error"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:visibility="gone"
+      android:layout_marginBottom="10dp"
+      />
+
+  <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/irc_server"
+      android:layout_marginBottom="10dp"
+      />
+
+  <EditText
+      android:id="@+id/irc_server"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="text"
+      android:maxLines="1"
+      android:imeOptions="actionNext"
+      android:layout_marginBottom="10dp"
+      />
+
+  <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/irc_nickname"
+      android:layout_marginBottom="10dp"
+      />
+
+  <EditText
+      android:id="@+id/irc_nickname"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="text"
+      android:maxLines="1"
+      android:imeOptions="actionGo"
+      android:layout_marginBottom="10dp"
+      />
+
+  <Button
+      android:id="@+id/irc_connect"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:text="@string/irc_connect"
+      />
+
+</LinearLayout>

--- a/stetho-sample/src/main/res/layout/irc_console_row.xml
+++ b/stetho-sample/src/main/res/layout/irc_console_row.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:typeface="monospace"
+    />

--- a/stetho-sample/src/main/res/layout/main_activity.xml
+++ b/stetho-sample/src/main/res/layout/main_activity.xml
@@ -22,4 +22,12 @@
       android:layout_marginBottom="10dp"
       />
 
+  <Button
+      android:id="@+id/irc_btn"
+      android:text="@string/irc_btn"
+      android:layout_width="@dimen/main_button_width"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="10dp"
+      />
+
 </LinearLayout>

--- a/stetho-sample/src/main/res/values/strings.xml
+++ b/stetho-sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
   <string name="app_name">Stetho Sample</string>
   <string name="settings_btn">Settings</string>
   <string name="apod_btn">APOD RSS Feed</string>
+  <string name="irc_btn">IRC Client</string>
   <string name="settings_title">Settings</string>
   <string name="pref_category1_title">General</string>
   <string name="pref_checkbox_title">Boolean setting</string>
@@ -14,5 +15,11 @@
   <string name="pref_list_dialog_title">Choices</string>
   <string name="pref_change_message">%1$s is now \'%2$s\'</string>
   <string name="apod_title">APOD Listing</string>
+  <string name="irc_connect_title">IRC Connect</string>
+  <string name="irc_chat_title">IRC Chat</string>
   <string name="stetho_missing">Stetho missing in %s build!</string>
+  <string name="send">Send</string>
+  <string name="irc_connect">Connect</string>
+  <string name="irc_nickname">Nickname:</string>
+  <string name="irc_server">IRC Server:</string>
 </resources>

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -328,6 +328,109 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
     return headers.firstHeaderValue("Content-Type");
   }
 
+  @Override
+  public void webSocketCreated(String requestId, String url) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketCreatedParams params = new Network.WebSocketCreatedParams();
+      params.requestId = requestId;
+      params.url = url;
+      peerManager.sendNotificationToPeers("Network.webSocketCreated", params);
+    }
+  }
+
+  @Override
+  public void webSocketClosed(String requestId) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketClosedParams params = new Network.WebSocketClosedParams();
+      params.requestId = requestId;
+      params.timestamp = stethoNow() / 1000.0;
+      peerManager.sendNotificationToPeers("Network.webSocketClosed", params);
+    }
+  }
+
+  @Override
+  public void webSocketWillSendHandshakeRequest(InspectorWebSocketRequest request) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketWillSendHandshakeRequestParams params =
+          new Network.WebSocketWillSendHandshakeRequestParams();
+      params.requestId = request.id();
+      params.timestamp = stethoNow() / 1000.0;
+      params.wallTime = System.currentTimeMillis() / 1000.0;
+      Network.WebSocketRequest requestJSON = new Network.WebSocketRequest();
+      requestJSON.headers = formatHeadersAsJSON(request);
+      params.request = requestJSON;
+      peerManager.sendNotificationToPeers("Network.webSocketWillSendHandshakeRequest", params);
+    }
+  }
+
+  @Override
+  public void webSocketHandshakeResponseReceived(InspectorWebSocketResponse response) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketHandshakeResponseReceivedParams params =
+          new Network.WebSocketHandshakeResponseReceivedParams();
+      params.requestId = response.requestId();
+      params.timestamp = stethoNow() / 1000.0;
+      Network.WebSocketResponse responseJSON = new Network.WebSocketResponse();
+      responseJSON.headers = formatHeadersAsJSON(response);
+      responseJSON.headersText = null;
+      if (response.requestHeaders() != null) {
+        responseJSON.requestHeaders = formatHeadersAsJSON(response.requestHeaders());
+        responseJSON.requestHeadersText = null;
+      }
+      responseJSON.status = response.statusCode();
+      responseJSON.statusText = response.reasonPhrase();
+      params.response = responseJSON;
+    }
+  }
+
+  @Override
+  public void webSocketFrameSent(InspectorWebSocketFrame frame) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketFrameSentParams params = new Network.WebSocketFrameSentParams();
+      params.requestId = frame.requestId();
+      params.timestamp = stethoNow() / 1000.0;
+      params.response = convertFrame(frame);
+      peerManager.sendNotificationToPeers("Network.webSocketFrameSent", params);
+    }
+  }
+
+  @Override
+  public void webSocketFrameReceived(InspectorWebSocketFrame frame) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketFrameReceivedParams params = new Network.WebSocketFrameReceivedParams();
+      params.requestId = frame.requestId();
+      params.timestamp = stethoNow() / 1000.0;
+      params.response = convertFrame(frame);
+      peerManager.sendNotificationToPeers("Network.webSocketFrameReceived", params);
+    }
+  }
+
+  private static Network.WebSocketFrame convertFrame(InspectorWebSocketFrame in) {
+    Network.WebSocketFrame out = new Network.WebSocketFrame();
+    out.opcode = in.opcode();
+    out.mask = in.mask();
+    out.payloadData = in.payloadData();
+    return out;
+  }
+
+  @Override
+  public void webSocketFrameError(String requestId, String errorMessage) {
+    NetworkPeerManager peerManager = getPeerManagerIfEnabled();
+    if (peerManager != null) {
+      Network.WebSocketFrameErrorParams params = new Network.WebSocketFrameErrorParams();
+      params.requestId = requestId;
+      params.timestamp = stethoNow() / 1000.0;
+      params.errorMessage = errorMessage;
+      peerManager.sendNotificationToPeers("Network.webSocketFrameError", params);
+    }
+  }
+
   private static JSONObject formatHeadersAsJSON(InspectorHeaders headers) {
     JSONObject json = new JSONObject();
     for (int i = 0; i < headers.headerCount(); i++) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleBinaryInspectorWebSocketFrame.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleBinaryInspectorWebSocketFrame.java
@@ -1,0 +1,39 @@
+package com.facebook.stetho.inspector.network;
+
+import java.io.UnsupportedEncodingException;
+
+public class SimpleBinaryInspectorWebSocketFrame
+    implements NetworkEventReporter.InspectorWebSocketFrame {
+  private final String mRequestId;
+  private final byte[] mPayload;
+
+  public SimpleBinaryInspectorWebSocketFrame(String requestId, byte[] payload) {
+    mRequestId = requestId;
+    mPayload = payload;
+  }
+
+  @Override
+  public String requestId() {
+    return mRequestId;
+  }
+
+  @Override
+  public int opcode() {
+    return OPCODE_BINARY;
+  }
+
+  @Override
+  public boolean mask() {
+    return false;
+  }
+
+  @Override
+  public String payloadData() {
+    try {
+      // LOL, yes this is really how Chrome does it too...
+      return new String(mPayload, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleTextInspectorWebSocketFrame.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleTextInspectorWebSocketFrame.java
@@ -1,0 +1,32 @@
+package com.facebook.stetho.inspector.network;
+
+public class SimpleTextInspectorWebSocketFrame
+    implements NetworkEventReporter.InspectorWebSocketFrame {
+  private final String mRequestId;
+  private final String mPayload;
+
+  public SimpleTextInspectorWebSocketFrame(String requestId, String payload) {
+    mRequestId = requestId;
+    mPayload = payload;
+  }
+
+  @Override
+  public String requestId() {
+    return mRequestId;
+  }
+
+  @Override
+  public int opcode() {
+    return OPCODE_TEXT;
+  }
+
+  @Override
+  public boolean mask() {
+    return false;
+  }
+
+  @Override
+  public String payloadData() {
+    return mPayload;
+  }
+}

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -311,4 +311,114 @@ public class Network implements ChromeDevtoolsDomain {
     @JsonProperty(required = true)
     public double receivedHeadersEnd;
   }
+
+  public static class WebSocketCreatedParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public String url;
+  }
+
+  public static class WebSocketClosedParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+  }
+
+  public static class WebSocketWillSendHandshakeRequestParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+
+    @JsonProperty(required = true)
+    public double wallTime;
+
+    @JsonProperty(required = true)
+    public WebSocketRequest request;
+  }
+
+  public static class WebSocketRequest {
+    @JsonProperty(required = true)
+    public JSONObject headers;
+  }
+
+  public static class WebSocketHandshakeResponseReceivedParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+
+    @JsonProperty(required = true)
+    public WebSocketResponse response;
+  }
+
+  public static class WebSocketResponse {
+    @JsonProperty(required = true)
+    public int status;
+
+    @JsonProperty(required = true)
+    public String statusText;
+
+    @JsonProperty(required = true)
+    public JSONObject headers;
+
+    @JsonProperty
+    public String headersText;
+
+    @JsonProperty
+    public JSONObject requestHeaders;
+
+    @JsonProperty
+    public String requestHeadersText;
+  }
+
+  public static class WebSocketFrameReceivedParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+
+    @JsonProperty(required = true)
+    public WebSocketFrame response;
+  }
+
+  public static class WebSocketFrameSentParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+
+    @JsonProperty(required = true)
+    public WebSocketFrame response;
+  }
+
+  public static class WebSocketFrame {
+    @JsonProperty(required = true)
+    public int opcode;
+
+    @JsonProperty(required = true)
+    public boolean mask;
+
+    @JsonProperty(required = true)
+    public String payloadData;
+  }
+
+  public static class WebSocketFrameErrorParams {
+    @JsonProperty(required = true)
+    public String requestId;
+
+    @JsonProperty(required = true)
+    public double timestamp;
+
+    @JsonProperty(required = true)
+    public String errorMessage;
+  }
 }


### PR DESCRIPTION
Generally this PR is designed to add full websocket (and raw socket) support to NetworkEventReporter but also introduces an IRC client in stetho-sample to test/demonstrate the functionality.  This screenshot shows the system in action in chrome://inspect:

![irc-socket](https://cloud.githubusercontent.com/assets/83791/23841426/66dab8f6-076a-11e7-9493-22848866f9d1.png)

Partially addresses #498 
