### PR TITLE
Crash fix: related to Fragment's ChildFragmentManager

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/android/FragmentCompatSupportLib.java
@@ -96,6 +96,10 @@ final class FragmentCompatSupportLib
     @Nullable
     @Override
     public FragmentManager getChildFragmentManager(Fragment fragment) {
+      if (!fragment.isAdded() || fragment.isDetached()) {
+        return null;
+      }
+
       return fragment.getChildFragmentManager();
     }
   }


### PR DESCRIPTION
If app uses ChildFragmentManager for nested fragments, when connecting to Chrome Developer Tool, every time fragments recreation (for example: screen rotates) will cause app crash.

This fix is to check current fragment state before grabbing ChildFragmentManager.