### PR TITLE
Fix markdown formatting in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ or:
   } 
 ```
 
-##Features 
+## Features 
 
 {% include content/gridblocks.html data_source=site.data.features grid_type="twoByGridBlock" %}
 
@@ -117,10 +117,10 @@ See the stetho-sample project for more details.
 ### Contributions
 Use [GitHub issues](https://github.com/facebook/stetho/issues) for requests. We actively welcome pull requests; learn how to [contribute](https://github.com/facebook/stetho/blob/master/CONTRIBUTING.md).
 
-###Changelog
+### Changelog
 Changes are tracked as [GitHub releases](https://github.com/facebook/stetho/releases).
 
-###License  
+### License  
 
 Stetho is [BSD-licensed](https://github.com/facebook/stetho/blob/master/LICENSE). We also provide an additional [patent grant](https://github.com/facebook/stetho/blob/master/PATENTS).
 


### PR DESCRIPTION
The formatting was broken on the
Stetho website (http://facebook.github.io/stetho/)