### PR TITLE
Throw RegistrationException when connection isn't present.

### DIFF
--- a/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
+++ b/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
@@ -103,7 +103,7 @@ public class StethoInterceptorTest {
         .build();
     Response filteredResponse =
         mInterceptor.intercept(
-            new SimpleTestChain(request, reply, null));
+            new SimpleTestChain(request, reply, Mockito.mock(Connection.class)));
 
     inOrder.verify(mMockEventReporter).isEnabled();
     inOrder.verify(mMockEventReporter)
@@ -198,6 +198,21 @@ public class StethoInterceptorTest {
 
     server.shutdown();
   }
+
+  @Test(expected = StethoInterceptor.RegistrationException.class)
+  public void testConnectionNotPresentThrowsRegistrationException() throws IOException {
+    Request request = new Request.Builder()
+            .url(Uri.parse("http://www.facebook.com/nowhere").toString())
+            .build();
+    Response reply = new Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .build();
+
+    mInterceptor.intercept(new SimpleTestChain(request, reply, null));
+  }
+
 
   private static String repeat(String s, int reps) {
     StringBuilder b = new StringBuilder(s.length() * reps);


### PR DESCRIPTION
@rickbrew I was chatting with @swankjesse about this: Connection is guaranteed to be present in network interceptors and is only and always nullable in vanilla interceptors.

This change causes Stetho to throw a `StethoInterceptor.RegistrationException` when a connection is not present and prompts consumers to check their interceptor registration.

Helps mitigate issues like: #423, #135, #420, #267, #346, #555 