### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,6 +2,11 @@
 layout: home
 id: home
 ---
+## Watch Introductory Video
+
+<div>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/QfDjhakiRho" title="Explain Like I'm 5: Stetho" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen ></iframe>
+</div>
 
 ## Download
 
@@ -48,7 +53,7 @@ or:
   } 
 ```
 
-##Features 
+## Features 
 
 {% include content/gridblocks.html data_source=site.data.features grid_type="twoByGridBlock" %}
 


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.