### PR TITLE
Sorts SharedPreferences entries

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
@@ -18,6 +18,7 @@ import android.text.TextUtils;
 import com.facebook.stetho.dumpapp.DumpUsageException;
 import com.facebook.stetho.dumpapp.DumperContext;
 import com.facebook.stetho.dumpapp.DumperPlugin;
+import com.facebook.stetho.inspector.domstorage.SharedPreferencesHelper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -174,7 +175,7 @@ public class SharedPreferencesDumperPlugin implements DumperPlugin {
   private void printFile(PrintStream writer, String prefsName, String keyPrefix) {
     writer.println(prefsName + ":");
     SharedPreferences preferences = getSharedPreferences(prefsName);
-    for (Map.Entry<String, ?> entry : preferences.getAll().entrySet()) {
+    for (Map.Entry<String, ?> entry : SharedPreferencesHelper.getSharedPreferenceEntriesSorted(preferences)) {
       if (entry.getKey().startsWith(keyPrefix)) {
         writer.println("  " + entry.getKey() + " = " + entry.getValue());
       }

--- a/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
@@ -10,6 +10,8 @@
 package com.facebook.stetho.inspector.domstorage;
 
 import android.content.Context;
+import android.content.SharedPreferences;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -17,9 +19,12 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeSet;
 
 public class SharedPreferencesHelper {
   private static final String PREFS_SUFFIX = ".xml";
@@ -44,6 +49,17 @@ public class SharedPreferencesHelper {
     Collections.sort(tags);
 
     return tags;
+  }
+
+  public static Set<Entry<String, ?>> getSharedPreferenceEntriesSorted(SharedPreferences preferences) {
+    TreeSet<Entry<String, ?>> entries = new TreeSet<>(new Comparator<Entry<String, ?>>() {
+      @Override
+      public int compare(Entry<String, ?> lhs, Entry<String, ?> rhs) {
+        return lhs.getKey().compareTo(rhs.getKey());
+      }
+    });
+    entries.addAll(preferences.getAll().entrySet());
+    return entries;
   }
 
   public static String valueToString(Object value) {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
@@ -63,7 +63,7 @@ public class DOMStorage implements ChromeDevtoolsDomain {
     String prefTag = storage.securityOrigin;
     if (storage.isLocalStorage) {
       SharedPreferences prefs = mContext.getSharedPreferences(prefTag, Context.MODE_PRIVATE);
-      for (Map.Entry<String, ?> prefsEntry : prefs.getAll().entrySet()) {
+      for (Map.Entry<String, ?> prefsEntry : SharedPreferencesHelper.getSharedPreferenceEntriesSorted(prefs)) {
         ArrayList<String> entry = new ArrayList<String>(2);
         entry.add(prefsEntry.getKey());
         entry.add(SharedPreferencesHelper.valueToString(prefsEntry.getValue()));


### PR DESCRIPTION
This PR solves #595 . Currently all preferences are unsorted and hard to find. This patch will make preferences sort by key alphabetically.