### PR TITLE
Fix the way /proc/net/unix is being parsed

### DIFF
--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -69,7 +69,7 @@ def _find_only_stetho_socket(device, port):
     last_stetho_socket_name = None
     process_names = []
     for line in adb.sock.makefile():
-      row = line.rstrip().split(' ')
+      row = re.split(r'\s+', line.rstrip())
       if len(row) < 8:
         continue
       socket_name = row[7]


### PR DESCRIPTION
dumpapp stopped working for me because /proc/net/unix has two spaces to separate state from inode when the inode length is less than the maximum inode length (123 vs 1234).

E.g.:

```
00000000: 00000002 00000000 00010000 0001 01 76292 /dev/socket/cryptd
00000000: 00000002 00000000 00010000 0001 01  3836 @stetho_com.facebook.wakizashi_devtools_remote
```

We should be parsing this with `\s+` and not a simple space since the output date is a table that is formatted to look like columns in the print out.

I tested this by running dumpapp in a situation like the one mentioned above.