### PR TITLE
Add synchronized to getTableNames

### DIFF
--- a/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
+++ b/stetho/src/main/java/com/facebook/stetho/inspector/database/ContentProviderDatabaseDriver.java
@@ -44,7 +44,7 @@ public class ContentProviderDatabaseDriver
   }
 
   @Override
-  public List<String> getTableNames(ContentProviderDatabaseDescriptor databaseDesc) {
+  public synchronized List<String> getTableNames(ContentProviderDatabaseDescriptor databaseDesc) {
     if (mTableNames == null) {
       mTableNames = new ArrayList<>();
       for (ContentProviderSchema schema : mContentProviderSchemas) {


### PR DESCRIPTION
## ✅ Summary
This PR addresses a potential data race in `ContentProviderDatabaseDriver#getTableNames`. The method lazily initializes mTableNames, which can lead to race conditions if accessed concurrently by multiple threads. While other methods reading this field may be benign, concurrent execution of getTableNames could result in initialization errors.

## 🔧 Changes Made
Marked `getTableNames(ContentProviderDatabaseDescriptor)` as synchronized to ensure thread-safe lazy initialization of mTableNames.

