### PR TITLE
Fix crash when stylesheet text is empty

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -173,9 +173,7 @@ public class CSS implements ChromeDevtoolsDomain {
 
     final String value;
     final String key;
-    if ("/* undefined */".equals(request.text)) {
-      // This gets sent when a key is disabled. Chrome does not send the key which was disabled
-      // though so not much we can do here.
+    if (request.text == null || !request.text.contains(":")) {
       key = null;
       value = null;
     } else {


### PR DESCRIPTION
When deleting the value of a style property chrome sends back an empty string instead of a key with an empty value.