### PR TITLE
updated to new groovy coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ begin.
 ### Download
 Download [the latest JARs](https://github.com/facebook/stetho/releases/latest) or grab via Gradle:
 ```groovy
-compile 'com.facebook.stetho:stetho:1.5.0'
+implementation 'com.facebook.stetho:stetho:1.5.0'
 ```
 or Maven:
 ```xml
@@ -29,17 +29,17 @@ or Maven:
 Only the main `stetho` dependency is strictly required; however, you may also wish to use one of the network helpers:
 
 ```groovy
-compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+implementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
 ```
 or:
 ```groovy
-compile 'com.facebook.stetho:stetho-urlconnection:1.5.0'
+implementation 'com.facebook.stetho:stetho-urlconnection:1.5.0'
 ```
 
 You can also enable a JavaScript console with:
 
 ```groovy
-compile 'com.facebook.stetho:stetho-js-rhino:1.5.0'
+implementation 'com.facebook.stetho:stetho-js-rhino:1.5.0'
 ```
 For more details on how to customize the JavaScript runtime see [stetho-js-rhino](stetho-js-rhino/).
 


### PR DESCRIPTION
Recently there was a change in groovy code that replaces `compile`with `implementation`, which will soon be standard. To keep this great repro future proof I have added these minor changes.