### PR TITLE
Use debugImplementation in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ begin.
 ### Download
 Download [the latest JARs](https://github.com/facebook/stetho/releases/latest) or grab via Gradle:
 ```groovy
-implementation 'com.facebook.stetho:stetho:1.5.1'
+debugImplementation 'com.facebook.stetho:stetho:1.5.1'
 ```
 or Maven:
 ```xml
@@ -29,17 +29,17 @@ or Maven:
 Only the main `stetho` dependency is strictly required; however, you may also wish to use one of the network helpers:
 
 ```groovy
-implementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
+debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
 ```
 or:
 ```groovy
-implementation 'com.facebook.stetho:stetho-urlconnection:1.5.1'
+debugImplementation 'com.facebook.stetho:stetho-urlconnection:1.5.1'
 ```
 
 You can also enable a JavaScript console with:
 
 ```groovy
-implementation 'com.facebook.stetho:stetho-js-rhino:1.5.1'
+debugImplementation 'com.facebook.stetho:stetho-js-rhino:1.5.1'
 ```
 For more details on how to customize the JavaScript runtime see [stetho-js-rhino](stetho-js-rhino/).
 


### PR DESCRIPTION
Because Stetho exposes Shared Prefs and SQLite, which may contain sensitive information, and since many devs will just copy / paste from the README, I thought I'd throw in my $0.02 that the code examples be changed such that it is a bit less susceptible to Murphy's Law.