### PR TITLE
Add support for ADB_SERVER_SOCKET in dumpapp

### DIFF
--- a/scripts/stetho_open.py
+++ b/scripts/stetho_open.py
@@ -18,16 +18,26 @@ import socket
 import struct
 import re
 
+def get_adb_server_port_from_server_socket():
+  socket_spec = os.environ.get('ADB_SERVER_SOCKET')
+  if not socket_spec:
+      return None
+  if not socket_spec.startswith('tcp:'):
+    raise HumanReadableError(
+      'Invalid or unsupported socket spec \'%s\' specified in ADB_SERVER_SOCKET.' % (
+        socket_spec))
+  return socket_spec.split(':')[-1]
+
 def get_adb_server_port():
   defaultPort = 5037
-  portStr = os.environ.get('ANDROID_ADB_SERVER_PORT')
+  portStr = get_adb_server_port_from_server_socket() or os.environ.get('ANDROID_ADB_SERVER_PORT')
   if portStr is None:
     return defaultPort
   elif portStr.isdigit():
     return int(portStr)
   else:
     raise HumanReadableError(
-      'Invalid integer \'%s\' specified in ANDROID_ADB_SERVER_PORT.' % (
+      'Invalid integer \'%s\' specified in ANDROID_ADB_SERVER_PORT or ADB_SERVER_SOCKET.' % (
         portStr))
 
 def stetho_open(device=None, process=None, port=None):


### PR DESCRIPTION
There are multiple ways to set the adb server connection information in the
environment. This commit adds support for `ADB_SERVER_SOCKET`.

Set a valid server socket environment variable:
```
$ export ADB_SERVER_SOCKET=tcp:localhost:5038
$ adb devices
List of devices attached
* daemon not running; starting now at tcp:localhost:5038
* daemon started successfully
```

Now dumpapp doesn't fail anymore:
```
$ scripts/dumpapp
Failure to target device None: no devices/emulators found
```

It does fail when the socket spec is invalid/unsupported:
```
$ export ADB_SERVER_SOCKET=nope
$ scripts/dumpapp
...
stetho_open.HumanReadableError: Invalid or unsupported socket spec 'nope' specified in ADB_SERVER_SOCKET.
```

```
$ export ADB_SERVER_SOCKET=tcp:localhost:abc
$ scripts/dumpapp
...
stetho_open.HumanReadableError: Invalid integer 'abc' specified in ANDROID_ADB_SERVER_PORT or ADB_SERVER_SOCKET.
```