### PR TITLE
exempt a disk read from StrictMode as stetho is strictly a debug orie…

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/Stetho.java
+++ b/stetho/src/main/java/com/facebook/stetho/Stetho.java
@@ -11,6 +11,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
+import android.os.StrictMode;
 
 import com.facebook.stetho.common.LogUtil;
 import com.facebook.stetho.common.Util;
@@ -443,9 +444,17 @@ public class Stetho {
     final void start() {
       // Note that _devtools_remote is a magic suffix understood by Chrome which causes
       // the discovery process to begin.
+      StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
+      String customAddress;
+      try {
+        customAddress = AddressNameHelper.createCustomAddress("_devtools_remote");
+      } finally {
+        StrictMode.setThreadPolicy(oldPolicy);
+      }
+
       LocalSocketServer server = new LocalSocketServer(
           "main",
-          AddressNameHelper.createCustomAddress("_devtools_remote"),
+          customAddress,
           new LazySocketHandler(new RealSocketHandlerFactory()));
 
       ServerManager serverManager = new ServerManager(server);


### PR DESCRIPTION
The violation is:

```
StrictMode policy violation; ~duration=5 ms: android.os.strictmode.DiskReadViolation
    at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1596)
    at libcore.io.BlockGuardOs.fstat(BlockGuardOs.java:174)
    at libcore.io.ForwardingOs.fstat(ForwardingOs.java:106)
    at libcore.io.IoBridge.open(IoBridge.java:481)
    at java.io.FileInputStream.<init>(FileInputStream.java:160)
    at java.io.FileInputStream.<init>(FileInputStream.java:115)
    at com.facebook.stetho.common.ProcessUtil.readProcessName(ProcessUtil.java:49)
    at com.facebook.stetho.common.ProcessUtil.getProcessName(ProcessUtil.java:38)
    at com.facebook.stetho.server.AddressNameHelper.createCustomAddress(AddressNameHelper.java:20)
    at com.facebook.stetho.Stetho$Initializer.start(Stetho.java:449)
    at com.facebook.stetho.Stetho.initialize(Stetho.java:134)
```

Since stetho is strictly a debug oriented tool, i think it's better we exempt this disk read. This will eliminate this noise for developers' logcat.