### PR TITLE
Added static method for removing objects previously added by .mapObject()

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -105,6 +105,13 @@ public class Runtime implements ChromeDevtoolsDomain {
     return session;
   }
 
+  /**
+   * Removes objects from peer's session previously added by {@link #mapObject}
+   */
+  public static void releaseObject(JsonRpcPeer peer, Integer id) throws JSONException {
+    getSession(peer).getObjects().removeObjectById(id);
+  }
+
   @ChromeDevtoolsMethod
   public void releaseObject(JsonRpcPeer peer, JSONObject params) throws JSONException {
     String objectId = params.getString("objectId");


### PR DESCRIPTION
I am developing debugger for [J2V8](https://github.com/eclipsesource/J2V8), which uses Stetho for communication over Chrome  DevTools protocol. Besides implementing Debugger domain I need to add local v8 variables to `Runtime` by static `.mapObject()` in order them to be visible in the Chrome Debugger UI.

The problem, that `@ChromeDevtoolsMethod` `.releaseObject()` method is not called by Chrome DevTools and I want to remove objects stored in the session manually in order to avoid memory leaks and possible OOM errors. That's why I would like to have static method to remove them from session. Some work-around are possible already now, but it makes sense for me to have it because `static` _counter-part_ for adding object is exists - `.mapObject()` .
