### PR TITLE
Null check Interceptor.Chain.connection().

### DIFF
--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -182,13 +182,13 @@ public class StethoInterceptor implements Interceptor {
     private final String mRequestId;
     private final Request mRequest;
     private final Response mResponse;
-    private final Connection mConnection;
+    @Nullable private final Connection mConnection;
 
     public OkHttpInspectorResponse(
         String requestId,
         Request request,
         Response response,
-        Connection connection) {
+        @Nullable Connection connection) {
       mRequestId = requestId;
       mRequest = request;
       mResponse = response;

--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -223,7 +223,7 @@ public class StethoInterceptor implements Interceptor {
 
     @Override
     public int connectionId() {
-      return mConnection.hashCode();
+      return mConnection == null ? 0 : mConnection.hashCode();
     }
 
     @Override

--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -182,7 +182,7 @@ public class StethoInterceptor implements Interceptor {
     private final String mRequestId;
     private final Request mRequest;
     private final Response mResponse;
-    @Nullable private final Connection mConnection;
+    private @Nullable final Connection mConnection;
 
     public OkHttpInspectorResponse(
         String requestId,


### PR DESCRIPTION
`Interceptor.Chain.connection()` was [marked nullable](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Interceptor.java#L38) in OkHttp 3.8.0. 

In `StethoInterceptor` we retrieve a connection and don't check for `null`. This causes Stetho to crash when calling [`OkHttpInspectorResponse.connectionId()`](https://github.com/facebook/stetho/blob/master/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java#L226) when a connection is not present. 

Addresses #541 