### PR TITLE
CheckCharset on PostData to prevent hanging or crashing

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -128,6 +128,9 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
       InspectorRequest request) {
     try {
       byte[] body = request.body();
+      if (body == null || body.length == 0) {
+        return "";
+      }
       try {
         CharBuffer charBuffer = decoder.decode(ByteBuffer.wrap(body));
         return charBuffer.toString();

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -137,7 +137,7 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
                 Console.MessageLevel.WARNING,
                 Console.MessageSource.NETWORK,
                 "Could not reproduce POST body do to a an invalid charset: " + e);
-        return "Data (length:"  +" cannot be represented as a string.";
+        return "Data (length:"+ body.length  +") cannot be represented as a string.";
       }
     } catch (IOException | OutOfMemoryError e) {
       CLog.writeToConsole(

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -132,19 +132,21 @@ public class NetworkEventReporterImpl implements NetworkEventReporter {
         CharBuffer charBuffer = decoder.decode(ByteBuffer.wrap(body));
         return charBuffer.toString();
       } catch (CharacterCodingException e) {
+        String logMessage = "Charset in POST/PUT is not UTF-8. Data (length:"+ body.length
+                +") cannot be represented as a string. ";
         CLog.writeToConsole(
                 peerManager,
                 Console.MessageLevel.WARNING,
                 Console.MessageSource.NETWORK,
-                "Could not reproduce POST body do to a an invalid charset: " + e);
-        return "Data (length:"+ body.length  +") cannot be represented as a string.";
+                 logMessage + e);
+        return logMessage;
       }
     } catch (IOException | OutOfMemoryError e) {
       CLog.writeToConsole(
               peerManager,
               Console.MessageLevel.WARNING,
               Console.MessageSource.NETWORK,
-              "Could not reproduce POST body: " + e);
+              "Could not reproduce POST/PUT body: " + e);
 
     }
     return null;


### PR DESCRIPTION
This should resolve the error around: https://github.com/facebook/stetho/issues/329
Use CharsetDecoder to decode the byte[]. if it reports an error, bail out and report to the chrome inspector that `Charset in POST/PUT is not UTF-8. Data (length:X) cannot be represented as a string.`