### PR TITLE
Support running Stetho in multi-user Android environments

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
+++ b/stetho/src/main/java/com/facebook/stetho/common/ProcessUtil.java
@@ -7,6 +7,13 @@
 
 package com.facebook.stetho.common;
 
+import android.os.Build;
+import android.os.Process;
+import android.os.UserManager;
+
+import androidx.annotation.Keep;
+import androidx.annotation.RequiresApi;
+
 import javax.annotation.Nullable;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -63,5 +70,21 @@ public class ProcessUtil {
       }
     }
     return -1;
+  }
+
+  public static int getUserId() {
+    // On multi-user devices, user id is calculated from process uid.
+    // On single-user devices, user id is always 0.
+    // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/UserHandle.java;l=282;drc=5a5038ddb87b9c4ac576935b77cab4688169ee48
+    final boolean supportsMultipleUsers = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && UserManager21Impl.supportsMultipleUsers();
+    return supportsMultipleUsers ? Process.myUid() / 100000 : 0;
+  }
+
+  @Keep
+  @RequiresApi(Build.VERSION_CODES.N)
+  private static class UserManager21Impl {
+    public static boolean supportsMultipleUsers() {
+      return UserManager.supportsMultipleUsers();
+    }
   }
 }

--- a/stetho/src/main/java/com/facebook/stetho/server/AddressNameHelper.java
+++ b/stetho/src/main/java/com/facebook/stetho/server/AddressNameHelper.java
@@ -13,9 +13,11 @@ public class AddressNameHelper {
   private static final String PREFIX = "stetho_";
 
   public static String createCustomAddress(String suffix) {
+    final int userId = ProcessUtil.getUserId();
     return
         PREFIX +
         ProcessUtil.getProcessName() +
+        (userId == 0 ? "" : ("_" + userId)) +
         suffix;
   }
 }


### PR DESCRIPTION
For supporting that, adding non-default user id to stetho socket name, so they can be distinguished.

Currently, Stetho uses socket address in form `stetho_<package>_devtools_remote`.
If two instances of the same app are running (e.g. in dual app mode), one of them will open socket successfully, but the second app will fail:
```
$ adb logcat -s 'stetho:*'
07-11 15:04:34.942 28329 28580 I stetho  : Listening on @stetho_com.myapp_devtools_remote
07-11 15:04:57.951 29513 29827 E stetho  : Could not start Stetho server: main
```

Adding user id for non-default (non-0) user into socket address, so both sockets can be opened at the same time:
```
$ adb logcat -s 'stetho:*'
07-11 15:07:09.405 31796 32606 I stetho  : Listening on @stetho_com.myapp_devtools_remote
07-11 15:07:14.751 31954   654 I stetho  : Listening on @stetho_com.myapp_999_devtools_remote
```