### PR TITLE
Remove private class (CallFunctionOnResponse) from signature of the public method

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -117,7 +117,7 @@ public class Runtime implements ChromeDevtoolsDomain {
   }
 
   @ChromeDevtoolsMethod
-  public CallFunctionOnResponse callFunctionOn(JsonRpcPeer peer, JSONObject params)
+  public JsonRpcResult callFunctionOn(JsonRpcPeer peer, JSONObject params)
       throws JsonRpcException {
     CallFunctionOnRequest args = mObjectMapper.convertValue(params, CallFunctionOnRequest.class);
 


### PR DESCRIPTION
Otherwise class can't be extended and method overridden (Currently only @ChromeDevtoolsMethod methods are detected and method needed to be overridden because look-up is done only in declared methods)

Override of Stetho's default domain classes might be need if issues like following are found: https://github.com/facebook/stetho/issues/611