### PR TITLE
exempt a disk read from StrictMode as stetho is strictly a debug orie…

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
@@ -7,6 +7,7 @@
 
 package com.facebook.stetho.common;
 
+import android.os.StrictMode;
 import javax.annotation.Nullable;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -46,6 +47,9 @@ public class ProcessUtil {
     // Avoid using a Reader to not pick up a forced 16K buffer.  Silly java.io...
     FileInputStream stream = new FileInputStream("/proc/self/cmdline");
     boolean success = false;
+
+    // /proc/self/cmdline is a memory file and won't actually hit disk
+    StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
     try {
       int n = stream.read(cmdlineBuffer);
       success = true;
@@ -53,6 +57,7 @@ public class ProcessUtil {
       return new String(cmdlineBuffer, 0, endIndex > 0 ? endIndex : n);
     } finally {
       Util.close(stream, !success);
+      StrictMode.setThreadPolicy(oldPolicy);
     }
   }
 


### PR DESCRIPTION
Violation:

```
StrictMode policy violation; ~duration=5 ms: android.os.strictmode.DiskReadViolation
    at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1596)
    at libcore.io.BlockGuardOs.fstat(BlockGuardOs.java:174)
    at libcore.io.ForwardingOs.fstat(ForwardingOs.java:106)
    at libcore.io.IoBridge.open(IoBridge.java:481)
    at java.io.FileInputStream.<init>(FileInputStream.java:160)
    at java.io.FileInputStream.<init>(FileInputStream.java:115)
    at com.facebook.stetho.common.ProcessUtil.readProcessName(ProcessUtil.java:49)
    at com.facebook.stetho.common.ProcessUtil.getProcessName(ProcessUtil.java:38)
    at com.facebook.stetho.server.AddressNameHelper.createCustomAddress(AddressNameHelper.java:20)
    at com.facebook.stetho.Stetho$Initializer.start(Stetho.java:449)
    at com.facebook.stetho.Stetho.initialize(Stetho.java:134)
```

But  "/proc/self/cmdline is a memory file and won't actually hit disk" 
thus it can be exempted.