### PR TITLE
Use https instead of http

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ gacode: "UA-44373548-5"
 description: > # this means to ignore newlines until "baseurl:"
   Stetho is a sophisticated debug bridge for Android applications. When enabled, developers have access to the Chrome Developer Tools feature natively part of the Chrome desktop browser. Developers can also choose to enable the optional dumpapp tool which offers a powerful command-line interface to application internals. 
 baseurl: "/stetho" # the subpath of your site, e.g. /blog/
-url: "http://facebook.github.io" # the base hostname & protocol for your site
+url: "https://facebook.github.io" # the base hostname & protocol for your site
 ghrepo: "facebook/stetho"
 
 # Build settings

--- a/_includes/blog_pagination.html
+++ b/_includes/blog_pagination.html
@@ -1,4 +1,4 @@
-<!-- Pagination links - copied from http://jekyllrb.com/docs/pagination/ -->
+<!-- Pagination links - copied from https://jekyllrb.com/docs/pagination/ -->
 {% if paginator.total_pages > 1 %}
 <br />
 <div class="pagination">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
   
   <base href="{{ site.url }}{{ site.baseurl }}/" />
   
-  <script src="http://fb.me/react-with-addons-0.13.1.js"></script>
+  <script src="https://fb.me/react-with-addons-0.13.1.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -2,7 +2,7 @@
   {% assign author = site.data.authors[page.author] %}
   <header class="post-header">
     {% if author %}
-    <div class="authorPhoto"><img src="http://graph.facebook.com/{{ author.fbid }}/picture/" alt="{{ author.fullname }}" title="{{ author.fullname }}" /></div>
+    <div class="authorPhoto"><img src="https://graph.facebook.com/{{ author.fbid }}/picture/" alt="{{ author.fullname }}" title="{{ author.fullname }}" /></div>
     {% endif %}
     <h1 class="post-title">{% if include.truncate %}<a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>{% else %}{{ page.title }}{% endif %}</h1>
     <p class="post-meta">Posted {{ page.date | date: '%B %d, %Y' }}{% if page.meta %} • {{ page.meta }}{% endif %}</p>


### PR DESCRIPTION
Note that the Stetho site is rated as "not secure" for including content from HTTP sources. This pull-request fixes this and prevents any possible attempts at intrusion.