### PR TITLE
Update to MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,4 @@ outlined on that page and do not file a public issue.
 
 ## License
 By contributing to Stetho, you agree that your contributions will be licensed
-under its BSD license.
+under its MIT license.  See LICENSE file for details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,21 @@
-BSD License
+MIT License
 
-For Stetho software
+Copyright (c) Facebook, Inc. and its affiliates.
 
-Copyright (c) 2015, Facebook, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
- * Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
- * Neither the name Facebook nor the names of its contributors may be used to
-   endorse or promote products derived from this software without specific
-   prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ See the [`stetho-sample` project](stetho-sample) for more details.
 See the [CONTRIBUTING.md](CONTRIBUTING.md) file for how to help out.
 
 ## License
-Stetho is BSD-licensed. We also provide an additional patent grant.
+Stetho is MIT-licensed. See LICENSE file for more details.

--- a/release.gradle
+++ b/release.gradle
@@ -36,7 +36,7 @@ def configureStethoPom(def pom) {
 
         licenses {
             license {
-                name 'BSD License'
+                name 'MIT License'
                 url 'https://github.com/facebook/stetho/blob/master/LICENSE'
                 distribution 'repo'
             }

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsConsole.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsConsole.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.rhino;

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsFormat.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsFormat.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.rhino;

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeRepl.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeRepl.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.rhino;

--- a/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
+++ b/stetho-js-rhino/src/main/java/com/facebook/stetho/rhino/JsRuntimeReplFactoryBuilder.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.rhino;

--- a/stetho-js-rhino/src/test/java/com/facebook/stetho/rhino/JsFormatTest.java
+++ b/stetho-js-rhino/src/test/java/com/facebook/stetho/rhino/JsFormatTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.rhino;

--- a/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
+++ b/stetho-okhttp/src/main/java/com/facebook/stetho/okhttp/StethoInterceptor.java
@@ -1,11 +1,9 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant 
- * of patent rights can be found in the PATENTS file in the same directory.
-*/
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package com.facebook.stetho.okhttp;
 

--- a/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
+++ b/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.okhttp;

--- a/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
+++ b/stetho-okhttp3/src/main/java/com/facebook/stetho/okhttp3/StethoInterceptor.java
@@ -1,11 +1,9 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant 
- * of patent rights can be found in the PATENTS file in the same directory.
-*/
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package com.facebook.stetho.okhttp3;
 

--- a/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
+++ b/stetho-okhttp3/src/test/java/com/facebook/stetho/okhttp3/StethoInterceptorTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.okhttp3;

--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/APODDumperPlugin.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/APODDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/HelloWorldDumperPlugin.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/HelloWorldDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
+++ b/stetho-sample/src/debug/java/com/facebook/stetho/sample/SampleDebugApplication.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODActivity.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContentProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODContract.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/APODRssFetcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/Constants.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/Constants.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/HtmlScraper.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/HtmlScraper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCChatActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCChatActivity.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.sample;
 
 import android.app.Activity;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCClientConnection.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCClientConnection.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.sample;
 
 import com.facebook.stetho.inspector.network.NetworkEventReporter;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/IRCConnectActivity.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.sample;
 
 import android.app.Activity;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/MainActivity.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/Networker.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/SampleApplication.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/SampleApplication.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
+++ b/stetho-sample/src/main/java/com/facebook/stetho/sample/SettingsActivity.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.sample;

--- a/stetho-timber/gradle.properties
+++ b/stetho-timber/gradle.properties
@@ -1,10 +1,8 @@
 #
-# Copyright (c) 2014-present, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 #
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 #
 
 POM_NAME=Stetho Timber module

--- a/stetho-timber/src/main/AndroidManifest.xml
+++ b/stetho-timber/src/main/AndroidManifest.xml
@@ -1,10 +1,8 @@
 <!--
-  ~ Copyright (c) 2014-present, Facebook, Inc.
-  ~ All rights reserved.
+  ~ Copyright (c) Facebook, Inc. and its affiliates.
   ~
-  ~ This source code is licensed under the BSD-style license found in the
-  ~ LICENSE file in the root directory of this source tree. An additional grant
-  ~ of patent rights can be found in the PATENTS file in the same directory.
+  ~ This source code is licensed under the MIT license found in the
+  ~ LICENSE file in the root directory of this source tree.
   -->
 
 <manifest

--- a/stetho-timber/src/main/java/com/facebook/stetho/timber/StethoTree.java
+++ b/stetho-timber/src/main/java/com/facebook/stetho/timber/StethoTree.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.timber;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/ByteArrayRequestEntity.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/ByteArrayRequestEntity.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/SimpleRequestEntity.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/SimpleRequestEntity.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManager.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManagerImpl.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/StethoURLConnectionManagerImpl.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorHeaders.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorRequest.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorRequest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorResponse.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/URLConnectionInspectorResponse.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/Util.java
+++ b/stetho-urlconnection/src/main/java/com/facebook/stetho/urlconnection/Util.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.urlconnection;

--- a/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/DumperPluginsProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/InspectorModulesProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho;

--- a/stetho/src/main/java/com/facebook/stetho/common/Accumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Accumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ArrayListAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ArrayListAccumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ExceptionUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ListUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/LogRedirector.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/LogUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/LogUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/Predicate.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Predicate.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ReflectionUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/StringUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/ThreadBound.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ThreadBound.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/UncheckedCallable.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/UncheckedCallable.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Utf8Charset.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/Util.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/Util.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/AccessibilityUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/DialogFragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/DialogFragmentAccessor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentAccessor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentActivityAccessor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompat.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatFramework.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentManagerAccessor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/HandlerUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ResourcesUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ResourcesUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewGroupUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/ViewUtil.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.common.android;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/ArgsHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/ArgsHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpUsageException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappFramingException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappFramingException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHttpSocketLikeHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappHttpSocketLikeHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappOutputBrokenException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappSocketLikeHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumpappSocketLikeHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/Dumper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperContext.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/DumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/Framer.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/Framer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/GlobalOptions.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/UnexpectedFrameException.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/UnexpectedFrameException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/CrashDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/CrashDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp.plugins;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/FilesDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/FilesDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp.plugins;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/HprofDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/HprofDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp.plugins;

--- a/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
+++ b/stetho/src/main/java/com/facebook/stetho/dumpapp/plugins/SharedPreferencesDumperPlugin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.dumpapp.plugins;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDevtoolsServer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/DevtoolsSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/DevtoolsSocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MessageHandlingException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MethodDispatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/MismatchedResponseException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/CLog.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/CLog.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.console;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/ConsolePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/ConsolePeerManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.console;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeRepl.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.console;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeReplFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/console/RuntimeReplFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.console;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderSchema.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderSchema.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseConnectionProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseConnectionProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseDriver2Adapter.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.database;
 
 import android.database.sqlite.SQLiteException;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DatabaseFilesProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseConnectionProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseConnectionProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/DefaultDatabaseFilesProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/SQLiteDatabaseCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/SQLiteDatabaseCompat.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/SqliteDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/SqliteDatabaseDriver.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/DOMStoragePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/DOMStoragePeerManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.domstorage;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/domstorage/SharedPreferencesHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.domstorage;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AbstractChainedDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/AttributeAccumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ChainedDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ComputedStyleAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ComputedStyleAccumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Descriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorMap.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorRegistrar.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DescriptorRegistrar.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Document.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentProviderListener.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/DocumentView.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ElementInfo.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ElementInfo.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/NodeType.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ObjectDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/Origin.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/Origin.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/ShadowDocument.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleAccumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleRuleNameAccumulator.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/StyleRuleNameAccumulator.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AccessibilityNodeInfoWrapper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityTracker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ActivityTracker.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDescriptorHost.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentConstants.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProvider.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentProviderFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentRoot.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/AndroidDocumentRoot.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ApplicationDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DialogFragmentDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DocumentHiddenView.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/DocumentHiddenView.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/FragmentDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/HighlightableDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/MethodInvoker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/MethodInvoker.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/TextViewDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewGroupDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlighter.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/WindowDescriptor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV16Impl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV16Impl.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.elements.android.window;
 
 import android.content.Context;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV18Impl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV18Impl.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.elements.android.window;
 
 import android.support.annotation.NonNull;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV19Impl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompactV19Impl.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.elements.android.window;
 
 import android.support.annotation.NonNull;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompat.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/window/WindowRootViewCompat.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.elements.android.window;
 
 import android.content.Context;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ChromePeerManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/IntegerFormatter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/IntegerFormatter.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ObjectIdMapper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeerRegistrationListener.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/PeersRegisteredListener.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/helper/ThreadBoundProxy.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/helper/ThreadBoundProxy.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.helper;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/DisconnectReceiver.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcPeer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/JsonRpcResult.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/PendingRequestCallback.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/EmptyResult.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcError.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcEvent.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcRequest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/jsonrpc/protocol/JsonRpcResponse.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.jsonrpc.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinter.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterExecutorHolder.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterExecutorHolder.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterInitializer.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterInitializer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterRegistry.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/AsyncPrettyPrinterRegistry.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/CountingOutputStream.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DecompressionHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultResponseHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DefaultResponseHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/DownloadingAsyncPrettyPrinterFactory.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import java.io.IOException;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/GunzippingOutputStream.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/MimeMatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporter.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkEventReporterImpl.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/NetworkPeerManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/PrettyPrinterDisplayType.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/PrettyPrinterDisplayType.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/RequestBodyHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/RequestBodyHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResourceTypeHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyData.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseBodyFileManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStream.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleBinaryInspectorWebSocketFrame.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleBinaryInspectorWebSocketFrame.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 import java.io.UnsupportedEncodingException;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleTextInspectorWebSocketFrame.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/network/SimpleTextInspectorWebSocketFrame.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.network;
 
 public class SimpleTextInspectorWebSocketFrame

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsDomain.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/ChromeDevtoolsMethod.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/BaseDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/BaseDatabaseDriver.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/CSS.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Console.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOM.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DOMStorage.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Database.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseConstants.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDescriptor.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDescriptor.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.protocol.module;
 
 public interface DatabaseDescriptor {

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/DatabaseDriver2.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Debugger.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/HeapProfiler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Inspector.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Network.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Page.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Profiler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Runtime.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/SimpleBooleanResult.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/protocol/module/Worker.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.protocol.module;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/runtime/RhinoDetectingRuntimeReplFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/runtime/RhinoDetectingRuntimeReplFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.runtime;

--- a/stetho/src/main/java/com/facebook/stetho/inspector/screencast/ScreencastDispatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/screencast/ScreencastDispatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.screencast;

--- a/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/ObjectMapper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.json;

--- a/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonProperty.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonProperty.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.json.annotation;

--- a/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonValue.java
+++ b/stetho/src/main/java/com/facebook/stetho/json/annotation/JsonValue.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.json.annotation;

--- a/stetho/src/main/java/com/facebook/stetho/server/AddressNameHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/AddressNameHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/CompositeInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/CompositeInputStream.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/LazySocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LazySocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/LeakyBufferedInputStream.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LeakyBufferedInputStream.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/LocalSocketServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/LocalSocketServer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/PeerAuthorizationException.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/PeerAuthorizationException.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/ProtocolDetectingSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/ProtocolDetectingSocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SecureSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SecureSocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/ServerManager.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/ServerManager.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SocketHandlerFactory.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SocketHandlerFactory.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SocketLike.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SocketLike.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/SocketLikeHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/SocketLikeHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/ExactPathMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/ExactPathMatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/HandlerRegistry.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/HandlerRegistry.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/HttpHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/HttpHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/HttpHeaders.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/HttpHeaders.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/HttpStatus.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/HttpStatus.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpBody.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpBody.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpMessage.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpMessage.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpRequest.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpRequest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpResponse.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpResponse.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpServer.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/LightHttpServer.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/PathMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/PathMatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/server/http/RegexpPathMatcher.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/http/RegexpPathMatcher.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.server.http;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/CloseCodes.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/Frame.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/FrameHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/MaskingHelper.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadCallback.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/ReadHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleEndpoint.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/SimpleSession.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WebSocketSession.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteCallback.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/websocket/WriteHandler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.websocket;

--- a/stetho/src/test/java/com/facebook/stetho/PluginBuilderTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/PluginBuilderTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho;
 
 import android.app.Activity;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/database/DatabasePeerManagerTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.database;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/MethodInvokerTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/MethodInvokerTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.elements.android;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/elements/android/ViewDescriptorTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.stetho.inspector.elements.android;
 
 import android.app.Activity;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/AsyncPrettyPrintResponseBodyTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/GunzippingOutputStreamTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/inspector/network/ResponseHandlingInputStreamTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.inspector.network;

--- a/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
+++ b/stetho/src/test/java/com/facebook/stetho/json/ObjectMapperTest.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.stetho.json;


### PR DESCRIPTION
The Stetho project has converted to the MIT license consistent with many
other popular Facebook open source projects.

Closes #568