### PR TITLE
Added ability for domain classes to be inherited

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
@@ -112,7 +112,7 @@ public class MethodDispatcher {
       Class<?> handlerClass = domainHandler.getClass();
       String domainName = handlerClass.getSimpleName();
 
-      for (Method method : handlerClass.getDeclaredMethods()) {
+      for (Method method : handlerClass.getMethods()) {
         if (isDevtoolsMethod(method)) {
           MethodDispatchHelper dispatchHelper = new MethodDispatchHelper(
               objectMapper,


### PR DESCRIPTION
 look-up for methods with @ChromeDevtoolsMethod not only in the class itself, but also in the parent classes.

Override of Stetho's default domain classes might be need if issues like following are found: #611 

Work-around with `fun method = super.method()` could be used, but in it's verbose, inconvenient and in some edge cases like following can't be implemented: https://github.com/facebook/stetho/pull/612