### PR TITLE
Test improvement: removed Magic Number test smell

### DIFF
--- a/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
+++ b/stetho-okhttp/src/test/java/com/facebook/stetho/okhttp/StethoInterceptorTest.java
@@ -60,6 +60,7 @@ public class StethoInterceptorTest {
   @Rule
   public PowerMockRule rule = new PowerMockRule();
 
+  private final int HTTP_OK = 200;
   private NetworkEventReporter mMockEventReporter;
   private StethoInterceptor mInterceptor;
   private OkHttpClient mClientWithInterceptor;
@@ -96,7 +97,7 @@ public class StethoInterceptorTest {
     Response reply = new Response.Builder()
         .request(request)
         .protocol(Protocol.HTTP_1_1)
-        .code(200)
+        .code(HTTP_OK)
         .body(ResponseBody.create(MediaType.parse("text/plain"), originalBodyData))
         .build();
     Response filteredResponse =


### PR DESCRIPTION
This is a test refactoring

**Problem:**
The Magic Number Test occurs when assert() statements in a test method contain numeric literals (i.e., magic numbers) as parameters.

**Solution:**
As magic numbers do not indicate the meaning/purpose of the number, they should be replaced with constants or variables, thereby providing a descriptive name for the input.

**Results:**

_Before:_

```
private final int HTTP_OK = 200;
.
.
.
Response reply = new Response.Builder()
        .request(request)
        .protocol(Protocol.HTTP_1_1)
        .code(200)
        .body(ResponseBody.create(MediaType.parse("text/plain"), originalBodyData))
        .build();
```

_After:_

```
Response reply = new Response.Builder()
        .request(request)
        .protocol(Protocol.HTTP_1_1)
        .code(HTTP_OK)
        .body(ResponseBody.create(MediaType.parse("text/plain"), originalBodyData))
        .build();
```