### PR TITLE
Upgrade gradle & android plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jdk:
 android:
   components:
     - tools
-    - build-tools-25.0.2
+    - build-tools-27.0.3
+    - build-tools-26.1.3
     - android-23
     - platform-tools
     - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,18 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
+
+apply from: "versions.gradle"
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 08 13:59:20 SGT 2017
+#Fri Jul 06 09:17:23 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/stetho-js-rhino/build.gradle
+++ b/stetho-js-rhino/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 9
@@ -19,11 +19,11 @@ android {
 }
 
 dependencies {
-    compile project(':stetho')
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
-    compile 'org.mozilla:rhino:1.7.6'
+    api project(':stetho')
+    api 'com.google.code.findbugs:jsr305:2.0.1'
+    api 'org.mozilla:rhino:1.7.6'
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho-okhttp/build.gradle
+++ b/stetho-okhttp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 9
@@ -21,23 +21,23 @@ android {
 }
 
 dependencies {
-    compile project(':stetho')
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
-    compile 'com.squareup.okhttp:okhttp:2.7.2'
+    api project(':stetho')
+    api 'com.google.code.findbugs:jsr305:2.0.1'
+    api 'com.squareup.okhttp:okhttp:2.7.2'
 
-    testCompile 'junit:junit:4.12'
-    testCompile('org.robolectric:robolectric:2.4') {
+    testImplementation 'junit:junit:4.12'
+    testImplementation('org.robolectric:robolectric:2.4') {
         exclude module: 'commons-logging'
         exclude module: 'httpclient'
     }
-    testCompile 'org.powermock:powermock-api-mockito:1.6.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.1'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.1'
 
     // Needed for Robolectric and PowerMock to be combined in a single test.
-    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.1'
-    testCompile 'org.powermock:powermock-classloading-xstream:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.1'
+    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.1'
 
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.2'
+    testImplementation 'com.squareup.okhttp:mockwebserver:2.7.2'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho-okhttp3/build.gradle
+++ b/stetho-okhttp3/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 9
@@ -21,23 +21,23 @@ android {
 }
 
 dependencies {
-    compile project(':stetho')
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
-    compile 'com.squareup.okhttp3:okhttp:3.4.2'
+    api project(':stetho')
+    api 'com.google.code.findbugs:jsr305:2.0.1'
+    api 'com.squareup.okhttp3:okhttp:3.4.2'
 
-    testCompile 'junit:junit:4.12'
-    testCompile('org.robolectric:robolectric:2.4') {
+    testImplementation 'junit:junit:4.12'
+    testImplementation('org.robolectric:robolectric:2.4') {
         exclude module: 'commons-logging'
         exclude module: 'httpclient'
     }
-    testCompile 'org.powermock:powermock-api-mockito:1.6.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.1'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.1'
 
     // Needed for Robolectric and PowerMock to be combined in a single test.
-    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.1'
-    testCompile 'org.powermock:powermock-classloading-xstream:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.1'
+    testImplementation 'org.powermock:powermock-classloading-xstream:1.6.1'
 
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.4.2'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho-sample/build.gradle
+++ b/stetho-sample/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         applicationId "com.facebook.stetho.sample"
@@ -29,14 +29,14 @@ android {
 }
 
 dependencies {
-    debugCompile project(':stetho')
-    debugCompile project(':stetho-urlconnection')
+    debugImplementation project(':stetho')
+    debugImplementation project(':stetho-urlconnection')
 
     // Uncomment if you wish to play with the Console evaluation
     // features of the Rhino JS implementation.  Disabled by default
     // because it is a large JAR by comparison to the rest of
     // Stetho.
-    //debugCompile project(':stetho-js-rhino')
+    //debugImplementation project(':stetho-js-rhino')
 
     // We must use Maven dependency resolution to demonstrate our usage
     // of optional dependencies to include stetho-urlconnection but not
@@ -44,8 +44,8 @@ dependencies {
     // way to express this is:
     //
     //   dependencies {
-    //     debugCompile 'com.facebook.stetho:stetho:<VERSION>'
-    //     compile 'com.facebook.stetho:stetho-urlconnection:<VERSION>'
+    //     debugImplementation 'com.facebook.stetho:stetho:<VERSION>'
+    //     implementation 'com.facebook.stetho:stetho-urlconnection:<VERSION>'
     //   }
     //
     // For Stetho developers, to verify locally that things are working
@@ -55,8 +55,8 @@ dependencies {
     //   ./gradlew installArchives
     //
     // Then uncomment the Maven style dependency and comment the project one:
-    //releaseCompile "com.facebook.stetho:stetho-urlconnection:${VERSION_NAME}"
-    releaseCompile project(':stetho-urlconnection')
+    //releaseImplementation "com.facebook.stetho:stetho-urlconnection:${VERSION_NAME}"
+    releaseImplementation project(':stetho-urlconnection')
 
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
+    api 'com.google.code.findbugs:jsr305:2.0.1'
 }

--- a/stetho-timber/build.gradle
+++ b/stetho-timber/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 11
@@ -13,8 +13,8 @@ android {
 }
 
 dependencies {
-    compile project(':stetho')
-    compile 'com.jakewharton.timber:timber:4.1.2'
+    api project(':stetho')
+    api 'com.jakewharton.timber:timber:4.1.2'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho-urlconnection/build.gradle
+++ b/stetho-urlconnection/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 9
@@ -13,8 +13,8 @@ android {
 }
 
 dependencies {
-    compile project(':stetho')
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
+    api project(':stetho')
+    api 'com.google.code.findbugs:jsr305:2.0.1'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/stetho/build.gradle
+++ b/stetho/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    buildToolsVersion versions.buildTools
 
     defaultConfig {
         minSdkVersion 9
@@ -15,18 +15,18 @@ android {
 }
 
 dependencies {
-    compile 'commons-cli:commons-cli:1.2'
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
+    implementation 'commons-cli:commons-cli:1.2'
+    api 'com.google.code.findbugs:jsr305:2.0.1'
 
-    compile 'com.android.support:appcompat-v7:23.0.1' // optional
+    api 'com.android.support:appcompat-v7:23.0.1'
 
-    testCompile 'junit:junit:4.12'
-    testCompile('org.robolectric:robolectric:2.4') {
+    testImplementation 'junit:junit:4.12'
+    testImplementation('org.robolectric:robolectric:2.4') {
         exclude module: 'commons-logging'
         exclude module: 'httpclient'
     }
-    testCompile 'org.powermock:powermock-api-mockito:1.6.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.1'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.1'
 }
 
 apply from: rootProject.file('release.gradle')
@@ -55,7 +55,7 @@ android.libraryVariants.all { variant ->
 
     task "fatjar${name}"(type: Jar, dependsOn: [ "jar${name}", "tidyCommonsCli${name}", "metainf${name}" ]) {
         classifier = 'fatjar'
-        from variant.javaCompile.destinationDir
+        from variant.javaCompiler.destinationDir
         from "build/commons-cli-tidy-${name}"
         from "build/metainf-${name}"
         exclude 'android/support/**/*'

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,0 +1,6 @@
+
+ext {
+    versions = [
+            'buildTools': "27.0.3"
+    ]
+}


### PR DESCRIPTION
I've updated gradle up to 4.4 and android plugin up to 3.1.3 and fixed all corresponding problems.
Some observations: I've tried to move to the `implementation` scope as much as it was possible without breaking stuff for other projects.
Most of dependencies are in `api` scope since it's a safe transition from end-users POV.
In reality perhaps some dependencies declarations should be further reworked to be more granular.