### PR TITLE
Allow hitting empty viewgroups

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -107,11 +107,8 @@ final class ViewGroupDescriptor extends AbstractChainedDescriptor<ViewGroup>
     View hitChild = null;
     for (int i = element.getChildCount() - 1; i >= 0; --i) {
       final View childView = element.getChildAt(i);
-      final boolean hasChildren = childView instanceof ViewGroup &&
-          ((ViewGroup) childView).getChildCount() > 0;
       if (isChildVisible(childView) &&
-          childView.getVisibility() == View.VISIBLE &&
-          (hasChildren || childView.isFocusable())) {
+          childView.getVisibility() == View.VISIBLE) {
         childView.getHitRect(bounds);
         if (bounds.contains(x, y)) {
           hitChild = childView;


### PR DESCRIPTION
This was implemented previously to get around an issue with overlays.
This was wrong and should be implemented by making overlays
non-focusable instead.