### PR TITLE
Fix the issue that latest chrome(119 or 120) can not dicover Stetho

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
@@ -36,6 +36,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
   private static final String PAGE_ID = "1";
 
   private static final String PATH_PAGE_LIST = "/json";
+  private static final String PATH_PAGE_LIST1 = "/json/list";
   private static final String PATH_VERSION = "/json/version";
   private static final String PATH_ACTIVATE = "/json/activate/" + PAGE_ID;
 
@@ -65,6 +66,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
 
   public void register(HandlerRegistry registry) {
     registry.register(new ExactPathMatcher(PATH_PAGE_LIST), this);
+    registry.register(new ExactPathMatcher(PATH_PAGE_LIST1), this);
     registry.register(new ExactPathMatcher(PATH_VERSION), this);
     registry.register(new ExactPathMatcher(PATH_ACTIVATE), this);
   }
@@ -75,7 +77,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
     try {
       if (PATH_VERSION.equals(path)) {
         handleVersion(response);
-      } else if (PATH_PAGE_LIST.equals(path)) {
+      } else if (PATH_PAGE_LIST.equals(path) || PATH_PAGE_LIST1.equals(path)) {
         handlePageList(response);
       } else if (PATH_ACTIVATE.equals(path)) {
         handleActivate(response);

--- a/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/ChromeDiscoveryHandler.java
@@ -43,7 +43,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
   /**
    * Latest version of the WebKit Inspector UI that we've tested again (ideally).
    */
-  private static final String WEBKIT_REV = "@188492";
+  private static final String WEBKIT_REV = "@cfede9db1d154de0468cb0538479f34c0755a0f4";
   private static final String WEBKIT_VERSION = "537.36 (" + WEBKIT_REV + ")";
 
   private static final String USER_AGENT = "Stetho";
@@ -51,7 +51,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
   /**
    * Structured version of the WebKit Inspector protocol that we understand.
    */
-  private static final String PROTOCOL_VERSION = "1.1";
+  private static final String PROTOCOL_VERSION = "1.3";
 
   private final Context mContext;
   private final String mInspectorPath;
@@ -124,7 +124,7 @@ public class ChromeDiscoveryHandler implements HttpHandler {
           .authority("chrome-devtools-frontend.appspot.com")
           .appendEncodedPath("serve_rev")
           .appendEncodedPath(WEBKIT_REV)
-          .appendEncodedPath("devtools.html")
+          .appendEncodedPath("inspector.html")
           .appendQueryParameter("ws", mInspectorPath)
           .build();
       page.put("devtoolsFrontendUrl", chromeFrontendUrl.toString());


### PR DESCRIPTION
1. Fix the issue that CDT contents are disordered, new WEBKIT_REV is from https://chromedevtools.github.io/devtools-protocol/
2. Fix the issue that latest chrome(119 or 120) can not dicover Stetho