### PR TITLE
Fix title is broken in doc

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ or:
   } 
 ```
 
-##Features 
+## Features 
 
 {% include content/gridblocks.html data_source=site.data.features grid_type="twoByGridBlock" %}
 


### PR DESCRIPTION
'Features' title is broken in [github pages](http://facebook.github.io/stetho/) as follows:

![スクリーンショット 2019-10-23 9 22 35](https://user-images.githubusercontent.com/823277/67345687-de895900-f576-11e9-9af0-dfdffd2cdad3.png)

Conforming CommonMark spec, at least one space is mandatory after sharp character for header titles.

This PR fixes the issue.