### PR TITLE
Made .remove() working for DefaultDumperPluginsBuilder 

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -177,7 +177,7 @@ public class Stetho {
 
     public void remove(String pluginName) {
       throwIfFinished();
-      mRemovedNames.remove(pluginName);
+      mRemovedNames.add(pluginName);
     }
 
     private void throwIfFinished() {

--- a/stetho/src/test/java/com/facebook/stetho/PluginBuilderTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/PluginBuilderTest.java
@@ -1,0 +1,62 @@
+package com.facebook.stetho;
+
+import android.app.Activity;
+import android.os.Build;
+import com.facebook.stetho.dumpapp.DumperPlugin;
+import com.facebook.stetho.dumpapp.plugins.HprofDumperPlugin;
+import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain;
+import com.facebook.stetho.inspector.protocol.module.Debugger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+
+@Config(emulateSdk = Build.VERSION_CODES.JELLY_BEAN)
+@RunWith(RobolectricTestRunner.class)
+public class PluginBuilderTest {
+  private final Activity mActivity = Robolectric.setupActivity(Activity.class);
+
+  @Test
+  public void test_Remove_DefaultInspectorModulesBuilder() throws IOException {
+    final Class<Debugger> debuggerClass = Debugger.class;
+
+    Iterable<ChromeDevtoolsDomain> domains = new Stetho.DefaultInspectorModulesBuilder(mActivity)
+            .remove(debuggerClass.getName())
+            .finish();
+
+    boolean containsDebugggerDomain = false;
+    for (ChromeDevtoolsDomain domain : domains) {
+      if (domain.getClass().equals(debuggerClass)) {
+        containsDebugggerDomain = true;
+        break;
+      }
+    }
+
+    assertFalse(containsDebugggerDomain);
+  }
+
+  @Test
+  public void test_Remove_DefaultDumperPluginsBuilder() throws IOException {
+    //HprofDumperPlugin.NAME is private
+    final String hprofDumperPluginNAME = "hprof";
+    final Iterable<DumperPlugin> dumperPlugins = new Stetho.DefaultDumperPluginsBuilder(mActivity)
+            .remove(hprofDumperPluginNAME)
+            .finish();
+
+    boolean containsDebugggerDomain = false;
+    for (DumperPlugin plugin : dumperPlugins) {
+      if (plugin.getClass().equals(HprofDumperPlugin.class)) {
+        containsDebugggerDomain = true;
+        break;
+      }
+    }
+
+    assertFalse(containsDebugggerDomain);
+  }
+
+}


### PR DESCRIPTION
and DefaultInspectorModulesBuilder by fixing PluginBuilder.remove(). Tests are added.