### PR TITLE
Fixing view highlighting on Android P

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/elements/android/ViewHighlightOverlays.java
@@ -140,7 +140,9 @@ abstract class ViewHighlightOverlays {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
           canvas.clipRect(newRect, Region.Op.REPLACE);
         } else {
-          canvas.clipOutRect(newRect);
+          canvas.save();
+          canvas.clipRect(newRect);
+          canvas.restore();
         }
         super.draw(canvas);
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/stetho/issues/648

`clipOutRect` wasn't the proper API to use in this case, so changed to use `save` and `restore`.

Based on this SO answer: https://stackoverflow.com/questions/50231950/what-is-the-best-alternative-to-canvas-cliprect-with-region-op-replace/50247323#50247323