### PR TITLE
Improve error message when addInterceptor is used instead of addNetworkInterceptor

### DIFF
--- a/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
+++ b/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
@@ -76,7 +76,9 @@ public class StethoInterceptor implements Interceptor {
 
       Connection connection = chain.connection();
       if (connection == null) {
-        throw new IllegalStateException("No connection associated with this request; did you use addInterceptor instead of addNetworkInterceptor?")
+        throw new IllegalStateException(
+            "No connection associated with this request; " +
+                "did you use addInterceptor instead of addNetworkInterceptor?");
       }
       mEventReporter.responseHeadersReceived(
           new OkHttpInspectorResponse(

--- a/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
+++ b/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
@@ -75,6 +75,9 @@ public class StethoInterceptor implements Interceptor {
       }
 
       Connection connection = chain.connection();
+      if (connection == null) {
+        throw new IllegalStateException("No connection associated with this request; did you use addInterceptor instead of addNetworkInterceptor?")
+      }
       mEventReporter.responseHeadersReceived(
           new OkHttpInspectorResponse(
               requestId,

--- a/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
+++ b/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
@@ -52,6 +52,7 @@ import java.util.zip.GZIPOutputStream;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 @Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
 @RunWith(RobolectricTestRunner.class)
@@ -69,7 +70,7 @@ public class StethoInterceptorTest {
   public void setUp() {
     PowerMockito.mockStatic(NetworkEventReporterImpl.class);
 
-    mMockEventReporter = Mockito.mock(NetworkEventReporter.class);
+    mMockEventReporter = mock(NetworkEventReporter.class);
     Mockito.when(mMockEventReporter.isEnabled()).thenReturn(true);
     PowerMockito.when(NetworkEventReporterImpl.get()).thenReturn(mMockEventReporter);
 
@@ -102,7 +103,7 @@ public class StethoInterceptorTest {
         .build();
     Response filteredResponse =
         mInterceptor.intercept(
-            new SimpleTestChain(request, reply, null));
+            new SimpleTestChain(request, reply, mock(Connection.class)));
 
     inOrder.verify(mMockEventReporter).isEnabled();
     inOrder.verify(mMockEventReporter)

--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -68,7 +68,9 @@ public class StethoInterceptor implements Interceptor {
 
       Connection connection = chain.connection();
       if (connection == null) {
-        throw new IllegalStateException("No connection associated with this request; did you use addInterceptor instead of addNetworkInterceptor?")
+        throw new IllegalStateException(
+            "No connection associated with this request; " +
+                "did you use addInterceptor instead of addNetworkInterceptor?");
       }
       mEventReporter.responseHeadersReceived(
           new OkHttpInspectorResponse(

--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -67,6 +67,9 @@ public class StethoInterceptor implements Interceptor {
       }
 
       Connection connection = chain.connection();
+      if (connection == null) {
+        throw new IllegalStateException("No connection associated with this request; did you use addInterceptor instead of addNetworkInterceptor?")
+      }
       mEventReporter.responseHeadersReceived(
           new OkHttpInspectorResponse(
               requestId,

--- a/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
+++ b/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
@@ -52,6 +52,7 @@ import java.util.zip.GZIPOutputStream;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
 
 @Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
 @RunWith(RobolectricTestRunner.class)
@@ -69,7 +70,7 @@ public class StethoInterceptorTest {
   public void setUp() {
     PowerMockito.mockStatic(NetworkEventReporterImpl.class);
 
-    mMockEventReporter = Mockito.mock(NetworkEventReporter.class);
+    mMockEventReporter = mock(NetworkEventReporter.class);
     Mockito.when(mMockEventReporter.isEnabled()).thenReturn(true);
     PowerMockito.when(NetworkEventReporterImpl.get()).thenReturn(mMockEventReporter);
 
@@ -103,7 +104,7 @@ public class StethoInterceptorTest {
         .build();
     Response filteredResponse =
         mInterceptor.intercept(
-            new SimpleTestChain(request, reply, null));
+            new SimpleTestChain(request, reply, mock(Connection.class)));
 
     inOrder.verify(mMockEventReporter).isEnabled();
     inOrder.verify(mMockEventReporter)


### PR DESCRIPTION
Previously this would yield a NullPointerException and was not very
discoverable/actionable for users.

Closes #580