### PR TITLE
Fix issue #480 : Documentation to add MyApplication to AndroidManifest.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ public class MyApplication extends Application {
   }
 }
 ```
+Also ensure that your `MyApplication` Java class is registered in your `AndroidManifest.xml` file, otherwise you will not see an "Inspect" button in `chrome://inspect/#devices` :
+
+```xml
+<manifest
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        ...>
+        <application
+                android:name="MyApplication"
+                ...>
+         </application>
+</manifest>                
+```
 
 This brings up most of the default configuration but does not enable some
 additional hooks (most notably, network inspection).  See below for specific


### PR DESCRIPTION
The MyApplication Java class must be added to the AndroidManifest.xml, otherwise there will be no "Inspect" button that appears in chrome://inspect/#devices

Add this explanation in the documentation of Readme.md