### PR TITLE
Fix fatjar compilation including android support library R.class files

### DIFF
--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -58,5 +58,6 @@ android.libraryVariants.all { variant ->
         from variant.javaCompile.destinationDir
         from "build/commons-cli-tidy-${name}"
         from "build/metainf-${name}"
+        exclude 'android/support/**/*'
     }
 }


### PR DESCRIPTION
These files would conflict with any other version of the support
library the user tried to add and are not otherwise required or
important for Stetho to function.

Closes #566